### PR TITLE
chore: add Homebrew tap support and auto-update workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -221,3 +221,45 @@ jobs:
           files: |
             build/releases/*.dmg
             build/releases/*.zip
+
+      - name: Update Homebrew tap
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          DMG="build/releases/${APP_NAME}-${VERSION}.dmg"
+          SHA256=$(shasum -a 256 "$DMG" | awk '{print $1}')
+
+          git clone https://x-access-token:${GH_TOKEN}@github.com/lzhgus/homebrew-tap.git /tmp/homebrew-tap
+          cd /tmp/homebrew-tap
+
+          cat > Casks/capso.rb << CASK
+          cask "capso" do
+            version "${VERSION}"
+            sha256 "${SHA256}"
+
+            url "https://github.com/lzhgus/Capso/releases/download/v#{version}/Capso-#{version}.dmg"
+            name "Capso"
+            desc "Open-source screenshot and screen recording for macOS"
+            homepage "https://github.com/lzhgus/Capso"
+
+            depends_on macos: ">= :sequoia"
+
+            app "Capso.app"
+
+            zap trash: [
+              "~/Library/Preferences/com.awesomemacapps.capso.plist",
+            ]
+          end
+          CASK
+
+          # Remove leading whitespace from heredoc indentation
+          sed -i '' 's/^          //' Casks/capso.rb
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/capso.rb
+          git commit -m "Update Capso to v${VERSION}"
+          git push

--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ A native, feature-rich alternative to CleanShot X. Built with Swift 6.0 and Swif
 
 Grab the latest signed, notarized DMG from [**GitHub Releases →**](https://github.com/lzhgus/Capso/releases/latest)
 
-<!-- TODO: Add Homebrew cask once submitted -->
-<!-- ```bash -->
-<!-- brew install --cask capso -->
-<!-- ``` -->
+Or install via Homebrew:
+
+```bash
+brew tap lzhgus/tap
+brew install --cask capso
+```
 
 Or [build from source](#build-from-source).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,6 +30,13 @@
 
 从 [**GitHub Releases →**](https://github.com/lzhgus/Capso/releases/latest) 下载最新的签名公证版 DMG，开箱即用。
 
+或通过 Homebrew 安装：
+
+```bash
+brew tap lzhgus/tap
+brew install --cask capso
+```
+
 也可以[从源码构建](#从源码构建)。
 
 > 首次使用时需要授予屏幕录制、摄像头和麦克风权限，App 会自动弹窗引导。


### PR DESCRIPTION
## Summary
- Add Homebrew install instructions to both READMEs
- Add workflow step to auto-update `lzhgus/homebrew-tap` cask on every tag push

## Setup required
Create a GitHub Personal Access Token with `repo` scope and add it as a secret `HOMEBREW_TAP_TOKEN` in this repo's Settings > Secrets.