### PR TITLE
fix: annotation editor disappearing when clicking other windows

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
@@ -40,6 +40,9 @@ final class AnnotationEditorWindow: NSPanel {
         self.isReleasedWhenClosed = false
         // Use .normal level so the window stays visible when app loses focus
         self.level = .normal
+        // Keep the panel visible when the app loses focus — without this,
+        // clicking another app's window hides the annotation editor.
+        self.hidesOnDeactivate = false
         // Ensure tooltip tracking and key-window behaviour work correctly.
         self.becomesKeyOnlyIfNeeded = false
         self.acceptsMouseMovedEvents = true


### PR DESCRIPTION
## Summary
- NSPanel's `hidesOnDeactivate` defaults to `true`, causing the annotation editor to disappear when clicking another app's window
- Set `hidesOnDeactivate = false` to keep the editor visible regardless of app focus

Relates to #12 — may also fix the reported pixelate/blur tool crash if it was caused by a focus-related panel hide

## Test plan
- [x] Open annotation editor, click another app's window, verify editor stays visible
- [x] Switch back to editor, verify all tools still work correctly