### PR TITLE
fix: allow capturing Capso's own windows (e.g. Settings)

### DIFF
--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -64,8 +64,11 @@ final class CaptureCoordinator {
         // Enumerate windows first, then show overlay in window selection mode
         Task {
             do {
+                // Exclude only Capso's overlay windows (not all Capso windows
+                // like Settings) so the user can still capture them.
+                let overlayIDs = Set(overlayWindows.map { CGWindowID($0.windowNumber) })
                 let windows = try await ContentEnumerator.windows()
-                    .filter { $0.appName != "Capso" }
+                    .filter { !overlayIDs.contains($0.id) }
 
                 guard !windows.isEmpty else {
                     print("No windows found to capture")


### PR DESCRIPTION
## Summary
- Window capture was filtering out ALL Capso windows by app name, which excluded Settings and other normal windows
- Now only excludes the capture overlay windows by their specific window IDs

## Test plan
- [x] Open Capso Settings, use Capture Window, verify Settings window appears in the selection list and can be captured
- [x] Verify capture overlay itself is still excluded from the window list