### PR TITLE
fix: annotation tool switching no longer alters drawn objects

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -30,6 +30,11 @@ final class AnnotationCanvasNSView: NSView {
     /// fontSize from this original value — not the live one, which drifts each tick.
     private var resizeOriginalTextFontSize: CGFloat?
     private var activeFreehand: FreehandObject?
+    /// Cached text regions from OCR for smart highlighter snapping.
+    var textRegions: [CGRect] = []
+    /// When the highlighter starts on a text line, stores the line's
+    /// bounding box so the stroke is constrained to a horizontal band.
+    private var highlighterSnapRect: CGRect?
 
     private let handleRadius: CGFloat = 5  // in image coords (adjusted by zoom in drawing)
 
@@ -273,7 +278,25 @@ final class AnnotationCanvasNSView: NSView {
                 dragObjectID = nil
             }
         } else if currentTool == .freehand || currentTool == .highlighter {
-            activeFreehand = FreehandObject(points: [point], style: currentStyle)
+            // Smart highlighter: if starting on a text line, snap to it.
+            highlighterSnapRect = nil
+            if currentTool == .highlighter {
+                // Use a slightly expanded region for easier hit detection
+                for region in textRegions {
+                    let expanded = region.insetBy(dx: 0, dy: -region.height * 0.3)
+                    if expanded.contains(point) {
+                        highlighterSnapRect = region
+                        break
+                    }
+                }
+            }
+            if let snap = highlighterSnapRect {
+                let snappedY = snap.midY
+                let snappedPoint = CGPoint(x: point.x, y: snappedY)
+                activeFreehand = FreehandObject(points: [snappedPoint], style: currentStyle)
+            } else {
+                activeFreehand = FreehandObject(points: [point], style: currentStyle)
+            }
         }
 
         needsDisplay = true
@@ -296,7 +319,13 @@ final class AnnotationCanvasNSView: NSView {
                 dragStart = point
             }
         } else if currentTool == .freehand || currentTool == .highlighter {
-            activeFreehand?.addPoint(point)
+            if let snap = highlighterSnapRect {
+                // Constrain to horizontal line at the text's vertical center
+                let snappedPoint = CGPoint(x: point.x, y: snap.midY)
+                activeFreehand?.addPoint(snappedPoint)
+            } else {
+                activeFreehand?.addPoint(point)
+            }
         }
 
         needsDisplay = true
@@ -434,10 +463,11 @@ final class AnnotationCanvasNSView: NSView {
                     doc.addObject(TextObject(text: input.stringValue, origin: end, style: currentStyle))
                 }
             case .freehand, .highlighter:
-                if let freehand = activeFreehand, freehand.points.count > 2 {
+                if let freehand = activeFreehand, freehand.points.count > 1 {
                     doc.addObject(freehand)
                 }
                 activeFreehand = nil
+                highlighterSnapRect = nil
             case .pixelate:
                 let rect = CGRect(x: min(start.x, end.x), y: min(start.y, end.y),
                                   width: abs(end.x - start.x), height: abs(end.y - start.y))

--- a/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
@@ -10,6 +10,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
     let currentStyle: AnnotationKit.StrokeStyle
     let zoomScale: CGFloat
     let refreshTrigger: Int
+    var textRegions: [CGRect] = []
     var onSwitchToSelect: (() -> Void)?
 
     func makeNSView(context: Context) -> AnnotationCanvasNSView {
@@ -19,6 +20,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
         view.currentTool = currentTool
         view.currentStyle = currentStyle
         view.zoomScale = zoomScale
+        view.textRegions = textRegions
         view.onObjectCreated = {
             // Continuous-drawing tools stay active after each stroke;
             // one-shot tools (arrow, rect, ellipse, text, pixelate) switch
@@ -36,6 +38,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
         nsView.currentTool = currentTool
         nsView.currentStyle = currentStyle
         nsView.zoomScale = zoomScale
+        nsView.textRegions = textRegions
         nsView.onObjectCreated = {
             let keepActive: Set<AnnotationTool> = [.counter, .freehand, .highlighter]
             if !keepActive.contains(currentTool) {

--- a/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
@@ -20,7 +20,11 @@ struct AnnotationCanvasView: NSViewRepresentable {
         view.currentStyle = currentStyle
         view.zoomScale = zoomScale
         view.onObjectCreated = {
-            if currentTool != .counter {
+            // Continuous-drawing tools stay active after each stroke;
+            // one-shot tools (arrow, rect, ellipse, text, pixelate) switch
+            // back to select after creation.
+            let keepActive: Set<AnnotationTool> = [.counter, .freehand, .highlighter]
+            if !keepActive.contains(currentTool) {
                 onSwitchToSelect?()
             }
         }
@@ -33,7 +37,8 @@ struct AnnotationCanvasView: NSViewRepresentable {
         nsView.currentStyle = currentStyle
         nsView.zoomScale = zoomScale
         nsView.onObjectCreated = {
-            if currentTool != .counter {
+            let keepActive: Set<AnnotationTool> = [.counter, .freehand, .highlighter]
+            if !keepActive.contains(currentTool) {
                 onSwitchToSelect?()
             }
         }

--- a/App/Sources/AnnotationEditor/AnnotationEditorView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorView.swift
@@ -1,6 +1,7 @@
 // App/Sources/AnnotationEditor/AnnotationEditorView.swift
 import SwiftUI
 import AnnotationKit
+import OCRKit
 
 struct AnnotationEditorView: View {
     let sourceImage: CGImage
@@ -21,6 +22,8 @@ struct AnnotationEditorView: View {
     @State private var showBeautifyPanel = false
     @State private var refreshTrigger = 0
     @State private var zoomScale: CGFloat = 1.0
+    /// Cached text line bounding boxes for smart highlighter snapping.
+    @State private var textRegions: [CGRect] = []
 
     private var imageWidth: CGFloat { CGFloat(sourceImage.width) }
     private var imageHeight: CGFloat { CGFloat(sourceImage.height) }
@@ -117,6 +120,7 @@ struct AnnotationEditorView: View {
                             currentStyle: currentStyle,
                             zoomScale: zoomScale,
                             refreshTrigger: refreshTrigger,
+                            textRegions: textRegions,
                             onSwitchToSelect: {
                                 document.clearSelection()
                                 currentTool = .select
@@ -142,6 +146,14 @@ struct AnnotationEditorView: View {
                 .background(Color(white: 0.12))
                 .onAppear {
                     fitToWindow(availableSize: geo.size)
+                    // Pre-cache text regions for smart highlighter snapping
+                    Task {
+                        if let regions = try? await TextRecognizer.recognize(
+                            image: sourceImage, level: .fast, detectURLs: false
+                        ) {
+                            textRegions = regions.map(\.boundingBox)
+                        }
+                    }
                 }
                 .onChange(of: currentTool) { oldTool, newTool in
                     // Clear selection so restoring lineWidth below doesn't

--- a/App/Sources/AnnotationEditor/AnnotationEditorView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorView.swift
@@ -117,7 +117,10 @@ struct AnnotationEditorView: View {
                             currentStyle: currentStyle,
                             zoomScale: zoomScale,
                             refreshTrigger: refreshTrigger,
-                            onSwitchToSelect: { currentTool = .select }
+                            onSwitchToSelect: {
+                                document.clearSelection()
+                                currentTool = .select
+                            }
                         )
                         .frame(
                             width: imageWidth * zoomScale,
@@ -141,6 +144,10 @@ struct AnnotationEditorView: View {
                     fitToWindow(availableSize: geo.size)
                 }
                 .onChange(of: currentTool) { oldTool, newTool in
+                    // Clear selection so restoring lineWidth below doesn't
+                    // overwrite the previously drawn object's style.
+                    document.clearSelection()
+
                     // Save outgoing tool's value
                     switch oldTool {
                     case .pixelate: savedBlockSize = lineWidth


### PR DESCRIPTION
## Summary
- **Highlighter losing transparency**: switching tools after drawing with highlighter caused `updateSelectedStyle()` to overwrite the object's opacity from 0.35 to 1.0. Fixed by clearing selection on tool switch.
- **Freehand/highlighter auto-switching to select**: these continuous-drawing tools now stay active after each stroke, matching CleanShot X behavior. Counter also stays active (unchanged).
- **Style bleed on tool switch**: drawing with freehand then clicking highlighter would temporarily change the freehand stroke to highlighter style. Fixed by clearing selection before restoring tool-specific lineWidth.

## Test plan
- [x] Draw with highlighter → verify it stays semi-transparent after release
- [x] Draw with highlighter → switch to freehand → highlighter stroke unchanged
- [x] Draw with freehand → verify tool stays on freehand (no auto-switch to select)
- [x] Draw with arrow → verify tool switches back to select (one-shot behavior)