### PR TITLE
fix: add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: macos-15


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` to `ci.yml` to restrict GITHUB_TOKEN to read-only access
- Resolves [CodeQL code-scanning alert #1](https://github.com/lzhgus/Capso/security/code-scanning/1)

No functional changes — CI only needs to checkout code and run builds/tests.