### PR TITLE
fix: retry stapling notarization ticket on CDN delay

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -145,7 +145,16 @@ jobs:
         run: |
           set -euo pipefail
           APP="build/export/${APP_NAME}.app"
-          xcrun stapler staple "$APP"
+          # Apple's CDN may take a moment to distribute the ticket after
+          # notarization completes. Retry stapling up to 5 times with a
+          # 15-second delay between attempts.
+          for i in 1 2 3 4 5; do
+            if xcrun stapler staple "$APP"; then
+              break
+            fi
+            echo "Staple attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
           xcrun stapler validate "$APP"
           spctl -a -t exec -vv "$APP" || true
 


### PR DESCRIPTION
## Summary
- Apple's CDN sometimes hasn't distributed the notarization ticket by the time `stapler staple` runs
- Add retry loop: up to 5 attempts with 15s delay between each
- Fixes the v0.1.6 build failure at "Staple notarization ticket" step