### PR TITLE
feat: integrate Sparkle for in-app auto-updates

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -263,3 +263,51 @@ jobs:
           git add Casks/capso.rb
           git commit -m "Update Capso to v${VERSION}"
           git push
+
+      - name: Update Sparkle appcast on gh-pages
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          BUILD="${{ steps.version.outputs.version }}"
+          DMG="build/releases/${APP_NAME}-${VERSION}.dmg"
+          DMG_SIZE=$(stat -f%z "$DMG")
+          PUB_DATE=$(date -R)
+
+          # Clone only the gh-pages branch
+          git clone --branch gh-pages --single-branch \
+            https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/lzhgus/Capso.git /tmp/gh-pages
+          cd /tmp/gh-pages
+
+          cat > appcast.xml << APPCAST
+          <?xml version="1.0" encoding="utf-8"?>
+          <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <channel>
+              <title>Capso Updates</title>
+              <link>https://lzhgus.github.io/Capso/appcast.xml</link>
+              <description>Open-source screenshot and screen recording for macOS</description>
+              <language>en</language>
+              <item>
+                <title>Version ${VERSION}</title>
+                <pubDate>${PUB_DATE}</pubDate>
+                <sparkle:version>${VERSION}</sparkle:version>
+                <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
+                <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+                <enclosure
+                  url="https://github.com/lzhgus/Capso/releases/download/v${VERSION}/Capso-${VERSION}.dmg"
+                  type="application/octet-stream"
+                  length="${DMG_SIZE}"
+                />
+              </item>
+            </channel>
+          </rss>
+          APPCAST
+
+          # Remove leading whitespace from heredoc indentation
+          sed -i '' 's/^          //' appcast.xml
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add appcast.xml
+          git commit -m "Update appcast for v${VERSION}"
+          git push

--- a/App/Entitlements/Capso.entitlements
+++ b/App/Entitlements/Capso.entitlements
@@ -6,5 +6,7 @@
 	<true/>
 	<key>com.apple.security.device.camera</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/App/Resources/Info.plist
+++ b/App/Resources/Info.plist
@@ -30,5 +30,11 @@
     <string>Capso needs microphone access to record audio during screen recordings.</string>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
+    <key>SUFeedURL</key>
+    <string>https://lzhgus.github.io/Capso/appcast.xml</string>
+    <key>SUEnableAutomaticChecks</key>
+    <true/>
+    <key>SUScheduledCheckInterval</key>
+    <integer>86400</integer>
 </dict>
 </plist>

--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -2,6 +2,7 @@
 import AppKit
 import SharedKit
 import KeyboardShortcuts
+import Sparkle
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
@@ -12,6 +13,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private(set) var recordingCoordinator: RecordingCoordinator?
     private(set) var ocrCoordinator: OCRCoordinator?
     private var preferencesWindow: PreferencesWindow?
+    /// Sparkle updater controller — manages the update lifecycle.
+    let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Show tooltips faster (default is ~2s, reduce to 0.3s)
@@ -23,7 +26,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         recordingCoordinator = RecordingCoordinator(settings: settings)
         ocrCoordinator = OCRCoordinator(settings: settings)
         captureCoordinator!.ocrCoordinator = ocrCoordinator
-        preferencesWindow = PreferencesWindow(settings: settings)
+        preferencesWindow = PreferencesWindow(settings: settings, updater: updaterController.updater)
         menuBarController = MenuBarController(
             settings: settings,
             captureCoordinator: captureCoordinator!,

--- a/App/Sources/Preferences/Components/CheckForUpdatesView.swift
+++ b/App/Sources/Preferences/Components/CheckForUpdatesView.swift
@@ -1,0 +1,37 @@
+// App/Sources/Preferences/Components/CheckForUpdatesView.swift
+import SwiftUI
+import Sparkle
+
+/// A SwiftUI wrapper that observes the Sparkle updater's `canCheckForUpdates`
+/// state and exposes a "Check for Updates" button.
+struct CheckForUpdatesView: View {
+    @ObservedObject private var checkForUpdatesViewModel: CheckForUpdatesViewModel
+
+    init(updater: SPUUpdater) {
+        self.checkForUpdatesViewModel = CheckForUpdatesViewModel(updater: updater)
+    }
+
+    var body: some View {
+        Button("Check for Updates") {
+            checkForUpdatesViewModel.updater.checkForUpdates()
+        }
+        .disabled(!checkForUpdatesViewModel.canCheckForUpdates)
+        .controlSize(.small)
+    }
+}
+
+@MainActor
+private final class CheckForUpdatesViewModel: ObservableObject {
+    @Published var canCheckForUpdates = false
+    let updater: SPUUpdater
+    private var observation: NSKeyValueObservation?
+
+    init(updater: SPUUpdater) {
+        self.updater = updater
+        observation = updater.observe(\.canCheckForUpdates, options: [.initial, .new]) { [weak self] updater, _ in
+            Task { @MainActor in
+                self?.canCheckForUpdates = updater.canCheckForUpdates
+            }
+        }
+    }
+}

--- a/App/Sources/Preferences/PreferencesView.swift
+++ b/App/Sources/Preferences/PreferencesView.swift
@@ -1,5 +1,6 @@
 // App/Sources/Preferences/PreferencesView.swift
 import SwiftUI
+import Sparkle
 
 enum PreferencesTab: String, CaseIterable {
     case general
@@ -38,6 +39,7 @@ enum PreferencesTab: String, CaseIterable {
 struct PreferencesView: View {
     @State private var selectedTab: PreferencesTab = .general
     let viewModel: PreferencesViewModel
+    let updater: SPUUpdater?
 
     var body: some View {
         HStack(spacing: 0) {
@@ -70,7 +72,7 @@ struct PreferencesView: View {
             VStack(alignment: .leading, spacing: 0) {
                 switch selectedTab {
                 case .general:
-                    GeneralSettingsView(viewModel: viewModel)
+                    GeneralSettingsView(viewModel: viewModel, updater: updater)
                 case .screenshots:
                     ScreenshotSettingsView(viewModel: viewModel)
                 case .recording:

--- a/App/Sources/Preferences/PreferencesWindow.swift
+++ b/App/Sources/Preferences/PreferencesWindow.swift
@@ -2,14 +2,17 @@
 import AppKit
 import SwiftUI
 import SharedKit
+import Sparkle
 
 @MainActor
 final class PreferencesWindow {
     private var window: NSWindow?
     private let settings: AppSettings
+    private let updater: SPUUpdater?
 
-    init(settings: AppSettings) {
+    init(settings: AppSettings, updater: SPUUpdater? = nil) {
         self.settings = settings
+        self.updater = updater
     }
 
     func show() {
@@ -39,7 +42,7 @@ final class PreferencesWindow {
         window.contentView = visualEffect
 
         let viewModel = PreferencesViewModel(settings: settings)
-        let hostingView = NSHostingView(rootView: PreferencesView(viewModel: viewModel))
+        let hostingView = NSHostingView(rootView: PreferencesView(viewModel: viewModel, updater: updater))
         hostingView.translatesAutoresizingMaskIntoConstraints = false
         visualEffect.addSubview(hostingView)
         NSLayoutConstraint.activate([

--- a/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
@@ -1,9 +1,11 @@
 // App/Sources/Preferences/Tabs/GeneralSettingsView.swift
 import SwiftUI
 import LaunchAtLogin
+import Sparkle
 
 struct GeneralSettingsView: View {
     @Bindable var viewModel: PreferencesViewModel
+    let updater: SPUUpdater?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -36,6 +38,16 @@ struct GeneralSettingsView: View {
                         Toggle("", isOn: $viewModel.playShutterSound)
                             .toggleStyle(.switch)
                             .controlSize(.small)
+                    }
+                }
+            }
+
+            if let updater {
+                SettingGroup(title: "Updates") {
+                    SettingCard {
+                        SettingRow(label: "Check for Updates", sublabel: "Automatically checks daily") {
+                            CheckForUpdatesView(updater: updater)
+                        }
                     }
                 }
             }

--- a/project.yml
+++ b/project.yml
@@ -46,6 +46,9 @@ packages:
   LaunchAtLogin:
     url: https://github.com/sindresorhus/LaunchAtLogin-Modern
     exactVersion: "1.1.0"
+  Sparkle:
+    url: https://github.com/sparkle-project/Sparkle
+    exactVersion: "2.9.1"
 
 targets:
   Capso:
@@ -76,8 +79,10 @@ targets:
       - package: KeyboardShortcuts
       - package: Defaults
       - package: LaunchAtLogin
+      - package: Sparkle
     entitlements:
       path: App/Entitlements/Capso.entitlements
       properties:
         com.apple.security.device.camera: true
         com.apple.security.device.audio-input: true
+        com.apple.security.network.client: true


### PR DESCRIPTION
## Summary
- Integrate Sparkle 2.9.1 for automatic update checking and in-app updates
- Appcast hosted on GitHub Pages at `https://lzhgus.github.io/Capso/appcast.xml`
- DMG downloads served from existing GitHub Releases
- "Check for Updates" button added to Settings > General
- Automatic daily update checks enabled by default

## Files changed
- `project.yml` — Sparkle dependency + network client entitlement
- `Info.plist` — SUFeedURL, SUEnableAutomaticChecks, SUScheduledCheckInterval
- `AppDelegate.swift` — SPUStandardUpdaterController initialization
- `PreferencesWindow/View` — pass updater through to GeneralSettingsView
- `GeneralSettingsView` — new "Updates" section with Check for Updates button
- `CheckForUpdatesView.swift` — new Sparkle KVO wrapper for SwiftUI

## Test plan
- [x] Open Settings > General, verify "Check for Updates" button is visible
- [x] Click "Check for Updates", verify Sparkle update dialog appears
- [x] Verify app launches without errors (Sparkle starts automatically)