### PR TITLE
fix: recording toolbar icons invisible in Light mode

### DIFF
--- a/App/Sources/Recording/RecordingToolbar.swift
+++ b/App/Sources/Recording/RecordingToolbar.swift
@@ -138,6 +138,10 @@ struct RecordingToolbarView: View {
                 .stroke(.white.opacity(0.1), lineWidth: 0.5)
         )
         .shadow(color: .black.opacity(0.5), radius: 12, y: 6)
+        // Force dark appearance so `.white` always resolves to true
+        // white — the toolbar has a dark background regardless of the
+        // system color scheme.
+        .environment(\.colorScheme, .dark)
     }
 
     // MARK: - Mic Menu


### PR DESCRIPTION
## Summary
- Force `.environment(\.colorScheme, .dark)` on the recording toolbar since it has a manually dark background
- Without this, SwiftUI resolves `.white` differently in Light mode, making disabled mic/camera/speaker icons nearly invisible

Fixes #5 

<img width="462" height="330" alt="image" src="https://github.com/user-attachments/assets/1ca97ae3-4bc7-41bd-b4f1-4a2e63582d64" />


## Test plan
- [x] Switch to Light mode, start area recording, verify mic/camera/speaker icons are visible in both enabled and disabled states
- [x] Verify Dark mode still looks correct