### PR TITLE
chore: reformat String Catalogs to Xcode canonical format

### DIFF
--- a/App/Resources/InfoPlist.xcstrings
+++ b/App/Resources/InfoPlist.xcstrings
@@ -1,27 +1,113 @@
 {
-  "sourceLanguage": "en",
-  "version": "1.0",
-  "strings": {
-    "NSScreenCaptureUsageDescription": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Capso 需要屏幕录制权限来截取屏幕截图和录制屏幕。" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "Capso はスクリーンショットの撮影と画面録画のために画面収録の許可が必要です。" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "Capso가 스크린샷을 캡처하고 화면을 녹화하려면 화면 녹화 권한이 필요합니다." } }
+  "sourceLanguage" : "en",
+  "strings" : {
+    "CFBundleDisplayName" : {
+      "comment" : "Bundle display name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Capso"
+          }
+        }
       }
     },
-    "NSCameraUsageDescription": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Capso 需要摄像头权限以在录屏时显示摄像头画面。" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "Capso は画面録画中にウェブカメラを表示するためにカメラへのアクセスが必要です。" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "Capso가 화면 녹화 중 웹캠을 표시하려면 카메라 접근 권한이 필요합니다." } }
+    "CFBundleName" : {
+      "comment" : "Bundle name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Capso"
+          }
+        }
       }
     },
-    "NSMicrophoneUsageDescription": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Capso 需要麦克风权限以在录屏时录制音频。" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "Capso は画面録画中にオーディオを録音するためにマイクへのアクセスが必要です。" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "Capso가 화면 녹화 중 오디오를 녹음하려면 마이크 접근 권한이 필요합니다." } }
+    "NSCameraUsageDescription" : {
+      "comment" : "Privacy - Camera Usage Description",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Capso needs camera access to show your webcam during screen recordings."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Capso は画面録画中にウェブカメラを表示するためにカメラへのアクセスが必要です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Capso가 화면 녹화 중 웹캠을 표시하려면 카메라 접근 권한이 필요합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Capso 需要摄像头权限以在录屏时显示摄像头画面。"
+          }
+        }
+      }
+    },
+    "NSMicrophoneUsageDescription" : {
+      "comment" : "Privacy - Microphone Usage Description",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Capso needs microphone access to record audio during screen recordings."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Capso は画面録画中にオーディオを録音するためにマイクへのアクセスが必要です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Capso가 화면 녹화 중 오디오를 녹음하려면 마이크 접근 권한이 필요합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Capso 需要麦克风权限以在录屏时录制音频。"
+          }
+        }
+      }
+    },
+    "NSScreenCaptureUsageDescription" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capso はスクリーンショットの撮影と画面録画のために画面収録の許可が必要です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capso가 스크린샷을 캡처하고 화면을 녹화하려면 화면 녹화 권한이 필요합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capso 需要屏幕录制权限来截取屏幕截图和录制屏幕。"
+          }
+        }
       }
     }
-  }
+  },
+  "version" : "1.0"
 }

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -1,979 +1,3205 @@
 {
-  "sourceLanguage": "en",
-  "version": "1.0",
-  "strings": {
-    "General": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "通用" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "一般" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "일반" } }
-      }
-    },
-    "Startup": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "启动" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "起動" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "시작" } }
-      }
-    },
-    "Launch at Login": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "登录时启动" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ログイン時に起動" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "로그인 시 실행" } }
-      }
-    },
-    "Start Capso when you log in": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "登录 Mac 时自动启动 Capso" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "Mac にログインしたときに Capso を自動起動" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "Mac에 로그인할 때 Capso 자동 실행" } }
-      }
-    },
-    "Feedback": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "反馈" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "フィードバック" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "피드백" } }
-      }
-    },
-    "Shutter Sound": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "快门音效" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "シャッター音" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "셔터 소리" } }
-      }
-    },
-    "Play sound after capture": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "截图后播放声音" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "キャプチャ後にサウンドを再生" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "캡처 후 소리 재생" } }
-      }
-    },
-    "About": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "关于" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "情報" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "정보" } }
-      }
-    },
-    "Version": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "版本" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "バージョン" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "버전" } }
-      }
-    },
-    "Screenshots": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "截图" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "スクリーンショット" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "스크린샷" } }
-      }
-    },
-    "Capture": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "截取" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "キャプチャ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "캡처" } }
-      }
-    },
-    "Capture Window Shadow": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "捕捉窗口阴影" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ウインドウシャドウをキャプチャ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "윈도우 그림자 캡처" } }
-      }
-    },
-    "Include shadow in window captures": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "窗口截图时包含阴影" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ウインドウキャプチャにシャドウを含める" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "윈도우 캡처에 그림자 포함" } }
-      }
-    },
-    "Format": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "格式" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "フォーマット" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "포맷" } }
-      }
-    },
-    "Screenshot Format": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "截图格式" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "スクリーンショット形式" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "스크린샷 형식" } }
-      }
-    },
-    "Recording": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "录屏" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "録画" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "녹화" } }
-      }
-    },
-    "Cursor": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "光标" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "カーソル" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "커서" } }
-      }
-    },
-    "Show Cursor": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "显示光标" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "カーソルを表示" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "커서 표시" } }
-      }
-    },
-    "Highlight Clicks": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "高亮点击" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "クリックをハイライト" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "클릭 강조" } }
-      }
-    },
-    "Radial pulse on mouse click": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "鼠标点击时显示脉冲动画" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "マウスクリック時に放射状パルスを表示" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "마우스 클릭 시 방사형 펄스" } }
-      }
-    },
-    "Behavior": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "行为" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "動作" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "동작" } }
-      }
-    },
-    "Show Countdown": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "显示倒计时" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "カウントダウンを表示" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "카운트다운 표시" } }
-      }
-    },
-    "3-second countdown before recording": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "录屏前 3 秒倒计时" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "録画前に3秒のカウントダウン" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "녹화 전 3초 카운트다운" } }
-      }
-    },
-    "Quick Access": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "快速访问" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "クイックアクセス" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "빠른 접근" } }
-      }
-    },
-    "Position": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "位置" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "位置" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "위치" } }
-      }
-    },
-    "Preview Position": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "预览位置" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "プレビュー位置" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "미리보기 위치" } }
-      }
-    },
-    "Where the floating preview appears": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "浮动预览窗口的显示位置" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "フローティングプレビューの表示位置" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "플로팅 미리보기 표시 위치" } }
-      }
-    },
-    "↙ Bottom Left": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "↙ 左下角" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "↙ 左下" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "↙ 왼쪽 아래" } }
-      }
-    },
-    "↘ Bottom Right": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "↘ 右下角" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "↘ 右下" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "↘ 오른쪽 아래" } }
-      }
-    },
-    "Auto Copy to Clipboard": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "自动复制到剪贴板" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "クリップボードに自動コピー" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "클립보드에 자동 복사" } }
-      }
-    },
-    "Copy screenshot immediately after capture": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "截图后立即复制到剪贴板" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "キャプチャ後すぐにクリップボードにコピー" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "캡처 직후 클립보드에 복사" } }
-      }
-    },
-    "Auto-Close": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "自动关闭" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "自動閉じる" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "자동 닫기" } }
-      }
-    },
-    "Auto-Close Preview": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "自动关闭预览" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "プレビューを自動閉じる" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "미리보기 자동 닫기" } }
-      }
-    },
-    "Dismiss after timeout": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "超时后自动关闭" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "タイムアウト後に閉じる" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "시간 초과 후 닫기" } }
-      }
-    },
-    "Close After": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "关闭时间" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "閉じるまでの時間" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "닫기 시간" } }
-      }
-    },
-    "Export": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "导出" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "書き出し" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "내보내기" } }
-      }
-    },
-    "Quality": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "品质" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "品質" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "품질" } }
-      }
-    },
-    "Export Quality": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "导出品质" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "書き出し品質" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "내보내기 품질" } }
-      }
-    },
-    "Applies to video and GIF exports": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "适用于视频和 GIF 导出" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ビデオとGIFの書き出しに適用" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "비디오 및 GIF 내보내기에 적용" } }
-      }
-    },
-    "Maximum": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "最高" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "最高" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "최고" } }
-      }
-    },
-    "Social": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "社交" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ソーシャル" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "소셜" } }
-      }
-    },
-    "Web": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "网页" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ウェブ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "웹" } }
-      }
-    },
-    "Save Location": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "保存位置" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "保存場所" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "저장 위치" } }
-      }
-    },
-    "Export To": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "导出到" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "書き出し先" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "내보내기 위치" } }
-      }
-    },
-    "Choose…": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "选择…" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "選択…" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "선택…" } }
-      }
-    },
-    "Select": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "选择" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "選択" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "선택" } }
-      }
-    },
-    "OCR": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "文字识别" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "テキスト認識" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "텍스트 인식" } }
-      }
-    },
-    "Text Recognition": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "文字识别" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "テキスト認識" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "텍스트 인식" } }
-      }
-    },
-    "Keep Line Breaks": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "保留换行" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "改行を維持" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "줄 바꿈 유지" } }
-      }
-    },
-    "Preserve original line structure": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "保留原始行结构" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "元の行構造を保持" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "원본 줄 구조 유지" } }
-      }
-    },
-    "Detect Links": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "检测链接" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "リンクを検出" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "링크 감지" } }
-      }
-    },
-    "Auto-detect and linkify URLs": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "自动检测并转换 URL 链接" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "URLを自動検出してリンク化" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "URL 자동 감지 및 링크화" } }
-      }
-    },
-    "Shortcuts": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "快捷键" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ショートカット" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "단축키" } }
-      }
-    },
-    "Click a shortcut to record a new combination. Press **Esc** to cancel or **Delete** to remove.": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "点击快捷键以录制新的组合。按 **Esc** 取消或按 **Delete** 删除。" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ショートカットをクリックして新しい組み合わせを記録します。**Esc** でキャンセル、**Delete** で削除。" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "단축키를 클릭하여 새 조합을 녹화하세요. **Esc**로 취소, **Delete**로 삭제합니다." } }
-      }
-    },
-    "Capture Area": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "截取区域" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "エリアをキャプチャ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "영역 캡처" } }
-      }
-    },
-    "Capture Fullscreen": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "截取全屏" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "フルスクリーンをキャプチャ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "전체 화면 캡처" } }
-      }
-    },
-    "Capture Window": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "截取窗口" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ウインドウをキャプチャ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "윈도우 캡처" } }
-      }
-    },
-    "Capture Text (OCR)": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "截取文字 (OCR)" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "テキストをキャプチャ (OCR)" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "텍스트 캡처 (OCR)" } }
-      }
-    },
-    "Start / Stop Recording": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "开始/停止录屏" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "録画を開始/停止" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "녹화 시작/중지" } }
-      }
-    },
-    "Record Screen": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "录制屏幕" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "画面を録画" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "화면 녹화" } }
-      }
-    },
-    "Preferences...": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "偏好设置…" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "環境設定…" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "환경설정…" } }
-      }
-    },
-    "About Capso": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "关于 Capso" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "Capso について" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "Capso 정보" } }
-      }
-    },
-    "Quit Capso": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "退出 Capso" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "Capso を終了" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "Capso 종료" } }
-      }
-    },
-    "GIF": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "GIF" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "GIF" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "GIF" } }
-      }
-    },
-    "Record GIF": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "录制 GIF" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "GIF を録画" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "GIF 녹화" } }
-      }
-    },
-    "Record Video": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "录制视频" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ビデオを録画" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "비디오 녹화" } }
-      }
-    },
-    "Do Not Record Microphone": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "不录制麦克风" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "マイクを録音しない" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "마이크 녹음 안 함" } }
-      }
-    },
-    "Microphone": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "麦克风" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "マイク" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "마이크" } }
-      }
-    },
-    "Mirror": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "镜像" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ミラー" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "미러" } }
-      }
-    },
-    "Camera": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "摄像头" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "カメラ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "카메라" } }
-      }
-    },
-    "None": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "なし" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "없음" } }
-      }
-    },
-    "SHAPE": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "形状" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "シェイプ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "모양" } }
-      }
-    },
-    "SIZE": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "大小" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "サイズ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "크기" } }
-      }
-    },
-    "System Audio": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "系统音频" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "システムオーディオ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "시스템 오디오" } }
-      }
-    },
-    "Circle": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "圆形" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "円" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "원형" } }
-      }
-    },
-    "Square": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "方形" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "正方形" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "사각형" } }
-      }
-    },
-    "Landscape (16:9)": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "横向 (16:9)" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "横向き (16:9)" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "가로 (16:9)" } }
-      }
-    },
-    "Portrait (9:16)": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "纵向 (9:16)" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "縦向き (9:16)" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "세로 (9:16)" } }
-      }
-    },
-    "Small": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "小" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "小" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "작게" } }
-      }
-    },
-    "Medium": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "中" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "中" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "보통" } }
-      }
-    },
-    "Large": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "大" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "大" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "크게" } }
-      }
-    },
-    "Shape": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "形状" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "シェイプ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "모양" } }
-      }
-    },
-    "Size": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "大小" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "サイズ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "크기" } }
-      }
-    },
-    "Stop recording": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "停止录制" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "録画を停止" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "녹화 중지" } }
-      }
-    },
-    "Resume recording": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "继续录制" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "録画を再開" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "녹화 재개" } }
-      }
-    },
-    "Pause recording": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "暂停录制" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "録画を一時停止" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "녹화 일시정지" } }
-      }
-    },
-    "Restart recording": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "重新录制" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "録画をやり直す" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "녹화 다시 시작" } }
-      }
-    },
-    "Delete recording": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "删除录制" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "録画を削除" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "녹화 삭제" } }
-      }
-    },
-    "Delete this recording?": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "删除这段录制？" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "この録画を削除しますか？" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "이 녹화를 삭제하시겠습니까?" } }
-      }
-    },
-    "The current recording will be permanently discarded.": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "当前录制将被永久删除。" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "現在の録画は完全に破棄されます。" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "현재 녹화가 영구적으로 삭제됩니다." } }
-      }
-    },
-    "Delete": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "删除" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "削除" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "삭제" } }
-      }
-    },
-    "Cancel": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "取消" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "キャンセル" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "취소" } }
-      }
-    },
-    "Couldn't save recording": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "无法保存录制" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "録画を保存できませんでした" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "녹화를 저장할 수 없습니다" } }
-      }
-    },
-    "OK": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "好" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "OK" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "확인" } }
-      }
-    },
-    "video": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "视频" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ビデオ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "비디오" } }
-      }
-    },
-    "Copy": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "复制" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "コピー" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "복사" } }
-      }
-    },
-    "Save": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "保存" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "保存" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "저장" } }
-      }
-    },
-    "Arrow": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "箭头" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "矢印" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "화살표" } }
-      }
-    },
-    "Rectangle": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "矩形" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "四角形" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "사각형" } }
-      }
-    },
-    "Ellipse": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "椭圆" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "楕円" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "타원" } }
-      }
-    },
-    "Text": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "文字" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "テキスト" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "텍스트" } }
-      }
-    },
-    "Draw": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "画笔" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "描画" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "그리기" } }
-      }
-    },
-    "Pixelate / Blur": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "像素化/模糊" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "モザイク/ぼかし" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "픽셀화/블러" } }
-      }
-    },
-    "Counter": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "序号" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "カウンター" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "카운터" } }
-      }
-    },
-    "Highlighter": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "荧光笔" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ハイライター" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "형광펜" } }
-      }
-    },
-    "Fill Shape": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "填充形状" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "塗りつぶし" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "도형 채우기" } }
-      }
-    },
-    "Beautify": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "美化" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "美化" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "꾸미기" } }
-      }
-    },
-    "Enter Text": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "输入文字" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "テキストを入力" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "텍스트 입력" } }
-      }
-    },
-    "Enable background": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "启用背景" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "背景を有効にする" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "배경 사용" } }
-      }
-    },
-    "Style": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "样式" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "スタイル" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "스타일" } }
-      }
-    },
-    "Background": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "背景" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "背景" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "배경" } }
-      }
-    },
-    "Padding": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "内边距" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "パディング" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "여백" } }
-      }
-    },
-    "Corners": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "圆角" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "角丸" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "모서리" } }
-      }
-    },
-    "Shadow": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "阴影" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "シャドウ" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "그림자" } }
-      }
-    },
-    "Solid": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "纯色" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ソリッド" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "단색" } }
-      }
-    },
-    "Liquid Glass": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "液态玻璃" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "リキッドグラス" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "리퀴드 글라스" } }
-      }
-    },
-    "Fit": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "适应" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "フィット" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "맞춤" } }
-      }
-    },
-    "Annotate": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "标注" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "注釈" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "주석" } }
-      }
-    },
-    "Pin": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "固定" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "ピン留め" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "고정" } }
-      }
-    },
-    "How to use Text Recognition": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "如何使用文字识别" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "テキスト認識の使い方" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "텍스트 인식 사용 방법" } }
-      }
-    },
-    "Copy non-selectable text from images, videos, and webpages": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "从图片、视频和网页中复制不可选中的文字" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "画像、ビデオ、ウェブページから選択できないテキストをコピー" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "이미지, 비디오, 웹페이지에서 선택할 수 없는 텍스트 복사" } }
-      }
-    },
-    "Select Area": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "选择区域" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "エリアを選択" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "영역 선택" } }
-      }
-    },
-    "Drag crosshair to select the region containing text": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "拖动十字准线选择包含文字的区域" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "十字カーソルをドラッグしてテキストを含む領域を選択" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "십자선을 드래그하여 텍스트가 포함된 영역 선택" } }
-      }
-    },
-    "Scan & Recognize": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "扫描与识别" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "スキャン＆認識" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "스캔 및 인식" } }
-      }
-    },
-    "Text is automatically detected and recognized": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "文字被自动检测和识别" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "テキストは自動的に検出・認識されます" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "텍스트가 자동으로 감지 및 인식됩니다" } }
-      }
-    },
-    "Auto-Copy": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "自动复制" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "自動コピー" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "자동 복사" } }
-      }
-    },
-    "Recognized text is instantly copied to your clipboard": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "识别的文字将即时复制到剪贴板" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "認識されたテキストは即座にクリップボードにコピーされます" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "인식된 텍스트가 클립보드에 즉시 복사됩니다" } }
-      }
-    },
-    "Got it!": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "知道了！" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "わかりました！" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "알겠습니다!" } }
-      }
-    },
-    "Copied 247 chars": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已复制 247 个字符" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "247文字をコピーしました" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "247자 복사됨" } }
-      }
-    },
-    "Recognized Text": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "识别结果" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "認識テキスト" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "인식된 텍스트" } }
-      }
-    },
-    "Select All": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "全选" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "すべて選択" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "모두 선택" } }
-      }
-    },
-    "Copy All": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "全部复制" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "すべてコピー" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "모두 복사" } }
-      }
-    },
-    "COPIED ✓": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已复制 ✓" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "コピー済み ✓" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "복사됨 ✓" } }
-      }
-    },
-    "5s": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "5 秒" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "5秒" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "5초" } }
-      }
-    },
-    "10s": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "10 秒" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "10秒" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "10초" } }
-      }
-    },
-    "15s": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "15 秒" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "15秒" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "15초" } }
-      }
-    },
-    "30s": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "30 秒" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "30秒" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "30초" } }
-      }
-    },
-    "PNG": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "PNG" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "PNG" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "PNG" } }
-      }
-    },
-    "JPEG": {
-      "localizations": {
-        "zh-Hans": { "stringUnit": { "state": "translated", "value": "JPEG" } },
-        "ja": { "stringUnit": { "state": "translated", "value": "JPEG" } },
-        "ko": { "stringUnit": { "state": "translated", "value": "JPEG" } }
+  "sourceLanguage" : "en",
+  "strings" : {
+    "" : {
+
+    },
+    "%@" : {
+      "comment" : "A label displaying a numeric value.",
+      "isCommentAutoGenerated" : true
+    },
+    "%@ regions · %@ chars" : {
+      "comment" : "A footer displaying the number of recognized text regions and the total number of characters in those regions.",
+      "isCommentAutoGenerated" : true,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ regions · %2$@ chars"
+          }
+        }
+      }
+    },
+    "%@%%" : {
+      "comment" : "A label showing the current zoom scale as a percentage.",
+      "isCommentAutoGenerated" : true
+    },
+    "↘ Bottom Right" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "↘ 右下"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "↘ 오른쪽 아래"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "↘ 右下角"
+          }
+        }
+      }
+    },
+    "↙ Bottom Left" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "↙ 左下"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "↙ 왼쪽 아래"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "↙ 左下角"
+          }
+        }
+      }
+    },
+    "×" : {
+      "comment" : "A cross mark.",
+      "isCommentAutoGenerated" : true
+    },
+    "3-second countdown before recording" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録画前に3秒のカウントダウン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "녹화 전 3초 카운트다운"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "录屏前 3 秒倒计时"
+          }
+        }
+      }
+    },
+    "5s" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5秒"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5초"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5 秒"
+          }
+        }
+      }
+    },
+    "10s" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10秒"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10초"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10 秒"
+          }
+        }
+      }
+    },
+    "15s" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "15秒"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "15초"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "15 秒"
+          }
+        }
+      }
+    },
+    "30s" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30秒"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30초"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 秒"
+          }
+        }
+      }
+    },
+    "About" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "情報"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정보"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关于"
+          }
+        }
+      }
+    },
+    "About Capso" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capso について"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capso 정보"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关于 Capso"
+          }
+        }
+      }
+    },
+    "Annotate" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "注釈"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주석"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "标注"
+          }
+        }
+      }
+    },
+    "Applies to video and GIF exports" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ビデオとGIFの書き出しに適用"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비디오 및 GIF 내보내기에 적용"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "适用于视频和 GIF 导出"
+          }
+        }
+      }
+    },
+    "Arrow" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "矢印"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "화살표"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "箭头"
+          }
+        }
+      }
+    },
+    "Auto Copy to Clipboard" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリップボードに自動コピー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클립보드에 자동 복사"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动复制到剪贴板"
+          }
+        }
+      }
+    },
+    "Auto-Close" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動閉じる"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 닫기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动关闭"
+          }
+        }
+      }
+    },
+    "Auto-Close Preview" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プレビューを自動閉じる"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리보기 자동 닫기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动关闭预览"
+          }
+        }
+      }
+    },
+    "Auto-Copy" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動コピー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 복사"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动复制"
+          }
+        }
+      }
+    },
+    "Auto-detect and linkify URLs" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URLを自動検出してリンク化"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL 자동 감지 및 링크화"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动检测并转换 URL 链接"
+          }
+        }
+      }
+    },
+    "Background" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "背景"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "배경"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "背景"
+          }
+        }
+      }
+    },
+    "Beautify" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "美化"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "꾸미기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "美化"
+          }
+        }
+      }
+    },
+    "Behavior" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "動作"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "동작"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行为"
+          }
+        }
+      }
+    },
+    "Camera" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カメラ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카메라"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "摄像头"
+          }
+        }
+      }
+    },
+    "Cancel" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "취소"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        }
+      }
+    },
+    "Capture" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャプチャ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캡처"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截取"
+          }
+        }
+      }
+    },
+    "Capture Area" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エリアをキャプチャ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "영역 캡처"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截取区域"
+          }
+        }
+      }
+    },
+    "Capture Fullscreen" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フルスクリーンをキャプチャ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 화면 캡처"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截取全屏"
+          }
+        }
+      }
+    },
+    "Capture Text (OCR)" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストをキャプチャ (OCR)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트 캡처 (OCR)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截取文字 (OCR)"
+          }
+        }
+      }
+    },
+    "Capture Window" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウインドウをキャプチャ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "윈도우 캡처"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截取窗口"
+          }
+        }
+      }
+    },
+    "Capture Window Shadow" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウインドウシャドウをキャプチャ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "윈도우 그림자 캡처"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "捕捉窗口阴影"
+          }
+        }
+      }
+    },
+    "Choose…" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择…"
+          }
+        }
+      }
+    },
+    "Circle" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "円"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "원형"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圆形"
+          }
+        }
+      }
+    },
+    "Click a shortcut to record a new combination. Press **Esc** to cancel or **Delete** to remove." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ショートカットをクリックして新しい組み合わせを記録します。**Esc** でキャンセル、**Delete** で削除。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "단축키를 클릭하여 새 조합을 녹화하세요. **Esc**로 취소, **Delete**로 삭제합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击快捷键以录制新的组合。按 **Esc** 取消或按 **Delete** 删除。"
+          }
+        }
+      }
+    },
+    "Close After" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "閉じるまでの時間"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "닫기 시간"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭时间"
+          }
+        }
+      }
+    },
+    "COPIED ✓" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コピー済み ✓"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "복사됨 ✓"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已复制 ✓"
+          }
+        }
+      }
+    },
+    "Copied 247 chars" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "247文字をコピーしました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "247자 복사됨"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已复制 247 个字符"
+          }
+        }
+      }
+    },
+    "Copy" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コピー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "복사"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制"
+          }
+        }
+      }
+    },
+    "Copy All" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてコピー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모두 복사"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部复制"
+          }
+        }
+      }
+    },
+    "Copy non-selectable text from images, videos, and webpages" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画像、ビデオ、ウェブページから選択できないテキストをコピー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이미지, 비디오, 웹페이지에서 선택할 수 없는 텍스트 복사"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从图片、视频和网页中复制不可选中的文字"
+          }
+        }
+      }
+    },
+    "Copy screenshot immediately after capture" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャプチャ後すぐにクリップボードにコピー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캡처 직후 클립보드에 복사"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截图后立即复制到剪贴板"
+          }
+        }
+      }
+    },
+    "Corners" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "角丸"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모서리"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "圆角"
+          }
+        }
+      }
+    },
+    "Couldn't save recording" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録画を保存できませんでした"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "녹화를 저장할 수 없습니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法保存录制"
+          }
+        }
+      }
+    },
+    "Counter" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カウンター"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카운터"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "序号"
+          }
+        }
+      }
+    },
+    "Cursor" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カーソル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커서"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "光标"
+          }
+        }
+      }
+    },
+    "Delete" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "삭제"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除"
+          }
+        }
+      }
+    },
+    "Delete recording" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録画を削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "녹화 삭제"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除录制"
+          }
+        }
+      }
+    },
+    "Delete this recording?" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この録画を削除しますか？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 녹화를 삭제하시겠습니까?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除这段录制？"
+          }
+        }
+      }
+    },
+    "Detect Links" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リンクを検出"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "링크 감지"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检测链接"
+          }
+        }
+      }
+    },
+    "Dismiss after timeout" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "タイムアウト後に閉じる"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시간 초과 후 닫기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "超时后自动关闭"
+          }
+        }
+      }
+    },
+    "Do Not Record Microphone" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マイクを録音しない"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마이크 녹음 안 함"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "不录制麦克风"
+          }
+        }
+      }
+    },
+    "Drag crosshair to select the region containing text" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "十字カーソルをドラッグしてテキストを含む領域を選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "십자선을 드래그하여 텍스트가 포함된 영역 선택"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拖动十字准线选择包含文字的区域"
+          }
+        }
+      }
+    },
+    "Draw" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "描画"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "그리기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画笔"
+          }
+        }
+      }
+    },
+    "Ellipse" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "楕円"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "타원"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "椭圆"
+          }
+        }
+      }
+    },
+    "Enable background" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "背景を有効にする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "배경 사용"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用背景"
+          }
+        }
+      }
+    },
+    "Enter Text" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストを入力"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트 입력"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "输入文字"
+          }
+        }
+      }
+    },
+    "Export" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書き出し"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "내보내기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出"
+          }
+        }
+      }
+    },
+    "Export Quality" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書き出し品質"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "내보내기 품질"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出品质"
+          }
+        }
+      }
+    },
+    "Export To" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "書き出し先"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "내보내기 위치"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导出到"
+          }
+        }
+      }
+    },
+    "Feedback" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フィードバック"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "피드백"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "反馈"
+          }
+        }
+      }
+    },
+    "Fill Shape" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "塗りつぶし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도형 채우기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "填充形状"
+          }
+        }
+      }
+    },
+    "Fit" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フィット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "맞춤"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "适应"
+          }
+        }
+      }
+    },
+    "Format" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フォーマット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "포맷"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "格式"
+          }
+        }
+      }
+    },
+    "General" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一般"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "일반"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通用"
+          }
+        }
+      }
+    },
+    "GIF" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF"
+          }
+        }
+      }
+    },
+    "Got it!" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "わかりました！"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알겠습니다!"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "知道了！"
+          }
+        }
+      }
+    },
+    "Highlight Clicks" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリックをハイライト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클릭 강조"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高亮点击"
+          }
+        }
+      }
+    },
+    "Highlighter" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ハイライター"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "형광펜"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "荧光笔"
+          }
+        }
+      }
+    },
+    "How to use Text Recognition" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキスト認識の使い方"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트 인식 사용 방법"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "如何使用文字识别"
+          }
+        }
+      }
+    },
+    "Include shadow in window captures" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウインドウキャプチャにシャドウを含める"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "윈도우 캡처에 그림자 포함"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "窗口截图时包含阴影"
+          }
+        }
+      }
+    },
+    "JPEG" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JPEG"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JPEG"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JPEG"
+          }
+        }
+      }
+    },
+    "Keep Line Breaks" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "改行を維持"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "줄 바꿈 유지"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留换行"
+          }
+        }
+      }
+    },
+    "Landscape (16:9)" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "横向き (16:9)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가로 (16:9)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "横向 (16:9)"
+          }
+        }
+      }
+    },
+    "Large" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "크게"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大"
+          }
+        }
+      }
+    },
+    "Launch at Login" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ログイン時に起動"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "로그인 시 실행"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登录时启动"
+          }
+        }
+      }
+    },
+    "Liquid Glass" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リキッドグラス"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "리퀴드 글라스"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "液态玻璃"
+          }
+        }
+      }
+    },
+    "Maximum" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最高"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "최고"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最高"
+          }
+        }
+      }
+    },
+    "Medium" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보통"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中"
+          }
+        }
+      }
+    },
+    "Microphone" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マイク"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마이크"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "麦克风"
+          }
+        }
+      }
+    },
+    "Mirror" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ミラー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미러"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "镜像"
+          }
+        }
+      }
+    },
+    "None" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "なし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "없음"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无"
+          }
+        }
+      }
+    },
+    "OCR" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキスト認識"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트 인식"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字识别"
+          }
+        }
+      }
+    },
+    "OK" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확인"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "好"
+          }
+        }
+      }
+    },
+    "Padding" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "パディング"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "여백"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "内边距"
+          }
+        }
+      }
+    },
+    "Pause recording" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録画を一時停止"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "녹화 일시정지"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂停录制"
+          }
+        }
+      }
+    },
+    "Pin" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ピン留め"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "고정"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "固定"
+          }
+        }
+      }
+    },
+    "Pixelate / Blur" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "モザイク/ぼかし"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "픽셀화/블러"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "像素化/模糊"
+          }
+        }
+      }
+    },
+    "Play sound after capture" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャプチャ後にサウンドを再生"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캡처 후 소리 재생"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截图后播放声音"
+          }
+        }
+      }
+    },
+    "PNG" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PNG"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PNG"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PNG"
+          }
+        }
+      }
+    },
+    "Portrait (9:16)" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "縦向き (9:16)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "세로 (9:16)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "纵向 (9:16)"
+          }
+        }
+      }
+    },
+    "Position" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "位置"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "위치"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "位置"
+          }
+        }
+      }
+    },
+    "Preferences..." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "環境設定…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "환경설정…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "偏好设置…"
+          }
+        }
+      }
+    },
+    "Preserve original line structure" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "元の行構造を保持"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "원본 줄 구조 유지"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留原始行结构"
+          }
+        }
+      }
+    },
+    "Preview Position" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プレビュー位置"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리보기 위치"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预览位置"
+          }
+        }
+      }
+    },
+    "Quality" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "品質"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "품질"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "品质"
+          }
+        }
+      }
+    },
+    "Quick Access" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クイックアクセス"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "빠른 접근"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快速访问"
+          }
+        }
+      }
+    },
+    "Quit Capso" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capso を終了"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capso 종료"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "退出 Capso"
+          }
+        }
+      }
+    },
+    "Radial pulse on mouse click" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "マウスクリック時に放射状パルスを表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마우스 클릭 시 방사형 펄스"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鼠标点击时显示脉冲动画"
+          }
+        }
+      }
+    },
+    "Recognized Text" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "認識テキスト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인식된 텍스트"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "识别结果"
+          }
+        }
+      }
+    },
+    "Recognized text is instantly copied to your clipboard" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "認識されたテキストは即座にクリップボードにコピーされます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "인식된 텍스트가 클립보드에 즉시 복사됩니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "识别的文字将即时复制到剪贴板"
+          }
+        }
+      }
+    },
+    "Record GIF" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF を録画"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "GIF 녹화"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "录制 GIF"
+          }
+        }
+      }
+    },
+    "Record Screen" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画面を録画"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "화면 녹화"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "录制屏幕"
+          }
+        }
+      }
+    },
+    "Record Video" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ビデオを録画"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비디오 녹화"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "录制视频"
+          }
+        }
+      }
+    },
+    "Recording" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録画"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "녹화"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "录屏"
+          }
+        }
+      }
+    },
+    "Rectangle" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "四角形"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사각형"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "矩形"
+          }
+        }
+      }
+    },
+    "Restart recording" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録画をやり直す"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "녹화 다시 시작"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新录制"
+          }
+        }
+      }
+    },
+    "Resume recording" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録画を再開"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "녹화 재개"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "继续录制"
+          }
+        }
+      }
+    },
+    "Save" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저장"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
+          }
+        }
+      }
+    },
+    "Save Location" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存場所"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "저장 위치"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存位置"
+          }
+        }
+      }
+    },
+    "Saving… %@%%" : {
+      "comment" : "A label that says \"Saving\" and the",
+      "isCommentAutoGenerated" : true
+    },
+    "Scan & Recognize" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スキャン＆認識"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스캔 및 인식"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "扫描与识别"
+          }
+        }
+      }
+    },
+    "Screenshot Format" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクリーンショット形式"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스크린샷 형식"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截图格式"
+          }
+        }
+      }
+    },
+    "Screenshots" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクリーンショット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스크린샷"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截图"
+          }
+        }
+      }
+    },
+    "Select" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择"
+          }
+        }
+      }
+    },
+    "Select All" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべて選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모두 선택"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全选"
+          }
+        }
+      }
+    },
+    "Select Area" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エリアを選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "영역 선택"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择区域"
+          }
+        }
+      }
+    },
+    "Shadow" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シャドウ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "그림자"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阴影"
+          }
+        }
+      }
+    },
+    "Shape" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シェイプ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모양"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "形状"
+          }
+        }
+      }
+    },
+    "SHAPE" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シェイプ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모양"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "形状"
+          }
+        }
+      }
+    },
+    "Shortcuts" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ショートカット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "단축키"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快捷键"
+          }
+        }
+      }
+    },
+    "Show Countdown" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カウントダウンを表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카운트다운 표시"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示倒计时"
+          }
+        }
+      }
+    },
+    "Show Cursor" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カーソルを表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커서 표시"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示光标"
+          }
+        }
+      }
+    },
+    "Shutter Sound" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "シャッター音"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "셔터 소리"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快门音效"
+          }
+        }
+      }
+    },
+    "Size" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サイズ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "크기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大小"
+          }
+        }
+      }
+    },
+    "SIZE" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サイズ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "크기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大小"
+          }
+        }
+      }
+    },
+    "Small" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작게"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小"
+          }
+        }
+      }
+    },
+    "Social" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソーシャル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "소셜"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "社交"
+          }
+        }
+      }
+    },
+    "Solid" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソリッド"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "단색"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "纯色"
+          }
+        }
+      }
+    },
+    "Square" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正方形"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사각형"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "方形"
+          }
+        }
+      }
+    },
+    "Start / Stop Recording" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録画を開始/停止"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "녹화 시작/중지"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开始/停止录屏"
+          }
+        }
+      }
+    },
+    "Start Capso when you log in" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac にログインしたときに Capso を自動起動"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac에 로그인할 때 Capso 자동 실행"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登录 Mac 时自动启动 Capso"
+          }
+        }
+      }
+    },
+    "Startup" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "起動"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시작"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启动"
+          }
+        }
+      }
+    },
+    "STEP %@" : {
+      "comment" : "A label that shows the step number. The argument is the step number.",
+      "isCommentAutoGenerated" : true
+    },
+    "Stop recording" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録画を停止"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "녹화 중지"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停止录制"
+          }
+        }
+      }
+    },
+    "Style" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スタイル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스타일"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "样式"
+          }
+        }
+      }
+    },
+    "System Audio" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "システムオーディオ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시스템 오디오"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统音频"
+          }
+        }
+      }
+    },
+    "Text" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキスト"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字"
+          }
+        }
+      }
+    },
+    "Text is automatically detected and recognized" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストは自動的に検出・認識されます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트가 자동으로 감지 및 인식됩니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字被自动检测和识别"
+          }
+        }
+      }
+    },
+    "Text Recognition" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキスト認識"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트 인식"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字识别"
+          }
+        }
+      }
+    },
+    "The current recording will be permanently discarded." : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在の録画は完全に破棄されます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 녹화가 영구적으로 삭제됩니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前录制将被永久删除。"
+          }
+        }
+      }
+    },
+    "Version" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バージョン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버전"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "版本"
+          }
+        }
+      }
+    },
+    "video" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ビデオ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "비디오"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "视频"
+          }
+        }
+      }
+    },
+    "Web" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ウェブ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "웹"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "网页"
+          }
+        }
+      }
+    },
+    "Where the floating preview appears" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "フローティングプレビューの表示位置"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "플로팅 미리보기 표시 위치"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浮动预览窗口的显示位置"
+          }
+        }
       }
     }
-  }
+  },
+  "version" : "1.1"
 }


### PR DESCRIPTION
## Summary
- Xcode expanded compact JSON String Catalogs into standard multi-line format
- No translation content changed — all existing zh-Hans, ja, ko values preserved
- One new English string auto-detected by Xcode (`%1$@ regions · %2$@ chars`)