### PR TITLE
feat: beautify panel redesign, after-capture options, frosted glass window capture

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -77,11 +77,15 @@ final class AnnotationCanvasNSView: NSView {
 
     // MARK: - Cursor Management
 
+    override func resetCursorRects() {
+        discardCursorRects()
+        let cursor: NSCursor = currentTool == .select ? .arrow : .crosshair
+        addCursorRect(visibleRect, cursor: cursor)
+    }
+
     override func mouseMoved(with event: NSEvent) {
-        guard currentTool == .select else {
-            NSCursor.crosshair.set()
-            return
-        }
+        // For drawing tools the cursor rect handles the crosshair; nothing to do.
+        guard currentTool == .select else { return }
 
         let point = toImagePoint(convert(event.locationInWindow, from: nil))
         guard let doc = document else { return }

--- a/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
@@ -28,6 +28,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: AnnotationCanvasNSView, context: Context) {
+        let toolChanged = nsView.currentTool != currentTool
         nsView.currentTool = currentTool
         nsView.currentStyle = currentStyle
         nsView.zoomScale = zoomScale
@@ -37,5 +38,8 @@ struct AnnotationCanvasView: NSViewRepresentable {
             }
         }
         nsView.needsDisplay = true
+        if toolChanged {
+            nsView.window?.invalidateCursorRects(for: nsView)
+        }
     }
 }

--- a/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
@@ -40,6 +40,9 @@ final class AnnotationEditorWindow: NSPanel {
         self.isReleasedWhenClosed = false
         // Use .normal level so the window stays visible when app loses focus
         self.level = .normal
+        // Ensure tooltip tracking and key-window behaviour work correctly.
+        self.becomesKeyOnlyIfNeeded = false
+        self.acceptsMouseMovedEvents = true
 
         let view = AnnotationEditorView(
             sourceImage: image,

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -71,6 +71,7 @@ struct AnnotationToolbar: View {
                         .overlay(Circle().stroke(Color.black.opacity(0.2), lineWidth: 0.5))
                 }
                 .buttonStyle(.plain)
+                .help(Text(color.rawValue.capitalized))
             }
         }
     }
@@ -124,11 +125,13 @@ struct AnnotationToolbar: View {
             }
             .disabled(!canUndo)
             .keyboardShortcut("z", modifiers: .command)
+            .help("Undo")
             Button(action: onRedo) {
                 Image(systemName: "arrow.uturn.forward")
             }
             .disabled(!canRedo)
             .keyboardShortcut("z", modifiers: [.command, .shift])
+            .help("Redo")
         }
         .buttonStyle(.bordered)
         .controlSize(.small)

--- a/App/Sources/AnnotationEditor/BeautifyPanel.swift
+++ b/App/Sources/AnnotationEditor/BeautifyPanel.swift
@@ -18,14 +18,13 @@ struct BeautifyPanel: View {
     ]
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
+        VStack(alignment: .leading, spacing: 10) {
             Toggle("Enable background", isOn: $settings.isEnabled)
 
             if settings.isEnabled {
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack(spacing: 8) {
-                        Text("Style")
-                            .frame(width: 90, alignment: .leading)
+                VStack(alignment: .leading, spacing: 8) {
+                    // -- Appearance --
+                    settingRow("Style") {
                         Picker("", selection: $settings.backgroundStyle) {
                             ForEach(BeautifyBackgroundStyle.allCases) { style in
                                 Text(style.label).tag(style)
@@ -34,24 +33,13 @@ struct BeautifyPanel: View {
                         .pickerStyle(.segmented)
                         .labelsHidden()
                         .fixedSize()
-                        Spacer()
                     }
 
                     if settings.backgroundStyle == .solid {
-                        HStack(spacing: 8) {
-                            Text("Background")
-                                .frame(width: 90, alignment: .leading)
-                            HStack(spacing: 6) {
+                        settingRow("Background") {
+                            HStack(spacing: 4) {
                                 ForEach(Array(presetColors.enumerated()), id: \.offset) { _, color in
-                                    Button {
-                                        settings.backgroundColor = color
-                                    } label: {
-                                        Circle()
-                                            .fill(color)
-                                            .frame(width: 18, height: 18)
-                                            .overlay(Circle().stroke(Color.black.opacity(0.15), lineWidth: 0.5))
-                                    }
-                                    .buttonStyle(.plain)
+                                    colorSwatch(color)
                                 }
                                 ColorPicker("", selection: $settings.backgroundColor, supportsOpacity: false)
                                     .labelsHidden()
@@ -59,38 +47,100 @@ struct BeautifyPanel: View {
                         }
                     }
 
-                    HStack(spacing: 8) {
-                        Text("Padding")
-                            .frame(width: 90, alignment: .leading)
-                        Slider(value: $settings.padding, in: 16...80, step: 1)
-                        Text("\(Int(settings.padding))")
-                            .font(.system(size: 11, design: .monospaced))
-                            .frame(width: 32, alignment: .trailing)
-                    }
+                    Divider()
+                        .padding(.vertical, 1)
 
-                    HStack(spacing: 8) {
-                        Text("Corners")
-                            .frame(width: 90, alignment: .leading)
-                        Slider(value: $settings.cornerRadius, in: 0...24, step: 1)
-                        Text("\(Int(settings.cornerRadius))")
-                            .font(.system(size: 11, design: .monospaced))
-                            .frame(width: 32, alignment: .trailing)
-                    }
+                    // -- Dimensions --
+                    sliderRow("Padding", value: $settings.padding, range: 16...80)
+                    sliderRow("Corners", value: $settings.cornerRadius, range: 0...24)
 
+                    Divider()
+                        .padding(.vertical, 1)
+
+                    // -- Shadow --
                     HStack(spacing: 8) {
-                        Toggle("Shadow", isOn: $settings.shadowEnabled)
-                            .frame(width: 90, alignment: .leading)
+                        Toggle(isOn: $settings.shadowEnabled) {
+                            Text("Shadow")
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(width: 80, alignment: .leading)
+
                         Slider(value: $settings.shadowRadius, in: 0...40, step: 1)
                             .disabled(!settings.shadowEnabled)
-                        Text("\(Int(settings.shadowRadius))")
-                            .font(.system(size: 11, design: .monospaced))
-                            .frame(width: 32, alignment: .trailing)
+
+                        valueLabel(Int(settings.shadowRadius))
                     }
+                    .opacity(settings.shadowEnabled ? 1 : 0.55)
+                    .animation(.easeInOut(duration: 0.15), value: settings.shadowEnabled)
                 }
             }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .background(.bar)
+        .animation(.easeInOut(duration: 0.2), value: settings.isEnabled)
+        .animation(.easeInOut(duration: 0.15), value: settings.backgroundStyle)
+    }
+
+    // MARK: - Reusable Components
+
+    private func settingRow<Content: View>(
+        _ title: LocalizedStringKey,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        HStack(spacing: 8) {
+            Text(title)
+                .foregroundStyle(.secondary)
+                .frame(width: 80, alignment: .leading)
+            content()
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func sliderRow(
+        _ title: LocalizedStringKey,
+        value: Binding<CGFloat>,
+        range: ClosedRange<CGFloat>
+    ) -> some View {
+        HStack(spacing: 8) {
+            Text(title)
+                .foregroundStyle(.secondary)
+                .frame(width: 80, alignment: .leading)
+            Slider(value: value, in: range, step: 1)
+            valueLabel(Int(value.wrappedValue))
+        }
+    }
+
+    private func valueLabel(_ value: Int) -> some View {
+        Text("\(value)")
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .foregroundStyle(.tertiary)
+            .frame(width: 28, alignment: .trailing)
+    }
+
+    private func colorSwatch(_ color: Color) -> some View {
+        let selected = isColorMatch(color, settings.backgroundColor)
+        return Button {
+            settings.backgroundColor = color
+        } label: {
+            Circle()
+                .fill(color)
+                .frame(width: 18, height: 18)
+                .overlay(Circle().strokeBorder(Color.primary.opacity(0.12), lineWidth: 0.5))
+                .padding(2)
+                .overlay(
+                    Circle()
+                        .strokeBorder(Color.accentColor, lineWidth: selected ? 1.5 : 0)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func isColorMatch(_ a: Color, _ b: Color) -> Bool {
+        guard let c1 = NSColor(a).usingColorSpace(.sRGB),
+              let c2 = NSColor(b).usingColorSpace(.sRGB) else { return false }
+        return abs(c1.redComponent - c2.redComponent) < 0.02
+            && abs(c1.greenComponent - c2.greenComponent) < 0.02
+            && abs(c1.blueComponent - c2.blueComponent) < 0.02
     }
 }

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -152,7 +152,12 @@ final class CaptureCoordinator {
         if settings.screenshotAutoCopy {
             copyImageToClipboard(result.image)
         }
-        showQuickAccess(for: result)
+        if settings.screenshotAutoSave {
+            saveImageToFile(result.image)
+        }
+        if settings.screenshotShowPreview {
+            showQuickAccess(for: result)
+        }
     }
 
     /// The real camera-shutter sound macOS itself plays for Cmd+Shift+3/4.

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -1,5 +1,6 @@
 // App/Sources/Capture/CaptureCoordinator.swift
 import AppKit
+import CoreImage
 import Observation
 import AnnotationKit
 import CaptureKit
@@ -101,15 +102,155 @@ final class CaptureCoordinator {
     private func performWindowCapture(windowID: CGWindowID) {
         Task {
             do {
+                // Always capture without system shadow — we generate our own
+                // uniform padding + frosted glass backdrop when the setting is on.
                 let result = try await ScreenCaptureManager.captureWindow(
                     windowID: windowID,
-                    includeShadow: settings.captureWindowShadow
+                    includeShadow: false
                 )
+                if settings.captureWindowShadow {
+                    // Capture the real desktop behind the window (excluding the
+                    // window itself) for the frosted glass background.
+                    // Padding = 4% of the shorter side, plus room for shadow blur.
+                    let shorter = min(CGFloat(result.image.width), CGFloat(result.image.height))
+                    let padding = max(30, shorter * 0.04)
+                    let totalPadding = padding + 20 // extra for shadow spread
+                    let desktopBg = try await ScreenCaptureManager.captureDesktopBehindWindow(
+                        windowID: windowID,
+                        padding: totalPadding
+                    )
+                    if let composited = Self.compositeWindowWithFrostedGlass(
+                        windowImage: result.image,
+                        desktopBackground: desktopBg
+                    ) {
+                        let enhanced = CaptureResult(
+                            image: composited,
+                            mode: result.mode,
+                            captureRect: result.captureRect,
+                            windowName: result.windowName,
+                            appName: result.appName,
+                            timestamp: result.timestamp,
+                            displayID: result.displayID
+                        )
+                        handleCaptureResult(enhanced)
+                        return
+                    }
+                }
                 handleCaptureResult(result)
             } catch {
                 print("Window capture failed: \(error)")
             }
         }
+    }
+
+    /// Composite a window screenshot over a frosted-glass version of the real
+    /// desktop background, with uniform padding, rounded corners, and a soft
+    /// drop shadow.
+    private static func compositeWindowWithFrostedGlass(
+        windowImage: CGImage,
+        desktopBackground: CGImage
+    ) -> CGImage? {
+        let outW = desktopBackground.width
+        let outH = desktopBackground.height
+        guard outW > 0, outH > 0 else { return nil }
+
+        let imgW = CGFloat(windowImage.width)
+        let imgH = CGFloat(windowImage.height)
+        let canvasSize = CGSize(width: outW, height: outH)
+        let shadowRadius: CGFloat = 20
+        let cornerRadius: CGFloat = 12
+
+        // Centre the window in the canvas
+        let offsetX = (CGFloat(outW) - imgW) / 2
+        let offsetY = (CGFloat(outH) - imgH) / 2
+        let imageRect = CGRect(x: offsetX, y: offsetY, width: imgW, height: imgH)
+        let roundedPath = CGPath(roundedRect: imageRect, cornerWidth: cornerRadius, cornerHeight: cornerRadius, transform: nil)
+
+        // --- Blur the desktop background via CoreImage ---
+        guard let backdrop = frostedGlassBackdrop(from: desktopBackground, targetSize: canvasSize) else { return nil }
+
+        // --- Composite ---
+        guard let ctx = CGContext(
+            data: nil,
+            width: outW,
+            height: outH,
+            bitsPerComponent: 8,
+            bytesPerRow: outW * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        ) else { return nil }
+
+        let canvasRect = CGRect(x: 0, y: 0, width: outW, height: outH)
+
+        // 1. Draw frosted desktop backdrop
+        ctx.draw(backdrop, in: canvasRect)
+
+        // 2. Draw soft shadow — clip to OUTSIDE the rounded rect so the
+        //    white fill used to generate the shadow never bleeds into the
+        //    corner area (which would show as white corner artifacts).
+        ctx.saveGState()
+        let outerPath = CGMutablePath()
+        outerPath.addRect(canvasRect)
+        outerPath.addPath(roundedPath)
+        ctx.addPath(outerPath)
+        ctx.clip(using: .evenOdd)
+        ctx.setShadow(
+            offset: CGSize(width: 0, height: -4),
+            blur: shadowRadius,
+            color: NSColor.black.withAlphaComponent(0.25).cgColor
+        )
+        ctx.addPath(roundedPath)
+        ctx.setFillColor(NSColor.white.cgColor)
+        ctx.fillPath()
+        ctx.restoreGState()
+
+        // 3. Draw window clipped to rounded corners
+        ctx.saveGState()
+        ctx.addPath(roundedPath)
+        ctx.clip()
+        ctx.draw(windowImage, in: imageRect)
+        ctx.restoreGState()
+
+        return ctx.makeImage()
+    }
+
+    /// Blur and slightly saturate a desktop background image for the frosted
+    /// glass effect behind window captures.
+    private static func frostedGlassBackdrop(from image: CGImage, targetSize: CGSize) -> CGImage? {
+        let srcW = CGFloat(image.width)
+        let srcH = CGFloat(image.height)
+        guard srcW > 0, srcH > 0 else { return nil }
+
+        var ci = CIImage(cgImage: image)
+
+        // Aspect-fill to target size with slight overshoot to avoid blur edges.
+        let coverScale = max(targetSize.width / srcW, targetSize.height / srcH) * 1.05
+        ci = ci.transformed(by: CGAffineTransform(scaleX: coverScale, y: coverScale))
+        let tx = (targetSize.width - ci.extent.width) / 2 - ci.extent.minX
+        let ty = (targetSize.height - ci.extent.height) / 2 - ci.extent.minY
+        ci = ci.transformed(by: CGAffineTransform(translationX: tx, y: ty))
+
+        // Boost saturation slightly for richer colours.
+        if let f = CIFilter(name: "CIColorControls", parameters: [
+            kCIInputImageKey: ci,
+            kCIInputSaturationKey: 1.4,
+            kCIInputBrightnessKey: 0.0,
+            kCIInputContrastKey: 0.98,
+        ]), let out = f.outputImage {
+            ci = out
+        }
+
+        // Heavy Gaussian blur for frosted glass look.
+        let clamped = ci.clampedToExtent()
+        if let f = CIFilter(name: "CIGaussianBlur", parameters: [
+            kCIInputImageKey: clamped,
+            kCIInputRadiusKey: 80.0,
+        ]), let out = f.outputImage {
+            ci = out
+        }
+
+        let ciCtx = CIContext(options: nil)
+        return ciCtx.createCGImage(ci, from: CGRect(origin: .zero, size: targetSize))
     }
 
     private func dismissOverlay() {

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -14,126 +14,333 @@ final class PreferencesViewModel {
 
     // MARK: General
     var playShutterSound: Bool {
-        get { settings.playShutterSound }
-        set { settings.playShutterSound = newValue }
+        get {
+            access(keyPath: \.playShutterSound)
+            return settings.playShutterSound
+        }
+        set {
+            withMutation(keyPath: \.playShutterSound) {
+                settings.playShutterSound = newValue
+            }
+        }
     }
     var showMenuBarIcon: Bool {
-        get { settings.showMenuBarIcon }
-        set { settings.showMenuBarIcon = newValue }
+        get {
+            access(keyPath: \.showMenuBarIcon)
+            return settings.showMenuBarIcon
+        }
+        set {
+            withMutation(keyPath: \.showMenuBarIcon) {
+                settings.showMenuBarIcon = newValue
+            }
+        }
     }
 
     // MARK: Screenshots
+    var screenshotShowPreview: Bool {
+        get {
+            access(keyPath: \.screenshotShowPreview)
+            return settings.screenshotShowPreview
+        }
+        set {
+            withMutation(keyPath: \.screenshotShowPreview) {
+                settings.screenshotShowPreview = newValue
+            }
+        }
+    }
     var screenshotAutoCopy: Bool {
-        get { settings.screenshotAutoCopy }
-        set { settings.screenshotAutoCopy = newValue }
+        get {
+            access(keyPath: \.screenshotAutoCopy)
+            return settings.screenshotAutoCopy
+        }
+        set {
+            withMutation(keyPath: \.screenshotAutoCopy) {
+                settings.screenshotAutoCopy = newValue
+            }
+        }
+    }
+    var screenshotAutoSave: Bool {
+        get {
+            access(keyPath: \.screenshotAutoSave)
+            return settings.screenshotAutoSave
+        }
+        set {
+            withMutation(keyPath: \.screenshotAutoSave) {
+                settings.screenshotAutoSave = newValue
+            }
+        }
     }
     var screenshotFormat: ScreenshotFormat {
-        get { settings.screenshotFormat }
-        set { settings.screenshotFormat = newValue }
+        get {
+            access(keyPath: \.screenshotFormat)
+            return settings.screenshotFormat
+        }
+        set {
+            withMutation(keyPath: \.screenshotFormat) {
+                settings.screenshotFormat = newValue
+            }
+        }
     }
     var captureWindowShadow: Bool {
-        get { settings.captureWindowShadow }
-        set { settings.captureWindowShadow = newValue }
+        get {
+            access(keyPath: \.captureWindowShadow)
+            return settings.captureWindowShadow
+        }
+        set {
+            withMutation(keyPath: \.captureWindowShadow) {
+                settings.captureWindowShadow = newValue
+            }
+        }
     }
     var freezeScreen: Bool {
-        get { settings.freezeScreen }
-        set { settings.freezeScreen = newValue }
+        get {
+            access(keyPath: \.freezeScreen)
+            return settings.freezeScreen
+        }
+        set {
+            withMutation(keyPath: \.freezeScreen) {
+                settings.freezeScreen = newValue
+            }
+        }
     }
     var showMagnifier: Bool {
-        get { settings.showMagnifier }
-        set { settings.showMagnifier = newValue }
+        get {
+            access(keyPath: \.showMagnifier)
+            return settings.showMagnifier
+        }
+        set {
+            withMutation(keyPath: \.showMagnifier) {
+                settings.showMagnifier = newValue
+            }
+        }
     }
     var rememberLastCaptureArea: Bool {
-        get { settings.rememberLastCaptureArea }
-        set { settings.rememberLastCaptureArea = newValue }
+        get {
+            access(keyPath: \.rememberLastCaptureArea)
+            return settings.rememberLastCaptureArea
+        }
+        set {
+            withMutation(keyPath: \.rememberLastCaptureArea) {
+                settings.rememberLastCaptureArea = newValue
+            }
+        }
     }
 
     // MARK: Recording
     var recordingFormat: RecordingFormat {
-        get { settings.recordingFormat }
-        set { settings.recordingFormat = newValue }
+        get {
+            access(keyPath: \.recordingFormat)
+            return settings.recordingFormat
+        }
+        set {
+            withMutation(keyPath: \.recordingFormat) {
+                settings.recordingFormat = newValue
+            }
+        }
     }
     var showCursor: Bool {
-        get { settings.showCursor }
-        set { settings.showCursor = newValue }
+        get {
+            access(keyPath: \.showCursor)
+            return settings.showCursor
+        }
+        set {
+            withMutation(keyPath: \.showCursor) {
+                settings.showCursor = newValue
+            }
+        }
     }
     var highlightClicks: Bool {
-        get { settings.highlightClicks }
-        set { settings.highlightClicks = newValue }
+        get {
+            access(keyPath: \.highlightClicks)
+            return settings.highlightClicks
+        }
+        set {
+            withMutation(keyPath: \.highlightClicks) {
+                settings.highlightClicks = newValue
+            }
+        }
     }
     var cursorSmoothing: Bool {
-        get { settings.cursorSmoothing }
-        set { settings.cursorSmoothing = newValue }
+        get {
+            access(keyPath: \.cursorSmoothing)
+            return settings.cursorSmoothing
+        }
+        set {
+            withMutation(keyPath: \.cursorSmoothing) {
+                settings.cursorSmoothing = newValue
+            }
+        }
     }
     var showCountdown: Bool {
-        get { settings.showCountdown }
-        set { settings.showCountdown = newValue }
+        get {
+            access(keyPath: \.showCountdown)
+            return settings.showCountdown
+        }
+        set {
+            withMutation(keyPath: \.showCountdown) {
+                settings.showCountdown = newValue
+            }
+        }
     }
     var dimScreenWhileRecording: Bool {
-        get { settings.dimScreenWhileRecording }
-        set { settings.dimScreenWhileRecording = newValue }
+        get {
+            access(keyPath: \.dimScreenWhileRecording)
+            return settings.dimScreenWhileRecording
+        }
+        set {
+            withMutation(keyPath: \.dimScreenWhileRecording) {
+                settings.dimScreenWhileRecording = newValue
+            }
+        }
     }
     var rememberLastRecordingArea: Bool {
-        get { settings.rememberLastRecordingArea }
-        set { settings.rememberLastRecordingArea = newValue }
+        get {
+            access(keyPath: \.rememberLastRecordingArea)
+            return settings.rememberLastRecordingArea
+        }
+        set {
+            withMutation(keyPath: \.rememberLastRecordingArea) {
+                settings.rememberLastRecordingArea = newValue
+            }
+        }
     }
 
     // MARK: Camera
     var cameraShape: CameraShape {
-        get { settings.cameraShape }
-        set { settings.cameraShape = newValue }
+        get {
+            access(keyPath: \.cameraShape)
+            return settings.cameraShape
+        }
+        set {
+            withMutation(keyPath: \.cameraShape) {
+                settings.cameraShape = newValue
+            }
+        }
     }
     var cameraSize: CameraSize {
-        get { settings.cameraSize }
-        set { settings.cameraSize = newValue }
+        get {
+            access(keyPath: \.cameraSize)
+            return settings.cameraSize
+        }
+        set {
+            withMutation(keyPath: \.cameraSize) {
+                settings.cameraSize = newValue
+            }
+        }
     }
     var cameraMirror: Bool {
-        get { settings.cameraMirror }
-        set { settings.cameraMirror = newValue }
+        get {
+            access(keyPath: \.cameraMirror)
+            return settings.cameraMirror
+        }
+        set {
+            withMutation(keyPath: \.cameraMirror) {
+                settings.cameraMirror = newValue
+            }
+        }
     }
     var cameraCustomSizePt: Double {
-        get { settings.cameraCustomSizePt }
-        set { settings.cameraCustomSizePt = newValue }
+        get {
+            access(keyPath: \.cameraCustomSizePt)
+            return settings.cameraCustomSizePt
+        }
+        set {
+            withMutation(keyPath: \.cameraCustomSizePt) {
+                settings.cameraCustomSizePt = newValue
+            }
+        }
     }
 
     // MARK: Quick Access
     var quickAccessPosition: QuickAccessPosition {
-        get { settings.quickAccessPosition }
-        set { settings.quickAccessPosition = newValue }
+        get {
+            access(keyPath: \.quickAccessPosition)
+            return settings.quickAccessPosition
+        }
+        set {
+            withMutation(keyPath: \.quickAccessPosition) {
+                settings.quickAccessPosition = newValue
+            }
+        }
     }
     var quickAccessAutoClose: Bool {
-        get { settings.quickAccessAutoClose }
-        set { settings.quickAccessAutoClose = newValue }
+        get {
+            access(keyPath: \.quickAccessAutoClose)
+            return settings.quickAccessAutoClose
+        }
+        set {
+            withMutation(keyPath: \.quickAccessAutoClose) {
+                settings.quickAccessAutoClose = newValue
+            }
+        }
     }
     var quickAccessAutoCloseInterval: Int {
-        get { settings.quickAccessAutoCloseInterval }
-        set { settings.quickAccessAutoCloseInterval = newValue }
+        get {
+            access(keyPath: \.quickAccessAutoCloseInterval)
+            return settings.quickAccessAutoCloseInterval
+        }
+        set {
+            withMutation(keyPath: \.quickAccessAutoCloseInterval) {
+                settings.quickAccessAutoCloseInterval = newValue
+            }
+        }
     }
 
     // MARK: Export
     var exportQuality: ExportQuality {
-        get { settings.exportQuality }
-        set { settings.exportQuality = newValue }
+        get {
+            access(keyPath: \.exportQuality)
+            return settings.exportQuality
+        }
+        set {
+            withMutation(keyPath: \.exportQuality) {
+                settings.exportQuality = newValue
+            }
+        }
     }
     var exportLocation: URL {
-        settings.exportLocation
+        access(keyPath: \.exportLocation)
+        return settings.exportLocation
     }
     func setExportLocation(_ url: URL) {
-        settings.setExportLocation(url)
+        withMutation(keyPath: \.exportLocation) {
+            settings.setExportLocation(url)
+        }
     }
 
     // MARK: OCR
     var ocrKeepLineBreaks: Bool {
-        get { settings.ocrKeepLineBreaks }
-        set { settings.ocrKeepLineBreaks = newValue }
+        get {
+            access(keyPath: \.ocrKeepLineBreaks)
+            return settings.ocrKeepLineBreaks
+        }
+        set {
+            withMutation(keyPath: \.ocrKeepLineBreaks) {
+                settings.ocrKeepLineBreaks = newValue
+            }
+        }
     }
     var ocrDetectLinks: Bool {
-        get { settings.ocrDetectLinks }
-        set { settings.ocrDetectLinks = newValue }
+        get {
+            access(keyPath: \.ocrDetectLinks)
+            return settings.ocrDetectLinks
+        }
+        set {
+            withMutation(keyPath: \.ocrDetectLinks) {
+                settings.ocrDetectLinks = newValue
+            }
+        }
     }
     var ocrPrimaryLanguage: String? {
-        get { settings.ocrPrimaryLanguage }
-        set { settings.ocrPrimaryLanguage = newValue }
+        get {
+            access(keyPath: \.ocrPrimaryLanguage)
+            return settings.ocrPrimaryLanguage
+        }
+        set {
+            withMutation(keyPath: \.ocrPrimaryLanguage) {
+                settings.ocrPrimaryLanguage = newValue
+            }
+        }
     }
 
     // MARK: Version

--- a/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
@@ -10,42 +10,36 @@ struct ScreenshotSettingsView: View {
             Text("Screenshots")
                 .font(.system(size: 20, weight: .bold))
 
-            SettingGroup(title: "Capture") {
+            SettingGroup(title: "After Capture") {
                 SettingCard {
-                    SettingRow(label: "Auto Copy to Clipboard", sublabel: "Copy screenshot immediately after capture") {
+                    SettingRow(label: "Show Preview", sublabel: "Display thumbnail with quick actions") {
+                        Toggle("", isOn: $viewModel.screenshotShowPreview)
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                    }
+                    SettingRow(label: "Copy to Clipboard", sublabel: "Copy screenshot immediately", showDivider: true) {
                         Toggle("", isOn: $viewModel.screenshotAutoCopy)
                             .toggleStyle(.switch)
                             .controlSize(.small)
                     }
-                    SettingRow(label: "Capture Window Shadow", sublabel: "Include shadow in window captures", showDivider: true) {
+                    SettingRow(label: "Auto Save", sublabel: "Save to file automatically", showDivider: true) {
+                        Toggle("", isOn: $viewModel.screenshotAutoSave)
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                    }
+                }
+            }
+
+            SettingGroup(title: "Capture") {
+                SettingCard {
+                    SettingRow(label: "Capture Window Shadow", sublabel: "Include shadow in window captures") {
                         Toggle("", isOn: $viewModel.captureWindowShadow)
                             .toggleStyle(.switch)
                             .controlSize(.small)
                     }
-                    // TODO: Re-enable the three rows below once the underlying
-                    // behaviors are implemented. They are currently dead UI —
-                    // the values are stored in AppSettings but never read by
-                    // CaptureCoordinator / CaptureOverlayView. Uncomment each
-                    // row when its feature ships:
-                    //   - freezeScreen: freeze the display during area selection
-                    //     (needs capture overlay to snapshot the desktop on entry)
-                    //   - showMagnifier: pixel-level loupe in the overlay
-                    //   - rememberLastCaptureArea: persist last drag rect across runs
-                    // SettingRow(label: "Freeze Screen", sublabel: "Freeze display during area selection", showDivider: true) {
-                    //     Toggle("", isOn: $viewModel.freezeScreen)
-                    //         .toggleStyle(.switch)
-                    //         .controlSize(.small)
-                    // }
-                    // SettingRow(label: "Show Magnifier", sublabel: "Pixel-level loupe during selection", showDivider: true) {
-                    //     Toggle("", isOn: $viewModel.showMagnifier)
-                    //         .toggleStyle(.switch)
-                    //         .controlSize(.small)
-                    // }
-                    // SettingRow(label: "Remember Last Area", sublabel: "Restore previous selection on next capture", showDivider: true) {
-                    //     Toggle("", isOn: $viewModel.rememberLastCaptureArea)
-                    //         .toggleStyle(.switch)
-                    //         .controlSize(.small)
-                    // }
+                    // TODO: Re-enable the rows below once underlying
+                    // behaviors are implemented (freezeScreen, showMagnifier,
+                    // rememberLastCaptureArea).
                 }
             }
 

--- a/Packages/CaptureKit/Sources/CaptureKit/ScreenCaptureManager.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/ScreenCaptureManager.swift
@@ -111,6 +111,56 @@ public enum ScreenCaptureManager {
         )
     }
 
+    // MARK: - Desktop Background Capture (for window shadow compositing)
+
+    /// Capture the desktop behind a window (excluding the window itself),
+    /// cropped to the window area with extra padding for the shadow region.
+    public static func captureDesktopBehindWindow(
+        windowID: CGWindowID,
+        padding: CGFloat
+    ) async throws -> CGImage {
+        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+
+        guard let scWindow = content.windows.first(where: { $0.windowID == windowID }) else {
+            throw CaptureError.windowNotFound(windowID)
+        }
+
+        let windowCenter = CGPoint(x: scWindow.frame.midX, y: scWindow.frame.midY)
+        guard let display = content.displays.first(where: { $0.frame.contains(windowCenter) })
+            ?? content.displays.first else {
+            throw CaptureError.noDisplayFound
+        }
+
+        // Capture the entire display EXCLUDING the target window.
+        let filter = SCContentFilter(display: display, excludingWindows: [scWindow])
+        let config = SCStreamConfiguration()
+        config.captureResolution = .best
+        config.showsCursor = false
+
+        // Crop to the window area + padding, in display-local coordinates.
+        var cropRect = CGRect(
+            x: scWindow.frame.origin.x - display.frame.origin.x - padding,
+            y: scWindow.frame.origin.y - display.frame.origin.y - padding,
+            width: scWindow.frame.width + padding * 2,
+            height: scWindow.frame.height + padding * 2
+        )
+        let displayBounds = CGRect(x: 0, y: 0, width: display.frame.width, height: display.frame.height)
+        cropRect = cropRect.intersection(displayBounds)
+        guard !cropRect.isEmpty else {
+            throw CaptureError.captureFailed("Window background is not visible")
+        }
+
+        config.sourceRect = cropRect
+        let scaleFactor = CGFloat(filter.pointPixelScale)
+        config.width = Int(cropRect.width * scaleFactor)
+        config.height = Int(cropRect.height * scaleFactor)
+
+        return try await SCScreenshotManager.captureImage(
+            contentFilter: filter,
+            configuration: config
+        )
+    }
+
     // MARK: - Area Capture
 
     public static func captureArea(rect: CGRect, displayID: CGDirectDisplayID = CGMainDisplayID()) async throws -> CaptureResult {

--- a/Packages/CaptureKit/Sources/CaptureKit/ScreenCaptureManager.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/ScreenCaptureManager.swift
@@ -49,49 +49,52 @@ public enum ScreenCaptureManager {
             throw CaptureError.windowNotFound(windowID)
         }
 
-        // Find which display this window is on
+        // Find which display this window is on (needed for displayID metadata
+        // and for the no-shadow display-based capture path).
         let windowCenter = CGPoint(x: scWindow.frame.midX, y: scWindow.frame.midY)
         guard let display = content.displays.first(where: { $0.frame.contains(windowCenter) })
             ?? content.displays.first else {
             throw CaptureError.noDisplayFound
         }
 
-        // Capture the display but only include this window.
-        // This renders the window in-place on the display (no distortion for GPU content),
-        // then we crop to the window bounds.
-        let filter = SCContentFilter(display: display, including: [scWindow])
+        let filter: SCContentFilter
         let config = SCStreamConfiguration()
         config.captureResolution = .best
         config.showsCursor = false
 
-        // `config.sourceRect` must be in the content filter's LOCAL coordinate
-        // space — i.e. relative to the display's top-left at (0, 0) — NOT in
-        // global display-space. `SCWindow.frame` and `SCDisplay.frame` are
-        // both in global coords, so we subtract the display origin to localise.
-        //
-        // Without this, any multi-display setup where the target window lives
-        // on a non-origin display (e.g. the built-in MacBook screen when an
-        // external monitor is set as primary) fails SCStream validation with
-        // "contentRect does not contain sourceRect" and the capture silently
-        // aborts (no preview shown).
-        var localRect = CGRect(
-            x: scWindow.frame.origin.x - display.frame.origin.x,
-            y: scWindow.frame.origin.y - display.frame.origin.y,
-            width: scWindow.frame.width,
-            height: scWindow.frame.height
-        )
-        // Clamp to the display's bounds in case the window extends slightly
-        // off the edge (e.g. sheets that overflow, or windows being dragged).
-        let displayBounds = CGRect(x: 0, y: 0, width: display.frame.width, height: display.frame.height)
-        localRect = localRect.intersection(displayBounds)
-        guard !localRect.isEmpty else {
-            throw CaptureError.captureFailed("Window is not visible on the target display")
-        }
+        if includeShadow {
+            // Desktop-independent window filter: ScreenCaptureKit renders the
+            // window with its shadow on a transparent background. The filter's
+            // contentRect automatically includes the shadow bounds.
+            filter = SCContentFilter(desktopIndependentWindow: scWindow)
+            config.ignoreShadowsSingleWindow = false
+            let scaleFactor = CGFloat(filter.pointPixelScale)
+            config.width = Int(filter.contentRect.width * scaleFactor)
+            config.height = Int(filter.contentRect.height * scaleFactor)
+        } else {
+            // Display-based capture including only this window, cropped to the
+            // window frame. This avoids the shadow and renders GPU content
+            // in-place on the display (no distortion).
+            filter = SCContentFilter(display: display, including: [scWindow])
 
-        config.sourceRect = localRect
-        let scaleFactor = CGFloat(filter.pointPixelScale)
-        config.width = Int(localRect.width * scaleFactor)
-        config.height = Int(localRect.height * scaleFactor)
+            // `config.sourceRect` must be in the content filter's LOCAL
+            // coordinate space — relative to the display's top-left at (0,0).
+            var localRect = CGRect(
+                x: scWindow.frame.origin.x - display.frame.origin.x,
+                y: scWindow.frame.origin.y - display.frame.origin.y,
+                width: scWindow.frame.width,
+                height: scWindow.frame.height
+            )
+            let displayBounds = CGRect(x: 0, y: 0, width: display.frame.width, height: display.frame.height)
+            localRect = localRect.intersection(displayBounds)
+            guard !localRect.isEmpty else {
+                throw CaptureError.captureFailed("Window is not visible on the target display")
+            }
+            config.sourceRect = localRect
+            let scaleFactor = CGFloat(filter.pointPixelScale)
+            config.width = Int(localRect.width * scaleFactor)
+            config.height = Int(localRect.height * scaleFactor)
+        }
 
         let image = try await SCScreenshotManager.captureImage(
             contentFilter: filter,

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -191,9 +191,19 @@ public final class AppSettings: @unchecked Sendable {
     }
 
     // MARK: Screenshots
+    public var screenshotShowPreview: Bool {
+        get { defaults.object(forKey: "screenshotShowPreview") as? Bool ?? true }
+        set { defaults.set(newValue, forKey: "screenshotShowPreview") }
+    }
+
     public var screenshotAutoCopy: Bool {
         get { defaults.object(forKey: "screenshotAutoCopy") as? Bool ?? false }
         set { defaults.set(newValue, forKey: "screenshotAutoCopy") }
+    }
+
+    public var screenshotAutoSave: Bool {
+        get { defaults.object(forKey: "screenshotAutoSave") as? Bool ?? false }
+        set { defaults.set(newValue, forKey: "screenshotAutoSave") }
     }
 
     public var captureWindowShadow: Bool {


### PR DESCRIPTION
## Summary
- **BeautifyPanel redesign**: visual hierarchy with secondary labels, section dividers, color swatch selection ring, animated state changes, extracted reusable components
- **Toolbar fixes**: cursor now reverts to arrow over toolbar (resetCursorRects), added tooltips to color swatches and undo/redo
- **After-capture settings**: independent Show Preview / Copy to Clipboard / Auto Save toggles (Shottr-style)
- **PreferencesViewModel observation fix**: added explicit access/withMutation so SwiftUI immediately reflects toggle changes
- **Frosted glass window capture**: captures real desktop behind window, blurs it into a frosted glass backdrop, composites window with uniform padding, rounded corners, and soft shadow

## Test plan
- [x] Open Annotate editor, verify cursor changes to arrow when hovering toolbar
- [x] Hover tool icons and color circles to verify tooltips appear
- [x] Open Settings > Screenshots, toggle Show Preview / Copy / Auto Save, switch tabs and verify state persists
- [x] Use window capture with Capture Window Shadow ON, verify frosted glass background with uniform padding
- [x] Open Beautify panel, verify section dividers, color selection ring, and smooth animations
🤖 Generated with [Claude Code](https://claude.com/claude-code)