### PR TITLE
feat: add Scrolling Capture (long screenshot) support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ CLAUDE.md
 
 # Local-only scripts (not shipped with the open-source repo)
 scripts/
+.omx/

--- a/App/Entitlements/Capso.entitlements
+++ b/App/Entitlements/Capso.entitlements
@@ -6,7 +6,5 @@
 	<true/>
 	<key>com.apple.security.device.camera</key>
 	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
 </dict>
 </plist>

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -206,6 +206,72 @@
         }
       }
     },
+    "After Capture" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャプチャ後"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캡처 후"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截图后"
+          }
+        }
+      }
+    },
+    "Auto Save" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動保存"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "자동 저장"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动保存"
+          }
+        }
+      }
+    },
+    "Automatically checks daily" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "毎日自動チェック"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "매일 자동 확인"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每天自动检查"
+          }
+        }
+      }
+    },
     "About Capso" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -506,7 +572,6 @@
       }
     },
     "Cancel" : {
-      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {
@@ -639,6 +704,72 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "截取窗口"
+          }
+        }
+      }
+    },
+    "Check for Updates" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデートを確認"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "업데이트 확인"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检查更新"
+          }
+        }
+      }
+    },
+    "Copy screenshot immediately" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャプチャ後すぐにコピー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캡처 후 즉시 복사"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截图后立即复制"
+          }
+        }
+      }
+    },
+    "Copy to Clipboard" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリップボードにコピー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클립보드에 복사"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制到剪贴板"
           }
         }
       }
@@ -1117,6 +1248,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "不录制麦克风"
+          }
+        }
+      }
+    },
+    "Display thumbnail with quick actions" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "サムネイルとクイックアクションを表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "빠른 작업이 포함된 미리보기 표시"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示缩略图和快捷操作"
+          }
+        }
+      }
+    },
+    "Done" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完了"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "완료"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
           }
         }
       }
@@ -2394,6 +2569,50 @@
         }
       }
     },
+    "Save to file automatically" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自動的にファイルに保存"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "파일로 자동 저장"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动保存到文件"
+          }
+        }
+      }
+    },
+    "Show Preview" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プレビューを表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "미리보기 표시"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示预览"
+          }
+        }
+      }
+    },
     "Save" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2508,6 +2727,116 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "截图"
+          }
+        }
+      }
+    },
+    "Click Start, then scroll" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スタートを押してスクロール"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "시작을 누르고 스크롤하세요"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击开始，然后滚动页面"
+          }
+        }
+      }
+    },
+    "Scroll slowly to capture" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ゆっくりスクロールしてキャプチャ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "천천히 스크롤하여 캡처"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缓慢滚动以捕获内容"
+          }
+        }
+      }
+    },
+    "Scroll to start" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクロールして開始"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스크롤하여 시작"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "滚动以开始"
+          }
+        }
+      }
+    },
+    "Scrolling Capture" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクロールキャプチャ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스크롤 캡처"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "滚动截图"
+          }
+        }
+      }
+    },
+    "Screenshot History" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクリーンショット履歴"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스크린샷 기록"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截图历史"
           }
         }
       }
@@ -2875,6 +3204,28 @@
         }
       }
     },
+    "Start Capture" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャプチャ開始"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캡처 시작"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开始截图"
+          }
+        }
+      }
+    },
     "Start / Stop Recording" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -3105,6 +3456,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "当前录制将被永久删除。"
+          }
+        }
+      }
+    },
+    "Updates" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "업데이트"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新"
           }
         }
       }

--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -69,6 +69,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         KeyboardShortcuts.onKeyDown(for: .recordScreen) { [weak self] in
             self?.recordingCoordinator?.startRecordingFlow()
         }
+        KeyboardShortcuts.onKeyDown(for: .captureScrolling) { [weak self] in
+            self?.captureCoordinator?.captureScrolling()
+        }
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -23,6 +23,8 @@ final class CaptureCoordinator {
     private let maxQuickAccessStackSize = 5
     private var annotationWindow: AnnotationEditorWindow?
     private var pinnedControllers: [PinnedScreenshotController] = []
+    private var scrollCaptureController: ScrollCaptureController?
+    private var scrollCaptureOverlay: ScrollCaptureOverlay?
 
     var lastCaptureResult: CaptureResult?
     var ocrCoordinator: OCRCoordinator?
@@ -60,6 +62,13 @@ final class CaptureCoordinator {
         }
     }
 
+    func captureScrolling() {
+        // Use area selection overlay, then start scrolling capture on the selected region
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+            self?.showOverlay(mode: .area, isScrollingCapture: true)
+        }
+    }
+
     func captureWindow() {
         // Enumerate windows first, then show overlay in window selection mode
         Task {
@@ -82,13 +91,17 @@ final class CaptureCoordinator {
         }
     }
 
-    private func showOverlay(mode: CaptureOverlayMode = .area) {
+    private func showOverlay(mode: CaptureOverlayMode = .area, isScrollingCapture: Bool = false) {
         dismissOverlay()
         for screen in NSScreen.screens {
             let overlay = CaptureOverlayWindow(screen: screen)
             overlay.onAreaSelected = { [weak self] rect, screen in
                 self?.dismissOverlay()
-                self?.performAreaCapture(rect: rect, screen: screen)
+                if isScrollingCapture {
+                    self?.startScrollingCapture(rect: rect, screen: screen)
+                } else {
+                    self?.performAreaCapture(rect: rect, screen: screen)
+                }
             }
             overlay.onWindowSelected = { [weak self] windowID in
                 self?.dismissOverlay()
@@ -261,6 +274,100 @@ final class CaptureCoordinator {
             window.deactivate()
         }
         overlayWindows.removeAll()
+    }
+
+    // MARK: - Scrolling Capture
+
+    /// Saved capture rect (ScreenCaptureKit coordinates) for deferred start.
+    private var scrollCaptureRect: CGRect = .zero
+    private var scrollCaptureDisplayID: CGDirectDisplayID = 0
+
+    private func startScrollingCapture(rect: CGRect, screen: NSScreen) {
+        let screenFrame = screen.frame
+        // Convert from bottom-left (NSView) to top-left (ScreenCaptureKit) coordinates
+        scrollCaptureRect = CGRect(
+            x: rect.origin.x,
+            y: screenFrame.height - rect.origin.y - rect.height,
+            width: rect.width,
+            height: rect.height
+        )
+        scrollCaptureDisplayID = screen.displayID
+
+        // Show persistent overlay: selection border + controls + preview
+        let overlay = ScrollCaptureOverlay()
+        self.scrollCaptureOverlay = overlay
+
+        overlay.onStart = { [weak self] in
+            self?.beginScrollingCaptureLoop()
+        }
+
+        overlay.onDone = { [weak self] in
+            self?.finishScrollingCapture()
+        }
+
+        overlay.onCancel = { [weak self] in
+            self?.cancelScrollingCapture()
+        }
+
+        overlay.show(selectionRect: rect, screen: screen)
+    }
+
+    /// Called when user clicks Start — begins the capture loop.
+    private func beginScrollingCaptureLoop() {
+        let captureRect = scrollCaptureRect
+        let displayID = scrollCaptureDisplayID
+
+        let config = ScrollCaptureConfig(
+            captureRect: captureRect,
+            displayID: displayID,
+            mode: .manual
+        )
+        let controller = ScrollCaptureController(config: config)
+        self.scrollCaptureController = controller
+
+        scrollCaptureOverlay?.setCapturing(true)
+
+        controller.start(
+            onProgress: { [weak self] progress in
+                Task { @MainActor in
+                    if let mergedImage = controller.currentMergedImage {
+                        self?.scrollCaptureOverlay?.updatePreview(
+                            image: mergedImage,
+                            height: progress.currentHeight,
+                            frameCount: progress.frameCount
+                        )
+                    }
+                }
+            },
+            onComplete: { [weak self] image in
+                Task { @MainActor in
+                    self?.scrollCaptureOverlay?.close()
+                    self?.scrollCaptureOverlay = nil
+                    self?.scrollCaptureController = nil
+
+                    if let image {
+                        let result = CaptureResult(
+                            image: image,
+                            mode: .scrolling,
+                            captureRect: captureRect,
+                            displayID: displayID
+                        )
+                        self?.handleCaptureResult(result)
+                    }
+                }
+            }
+        )
+    }
+
+    private func finishScrollingCapture() {
+        scrollCaptureController?.stop()
+    }
+
+    private func cancelScrollingCapture() {
+        scrollCaptureController?.stop()
+        scrollCaptureOverlay?.close()
+        scrollCaptureOverlay = nil
+        scrollCaptureController = nil
     }
 
     private func performAreaCapture(rect: CGRect, screen: NSScreen) {

--- a/App/Sources/Capture/ScrollCaptureHUD.swift
+++ b/App/Sources/Capture/ScrollCaptureHUD.swift
@@ -1,0 +1,342 @@
+// App/Sources/Capture/ScrollCaptureHUD.swift
+import AppKit
+import SwiftUI
+import CaptureKit
+
+/// Persistent overlay shown during scrolling capture.
+/// Shows: selection border, live preview on the left, Cancel/Start/Done at the bottom.
+@MainActor
+final class ScrollCaptureOverlay {
+    private var borderWindow: NSPanel?
+    private var controlsWindow: NSPanel?
+    private var previewWindow: NSPanel?
+    private let viewModel = ScrollCaptureViewModel()
+    private var escMonitor: Any?
+
+    var onStart: (() -> Void)?
+    var onDone: (() -> Void)?
+    var onCancel: (() -> Void)?
+
+    func show(selectionRect: CGRect, screen: NSScreen) {
+        let screenOrigin = screen.frame.origin
+        let screenRect = NSRect(
+            x: screenOrigin.x + selectionRect.origin.x,
+            y: screenOrigin.y + selectionRect.origin.y,
+            width: selectionRect.width,
+            height: selectionRect.height
+        )
+
+        showBorder(screenRect: screenRect)
+        showControls(screenRect: screenRect, screen: screen)
+        showPreview(screenRect: screenRect, screen: screen)
+        installEscHandler()
+    }
+
+    func setCapturing(_ capturing: Bool) {
+        viewModel.isCapturing = capturing
+    }
+
+    func updatePreview(image: CGImage, height: Int, frameCount: Int) {
+        viewModel.previewImage = NSImage(cgImage: image, size: NSSize(width: image.width, height: image.height))
+        viewModel.currentHeight = height
+        viewModel.frameCount = frameCount
+    }
+
+    func close() {
+        if let escMonitor {
+            NSEvent.removeMonitor(escMonitor)
+            self.escMonitor = nil
+        }
+        borderWindow?.orderOut(nil)
+        borderWindow = nil
+        controlsWindow?.orderOut(nil)
+        controlsWindow = nil
+        previewWindow?.orderOut(nil)
+        previewWindow = nil
+    }
+
+    /// CGWindowIDs of all overlay panels, for excluding from capture.
+    var windowIDs: [CGWindowID] {
+        var ids: [CGWindowID] = []
+        if let w = borderWindow { ids.append(CGWindowID(w.windowNumber)) }
+        if let w = controlsWindow { ids.append(CGWindowID(w.windowNumber)) }
+        if let w = previewWindow { ids.append(CGWindowID(w.windowNumber)) }
+        return ids
+    }
+
+    private func installEscHandler() {
+        escMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.keyCode == 53 { // ESC key
+                self?.onCancel?()
+                return nil // consume the event
+            }
+            return event
+        }
+    }
+
+    // MARK: - Border
+
+    private func showBorder(screenRect: NSRect) {
+        let inset: CGFloat = 3
+        let borderRect = screenRect.insetBy(dx: -inset, dy: -inset)
+
+        let panel = NSPanel(
+            contentRect: borderRect,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .floating
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.ignoresMouseEvents = true
+        panel.hidesOnDeactivate = false
+
+        let borderView = ScrollCaptureBorderView(frame: NSRect(origin: .zero, size: borderRect.size))
+        panel.contentView = borderView
+
+        self.borderWindow = panel
+        panel.orderFrontRegardless()
+    }
+
+    // MARK: - Controls
+
+    private func showControls(screenRect: NSRect, screen: NSScreen) {
+        let controlsWidth: CGFloat = 300
+        let controlsHeight: CGFloat = 52
+        let gap: CGFloat = 10
+
+        // Try below the selection first
+        var controlsY = screenRect.origin.y - controlsHeight - gap
+
+        // If not enough space below (off-screen), show above the selection
+        if controlsY < screen.frame.origin.y {
+            controlsY = screenRect.maxY + gap
+        }
+
+        // If still off-screen (selection fills entire height), show inside at the bottom
+        if controlsY + controlsHeight > screen.frame.maxY {
+            controlsY = screenRect.origin.y + 8
+        }
+
+        let controlsRect = NSRect(
+            x: screenRect.midX - controlsWidth / 2,
+            y: controlsY,
+            width: controlsWidth,
+            height: controlsHeight
+        )
+
+        let panel = NSPanel(
+            contentRect: controlsRect,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .floating
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.hidesOnDeactivate = false
+
+        let hostingView = NSHostingView(rootView: ScrollCaptureControlsView(
+            viewModel: viewModel,
+            onStart: { [weak self] in self?.onStart?() },
+            onCancel: { [weak self] in self?.onCancel?() },
+            onDone: { [weak self] in self?.onDone?() }
+        ))
+        panel.contentView = hostingView
+
+        self.controlsWindow = panel
+        panel.orderFrontRegardless()
+    }
+
+    // MARK: - Preview
+
+    private func showPreview(screenRect: NSRect, screen: NSScreen) {
+        let previewWidth: CGFloat = 180
+        let previewHeight: CGFloat = min(screenRect.height, 400)
+        let previewX = screenRect.origin.x - previewWidth - 12
+
+        guard previewX >= screen.frame.origin.x else { return }
+
+        let previewRect = NSRect(
+            x: previewX,
+            y: screenRect.midY - previewHeight / 2,
+            width: previewWidth,
+            height: previewHeight
+        )
+
+        let panel = NSPanel(
+            contentRect: previewRect,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .floating
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.ignoresMouseEvents = true
+        panel.hidesOnDeactivate = false
+
+        let hostingView = NSHostingView(rootView: ScrollCapturePreviewView(viewModel: viewModel))
+        panel.contentView = hostingView
+
+        self.previewWindow = panel
+        panel.orderFrontRegardless()
+    }
+}
+
+// MARK: - Border View
+
+final class ScrollCaptureBorderView: NSView {
+    private var dashPhase: CGFloat = 0
+    private nonisolated(unsafe) var animTimer: Timer?
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        animTimer = Timer.scheduledTimer(withTimeInterval: 0.15, repeats: true) { [weak self] _ in
+            self?.dashPhase += 2
+            self?.needsDisplay = true
+        }
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    deinit { animTimer?.invalidate() }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+        let rect = bounds.insetBy(dx: 3, dy: 3)
+        ctx.setStrokeColor(NSColor.systemBlue.withAlphaComponent(0.8).cgColor)
+        ctx.setLineWidth(2.5)
+        ctx.setLineDash(phase: dashPhase, lengths: [6, 4])
+        ctx.stroke(rect)
+    }
+}
+
+// MARK: - ViewModel
+
+@MainActor
+@Observable
+final class ScrollCaptureViewModel {
+    var previewImage: NSImage?
+    var currentHeight: Int = 0
+    var frameCount: Int = 0
+    var isCapturing: Bool = false
+
+    var statusText: String {
+        if !isCapturing {
+            return String(localized: "Click Start, then scroll")
+        }
+        if frameCount == 0 {
+            return String(localized: "Scroll slowly to capture")
+        }
+        return "\(currentHeight)px · \(frameCount) frames"
+    }
+}
+
+// MARK: - Controls View
+
+struct ScrollCaptureControlsView: View {
+    let viewModel: ScrollCaptureViewModel
+    let onStart: () -> Void
+    let onCancel: () -> Void
+    let onDone: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            controlButton(
+                icon: "xmark",
+                label: String(localized: "Cancel"),
+                color: .white.opacity(0.15),
+                action: onCancel
+            )
+
+            if viewModel.isCapturing {
+                controlButton(
+                    icon: "checkmark",
+                    label: String(localized: "Done"),
+                    color: Color.accentColor,
+                    action: onDone
+                )
+            } else {
+                controlButton(
+                    icon: "play.fill",
+                    label: String(localized: "Start Capture"),
+                    color: Color.green,
+                    action: onStart
+                )
+            }
+        }
+        .padding(8)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .environment(\.colorScheme, .dark)
+    }
+
+    private func controlButton(icon: String, label: String, color: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .semibold))
+                Text(label)
+                    .font(.system(size: 13, weight: .medium))
+                    .fixedSize()
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(color)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Preview View
+
+struct ScrollCapturePreviewView: View {
+    let viewModel: ScrollCaptureViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let image = viewModel.previewImage {
+                // Scale-to-fit: show the entire captured image shrunk to fit the panel
+                GeometryReader { geo in
+                    Image(nsImage: image)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: geo.size.width)
+                        .frame(maxHeight: geo.size.height, alignment: .top)
+                }
+            } else {
+                VStack(spacing: 6) {
+                    Image(systemName: "arrow.down.doc")
+                        .font(.system(size: 20))
+                        .foregroundStyle(.tertiary)
+                    Text(viewModel.statusText)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.tertiary)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+
+            HStack {
+                Text(viewModel.statusText)
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Spacer()
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(.bar)
+        }
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .environment(\.colorScheme, .dark)
+    }
+}

--- a/App/Sources/Capture/ScrollCaptureHUD.swift
+++ b/App/Sources/Capture/ScrollCaptureHUD.swift
@@ -197,8 +197,10 @@ final class ScrollCaptureBorderView: NSView {
     override init(frame: NSRect) {
         super.init(frame: frame)
         animTimer = Timer.scheduledTimer(withTimeInterval: 0.15, repeats: true) { [weak self] _ in
-            self?.dashPhase += 2
-            self?.needsDisplay = true
+            Task { @MainActor in
+                self?.dashPhase += 2
+                self?.needsDisplay = true
+            }
         }
     }
 

--- a/App/Sources/MenuBar/MenuBarController.swift
+++ b/App/Sources/MenuBar/MenuBarController.swift
@@ -54,6 +54,10 @@ final class MenuBarController: NSObject {
         captureText.setShortcut(for: .captureText)
         menu.addItem(captureText)
 
+        let captureScrolling = menuItem(String(localized: "Scrolling Capture"), action: #selector(captureScrolling))
+        captureScrolling.setShortcut(for: .captureScrolling)
+        menu.addItem(captureScrolling)
+
         menu.addItem(.separator())
 
         let recordScreen = menuItem(String(localized: "Record Screen"), action: #selector(recordScreen))
@@ -100,6 +104,10 @@ final class MenuBarController: NSObject {
         ocrCoordinator.startInstantOCR()
     }
 
+    @objc private func captureScrolling() {
+        captureCoordinator.captureScrolling()
+    }
+
     @objc private func recordScreen() {
         recordingCoordinator.startRecordingFlow()
     }
@@ -134,6 +142,7 @@ extension MenuBarController: NSMenuDelegate {
             case #selector(captureWindow): item.setShortcut(for: .captureWindow)
             case #selector(captureText): item.setShortcut(for: .captureText)
             case #selector(recordScreen): item.setShortcut(for: .recordScreen)
+            case #selector(captureScrolling): item.setShortcut(for: .captureScrolling)
             default: break
             }
         }

--- a/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
@@ -8,6 +8,7 @@ extension KeyboardShortcuts.Name {
     static let captureWindow = Self("captureWindow", default: .init(.three, modifiers: [.option, .shift]))
     static let captureText = Self("captureText", default: .init(.four, modifiers: [.option, .shift]))
     static let recordScreen = Self("recordScreen", default: .init(.five, modifiers: [.option, .shift]))
+    static let captureScrolling = Self("captureScrolling", default: .init(.six, modifiers: [.option, .shift]))
 }
 
 struct ShortcutSettingsView: View {
@@ -39,6 +40,7 @@ struct ShortcutSettingsView: View {
                     shortcutRow("Capture Fullscreen", name: .captureFullscreen, showDivider: true)
                     shortcutRow("Capture Window", name: .captureWindow, showDivider: true)
                     shortcutRow("Capture Text (OCR)", name: .captureText, showDivider: true)
+                    shortcutRow("Scrolling Capture", name: .captureScrolling, showDivider: true)
                 }
             }
 

--- a/Packages/CaptureKit/Sources/CaptureKit/CaptureMode.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/CaptureMode.swift
@@ -6,6 +6,7 @@ public enum CaptureMode: String, Sendable {
     case area
     case fullscreen
     case window
+    case scrolling
 }
 
 public struct CaptureResult: Sendable {

--- a/Packages/CaptureKit/Sources/CaptureKit/Scrolling/HeaderDetector.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/Scrolling/HeaderDetector.swift
@@ -1,0 +1,62 @@
+// Packages/CaptureKit/Sources/CaptureKit/Scrolling/HeaderDetector.swift
+import CoreGraphics
+
+/// Detects sticky/frozen headers at the top of captured frames by comparing
+/// pixel rows between two consecutive frames. Rows that are identical in
+/// both frames are part of a sticky header and should be excluded from stitching.
+enum HeaderDetector {
+    /// Maximum percentage of image height to scan for headers.
+    private static let maxScanPercent = 0.20
+    /// Number of columns to sample per row for comparison.
+    private static let sampleColumns = 20
+    /// Per-pixel difference tolerance (accounts for sub-pixel rendering differences).
+    private static let tolerance: Int = 2
+
+    /// Detect the sticky header height by comparing two consecutive frames.
+    /// Returns the number of pixel rows at the top that are identical (frozen).
+    static func detectHeaderHeight(frame1: CGImage, frame2: CGImage) -> Int {
+        let width = min(frame1.width, frame2.width)
+        let height = min(frame1.height, frame2.height)
+        let maxScanRows = Int(Double(height) * maxScanPercent)
+        guard width > sampleColumns, maxScanRows > 0 else { return 0 }
+
+        guard let data1 = frame1.dataProvider?.data,
+              let data2 = frame2.dataProvider?.data else { return 0 }
+
+        let ptr1 = CFDataGetBytePtr(data1)!
+        let ptr2 = CFDataGetBytePtr(data2)!
+        let bpr1 = frame1.bytesPerRow
+        let bpr2 = frame2.bytesPerRow
+        let bpp = frame1.bitsPerPixel / 8
+
+        let colStep = max(1, width / sampleColumns)
+        var headerHeight = 0
+
+        for row in 0..<maxScanRows {
+            var rowMatches = true
+            var col = 0
+            while col < width {
+                let offset1 = row * bpr1 + col * bpp
+                let offset2 = row * bpr2 + col * bpp
+
+                let dr = abs(Int(ptr1[offset1]) - Int(ptr2[offset2]))
+                let dg = abs(Int(ptr1[offset1 + 1]) - Int(ptr2[offset2 + 1]))
+                let db = abs(Int(ptr1[offset1 + 2]) - Int(ptr2[offset2 + 2]))
+
+                if dr > tolerance || dg > tolerance || db > tolerance {
+                    rowMatches = false
+                    break
+                }
+                col += colStep
+            }
+
+            if rowMatches {
+                headerHeight = row + 1
+            } else {
+                break
+            }
+        }
+
+        return headerHeight
+    }
+}

--- a/Packages/CaptureKit/Sources/CaptureKit/Scrolling/ScrollCaptureController.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/Scrolling/ScrollCaptureController.swift
@@ -1,0 +1,267 @@
+// Packages/CaptureKit/Sources/CaptureKit/Scrolling/ScrollCaptureController.swift
+import CoreGraphics
+import Foundation
+import Vision
+@preconcurrency import ScreenCaptureKit
+
+public struct ScrollCaptureConfig: Sendable {
+    public let captureRect: CGRect
+    public let displayID: CGDirectDisplayID
+    public let mode: ScrollMode
+    public let maxHeight: Int
+
+    public init(
+        captureRect: CGRect,
+        displayID: CGDirectDisplayID,
+        mode: ScrollMode = .manual,
+        maxHeight: Int = 30_000
+    ) {
+        self.captureRect = captureRect
+        self.displayID = displayID
+        self.mode = mode
+        self.maxHeight = maxHeight
+    }
+}
+
+public enum ScrollMode: Sendable {
+    case auto
+    case manual
+}
+
+public struct ScrollCaptureProgress: Sendable {
+    public let currentHeight: Int
+    public let maxHeight: Int
+    public let frameCount: Int
+}
+
+public final class ScrollCaptureController: @unchecked Sendable {
+    private let config: ScrollCaptureConfig
+    private let stitcher = ScrollStitcher()
+    private var isCancelled = false
+    private var frameCount = 0
+
+    /// A/B frame model
+    private var shotA: CGImage?
+
+    /// Cached ScreenCaptureKit objects (created once, reused)
+    private var cachedFilter: SCContentFilter?
+    private var cachedStreamConfig: SCStreamConfiguration?
+
+    public var currentMergedImage: CGImage? { stitcher.mergedImage }
+
+    public init(config: ScrollCaptureConfig) {
+        self.config = config
+    }
+
+    public func start(
+        onProgress: @escaping @Sendable (ScrollCaptureProgress) -> Void,
+        onComplete: @escaping @Sendable (CGImage?) -> Void
+    ) {
+        Task.detached(priority: .utility) { [self] in
+            let result = await self.runCaptureLoop(onProgress: onProgress)
+            onComplete(result)
+        }
+    }
+
+    public func stop() {
+        isCancelled = true
+    }
+
+    // MARK: - Capture Loop
+
+    private func runCaptureLoop(
+        onProgress: @escaping @Sendable (ScrollCaptureProgress) -> Void
+    ) async -> CGImage? {
+        // Capture initial frame
+        guard let firstFrame = await captureFrame() else {
+            print("[ScrollCapture] Failed to capture initial frame")
+            return nil
+        }
+        stitcher.setInitialFrame(firstFrame)
+        shotA = firstFrame
+        frameCount = 1
+        print("[ScrollCapture] Initial frame: \(firstFrame.width)x\(firstFrame.height)")
+
+        onProgress(ScrollCaptureProgress(
+            currentHeight: stitcher.totalHeight,
+            maxHeight: config.maxHeight,
+            frameCount: frameCount
+        ))
+
+        var consecutiveNoChange = 0
+        var consecutiveFailures = 0
+        var firstOffsetSign: Int? = nil
+
+        // Main capture loop — runs until user clicks Done or stop condition
+        captureLoop: while !isCancelled {
+            if stitcher.totalHeight >= config.maxHeight {
+                print("[ScrollCapture] Max height reached: \(stitcher.totalHeight)")
+                break
+            }
+
+            // Poll interval
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !isCancelled else { break }
+
+            // Capture frame B
+            guard let shotB = await captureFrame() else {
+                consecutiveFailures += 1
+                if consecutiveFailures >= 15 { break }
+                continue
+            }
+
+            // Quick byte-level check: skip if identical (user not scrolling)
+            guard let dataA = shotA?.dataProvider?.data,
+                  let dataB = shotB.dataProvider?.data else {
+                continue
+            }
+            let lenA = CFDataGetLength(dataA)
+            let lenB = CFDataGetLength(dataB)
+            if lenA == lenB, memcmp(CFDataGetBytePtr(dataA)!, CFDataGetBytePtr(dataB)!, lenA) == 0 {
+                // Identical — user hasn't scrolled, keep waiting
+                continue
+            }
+
+            // Frames are different — detect offset with Vision
+            let offset = detectOffset(imageA: shotA!, imageB: shotB)
+
+            if offset == nil {
+                print("[ScrollCapture] Vision failed to detect offset")
+                consecutiveFailures += 1
+                if consecutiveFailures >= 15 { break captureLoop }
+                // Still update shotA so next comparison is fresh
+                shotA = shotB
+                continue
+            }
+
+            let rawOffset = offset!
+            let absOffset = abs(rawOffset)
+            print("[ScrollCapture] Vision offset: \(rawOffset) (abs: \(absOffset))")
+
+            // Too small offset = noise, not a real scroll
+            if absOffset < 3 {
+                consecutiveNoChange += 1
+                if consecutiveNoChange >= 10 { break captureLoop }
+                continue
+            }
+
+            // Detect direction reversal (elastic bounce = end of content)
+            let sign = rawOffset > 0 ? 1 : -1
+            if let first = firstOffsetSign {
+                if sign != first {
+                    print("[ScrollCapture] Direction reversed — end of content")
+                    break captureLoop
+                }
+            } else {
+                firstOffsetSign = sign
+            }
+
+            // Stitch the new frame
+            let result = stitcher.stitch(newFrame: shotB, detectedOffset: absOffset)
+
+            switch result {
+            case .stitched(let rows):
+                consecutiveNoChange = 0
+                consecutiveFailures = 0
+                frameCount += 1
+                print("[ScrollCapture] Stitched \(rows) new rows, total: \(stitcher.totalHeight)px, frames: \(frameCount)")
+                onProgress(ScrollCaptureProgress(
+                    currentHeight: stitcher.totalHeight,
+                    maxHeight: config.maxHeight,
+                    frameCount: frameCount
+                ))
+
+            case .noChange:
+                consecutiveNoChange += 1
+                print("[ScrollCapture] Stitch: no change (\(consecutiveNoChange)/10)")
+                if consecutiveNoChange >= 10 { break captureLoop }
+
+            case .reversedScroll:
+                print("[ScrollCapture] Stitch: reversed scroll")
+                break captureLoop
+
+            case .alignmentFailed:
+                consecutiveFailures += 1
+                print("[ScrollCapture] Stitch: alignment failed (\(consecutiveFailures)/15)")
+                if consecutiveFailures >= 15 { break captureLoop }
+            }
+
+            // A = B for next cycle
+            shotA = shotB
+        }
+
+        print("[ScrollCapture] Finished. Total: \(stitcher.totalHeight)px, \(frameCount) frames")
+        return stitcher.mergedImage
+    }
+
+    // MARK: - Frame Capture
+
+    private func captureFrame() async -> CGImage? {
+        do {
+            if cachedFilter == nil {
+                let content = try await SCShareableContent.excludingDesktopWindows(
+                    false, onScreenWindowsOnly: true
+                )
+                guard let display = content.displays.first(where: {
+                    $0.displayID == config.displayID
+                }) ?? content.displays.first else {
+                    return nil
+                }
+
+                // Exclude all Capso windows (our overlay panels)
+                let myBundleID = Bundle.main.bundleIdentifier ?? ""
+                let myWindows = content.windows.filter {
+                    $0.owningApplication?.bundleIdentifier == myBundleID
+                }
+
+                let filter = SCContentFilter(display: display, excludingWindows: myWindows)
+                let streamConfig = SCStreamConfiguration()
+                streamConfig.captureResolution = .best
+                streamConfig.showsCursor = false
+                streamConfig.sourceRect = config.captureRect
+                let scale = CGFloat(filter.pointPixelScale)
+                streamConfig.width = Int(config.captureRect.width * scale)
+                streamConfig.height = Int(config.captureRect.height * scale)
+
+                cachedFilter = filter
+                cachedStreamConfig = streamConfig
+            }
+
+            guard let filter = cachedFilter, let cfg = cachedStreamConfig else {
+                return nil
+            }
+
+            return try await SCScreenshotManager.captureImage(
+                contentFilter: filter,
+                configuration: cfg
+            )
+        } catch {
+            print("[ScrollCapture] Capture error: \(error)")
+            return nil
+        }
+    }
+
+    // MARK: - Vision Offset Detection
+
+    /// Detect Y offset between two frames using VNTranslationalImageRegistrationRequest.
+    /// Each call creates a fresh VNImageRequestHandler (stateless, reliable).
+    private func detectOffset(imageA: CGImage, imageB: CGImage) -> Int? {
+        let request = VNTranslationalImageRegistrationRequest(targetedCGImage: imageA)
+        let handler = VNImageRequestHandler(cgImage: imageB, options: [:])
+
+        do {
+            try handler.perform([request])
+        } catch {
+            print("[ScrollCapture] Vision error: \(error)")
+            return nil
+        }
+
+        guard let observation = request.results?.first
+                as? VNImageTranslationAlignmentObservation else {
+            return nil
+        }
+
+        let ty = observation.alignmentTransform.ty
+        return Int(round(ty))
+    }
+}

--- a/Packages/CaptureKit/Sources/CaptureKit/Scrolling/ScrollStitcher.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/Scrolling/ScrollStitcher.swift
@@ -1,0 +1,131 @@
+// Packages/CaptureKit/Sources/CaptureKit/Scrolling/ScrollStitcher.swift
+import CoreGraphics
+import AppKit
+
+public enum StitchResult: Sendable {
+    case stitched(yOffset: Int)
+    case noChange
+    case reversedScroll
+    case alignmentFailed
+}
+
+/// Incrementally stitches captured frames into a single tall image.
+/// The offset is detected externally (by ScrollCaptureController via Vision)
+/// and passed in. This class only handles the pixel compositing.
+public final class ScrollStitcher: @unchecked Sendable {
+    private(set) var mergedImage: CGImage?
+    private var previousFrame: CGImage?
+    private(set) var headerHeight: Int = 0
+    private(set) var scrollbarWidth: Int = 0
+    private(set) var totalHeight: Int = 0
+    private var isFirstStitch = true
+
+    public init() {}
+
+    public func setInitialFrame(_ frame: CGImage) {
+        mergedImage = frame
+        previousFrame = frame
+        totalHeight = frame.height
+        isFirstStitch = true
+    }
+
+    /// Stitch a new frame with a pre-computed offset (from Vision).
+    /// `detectedOffset` is the absolute number of new pixel rows (always positive).
+    public func stitch(newFrame: CGImage, detectedOffset: Int) -> StitchResult {
+        guard let previousFrame, let mergedImage else {
+            setInitialFrame(newFrame)
+            return .stitched(yOffset: 0)
+        }
+
+        // Detect scrollbar and header on the first stitch only
+        if isFirstStitch {
+            scrollbarWidth = ScrollbarDetector.detectScrollbarWidth(
+                frame1: previousFrame, frame2: newFrame
+            )
+            headerHeight = HeaderDetector.detectHeaderHeight(
+                frame1: previousFrame, frame2: newFrame
+            )
+            isFirstStitch = false
+        }
+
+        let newRows = detectedOffset
+        guard newRows > 0 else { return .noChange }
+
+        let frameHeight = newFrame.height
+
+        // If offset is larger than the frame, clamp to frame height
+        // (this means the user scrolled past one full frame — no overlap)
+        let clampedRows = min(newRows, frameHeight)
+
+        let mergedWidth = mergedImage.width
+        let newMergedHeight = totalHeight + clampedRows
+
+        guard let ctx = CGContext(
+            data: nil,
+            width: mergedWidth,
+            height: newMergedHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: mergedImage.colorSpace ?? CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        ) else {
+            return .alignmentFailed
+        }
+
+        // CGContext origin is bottom-left.
+        //
+        // Canvas layout:
+        //   top:    merged image (non-overlapping portion)
+        //   bottom: entire new frame (covers overlap zone + new content)
+        //
+        // The overlap region is overwritten by the new frame's data,
+        // which is pixel-perfect for the current scroll position.
+
+        // 1. Draw existing merged image at the top
+        ctx.draw(mergedImage, in: CGRect(
+            x: 0,
+            y: clampedRows,
+            width: mergedWidth,
+            height: totalHeight
+        ))
+
+        // 2. Prepare the new frame (exclude sticky header if detected)
+        let drawFrame: CGImage
+        let drawHeight: Int
+
+        if headerHeight > 0 && headerHeight < frameHeight {
+            // Crop header from the new frame
+            let contentHeight = frameHeight - headerHeight
+            if let cropped = newFrame.cropping(to: CGRect(
+                x: 0, y: headerHeight, width: newFrame.width, height: contentHeight
+            )) {
+                drawFrame = cropped
+                drawHeight = contentHeight
+            } else {
+                drawFrame = newFrame
+                drawHeight = frameHeight
+            }
+        } else {
+            drawFrame = newFrame
+            drawHeight = frameHeight
+        }
+
+        // 3. Draw the entire new frame at the bottom of the canvas.
+        //    This naturally overlaps with the merged image in the overlap zone,
+        //    replacing it with the latest pixel data.
+        ctx.draw(drawFrame, in: CGRect(
+            x: 0,
+            y: 0,
+            width: mergedWidth,
+            height: drawHeight
+        ))
+
+        if let result = ctx.makeImage() {
+            self.mergedImage = result
+            self.totalHeight = newMergedHeight
+        }
+
+        self.previousFrame = newFrame
+        return .stitched(yOffset: clampedRows)
+    }
+}

--- a/Packages/CaptureKit/Sources/CaptureKit/Scrolling/ScrollbarDetector.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/Scrolling/ScrollbarDetector.swift
@@ -1,0 +1,73 @@
+// Packages/CaptureKit/Sources/CaptureKit/Scrolling/ScrollbarDetector.swift
+import CoreGraphics
+
+/// Detects scrollbar width on the right edge of captured frames using
+/// Sum of Absolute Differences (SAD). The scrollbar thumb moves independently
+/// of content and would confuse the Vision offset detector if not cropped.
+enum ScrollbarDetector {
+    /// Number of columns to scan from the right edge.
+    private static let scanColumns = 50
+    /// Number of rows to sample per column (across middle 60% of image).
+    private static let sampleRows = 40
+    /// SAD threshold below which a column is considered static (window chrome, not scrollbar).
+    private static let staticThreshold: CGFloat = 8
+
+    /// Detect the scrollbar width by comparing two consecutive frames.
+    /// Returns the number of pixel columns to crop from the right edge.
+    static func detectScrollbarWidth(frame1: CGImage, frame2: CGImage) -> Int {
+        let width = min(frame1.width, frame2.width)
+        let height = min(frame1.height, frame2.height)
+        guard width > scanColumns, height > sampleRows else { return 0 }
+
+        guard let data1 = frame1.dataProvider?.data,
+              let data2 = frame2.dataProvider?.data else { return 0 }
+
+        let ptr1 = CFDataGetBytePtr(data1)!
+        let ptr2 = CFDataGetBytePtr(data2)!
+        let bpr1 = frame1.bytesPerRow
+        let bpr2 = frame2.bytesPerRow
+        let bpp = frame1.bitsPerPixel / 8
+
+        // Sample rows in the middle 60% of the image
+        let startRow = Int(Double(height) * 0.2)
+        let endRow = Int(Double(height) * 0.8)
+        let rowStep = max(1, (endRow - startRow) / sampleRows)
+
+        var scrollbarStart = width // no scrollbar by default
+
+        // Scan columns from right edge inward
+        for colOffset in 0..<min(scanColumns, width) {
+            let col = width - 1 - colOffset
+            var totalDiff: CGFloat = 0
+            var sampleCount = 0
+
+            var row = startRow
+            while row < endRow {
+                let offset1 = row * bpr1 + col * bpp
+                let offset2 = row * bpr2 + col * bpp
+
+                // Compare RGB channels
+                let dr = abs(Int(ptr1[offset1]) - Int(ptr2[offset2]))
+                let dg = abs(Int(ptr1[offset1 + 1]) - Int(ptr2[offset2 + 1]))
+                let db = abs(Int(ptr1[offset1 + 2]) - Int(ptr2[offset2 + 2]))
+                totalDiff += CGFloat(dr + dg + db) / 3.0
+                sampleCount += 1
+                row += rowStep
+            }
+
+            let avgDiff = sampleCount > 0 ? totalDiff / CGFloat(sampleCount) : 0
+
+            if avgDiff > staticThreshold {
+                // This column has changing content — likely scrollbar or real content
+                scrollbarStart = col
+            } else if scrollbarStart < width {
+                // We found static columns after scrollbar columns — this is the boundary
+                break
+            }
+        }
+
+        let scrollbarWidth = width - scrollbarStart
+        // Only crop if we detected a reasonable scrollbar width (4-30px)
+        return (scrollbarWidth >= 4 && scrollbarWidth <= 60) ? scrollbarWidth : 0
+    }
+}

--- a/Packages/SharedKit/Sources/SharedKit/Permissions/PermissionManager.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Permissions/PermissionManager.swift
@@ -9,6 +9,7 @@ public final class PermissionManager {
     public private(set) var screenRecordingGranted: Bool = false
     public private(set) var cameraGranted: Bool = false
     public private(set) var microphoneGranted: Bool = false
+    public private(set) var accessibilityGranted: Bool = false
 
     public init() {}
 
@@ -51,6 +52,20 @@ public final class PermissionManager {
         }
     }
 
+    // MARK: - Accessibility
+
+    public func checkAccessibilityPermission() {
+        accessibilityGranted = AXIsProcessTrusted()
+    }
+
+    /// Prompt the user to grant Accessibility permission.
+    /// Opens System Settings if not yet trusted.
+    public func requestAccessibilityPermission() {
+        // AXIsProcessTrustedWithOptions with prompt option
+        let options = ["AXTrustedCheckOptionPrompt": true] as CFDictionary
+        accessibilityGranted = AXIsProcessTrustedWithOptions(options)
+    }
+
     // MARK: - Open System Settings
 
     public func openScreenRecordingSettings() {
@@ -65,6 +80,11 @@ public final class PermissionManager {
 
     public func openMicrophoneSettings() {
         let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")!
+        NSWorkspace.shared.open(url)
+    }
+
+    public func openAccessibilitySettings() {
+        let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
         NSWorkspace.shared.open(url)
     }
 }


### PR DESCRIPTION
## Summary

- Add Scrolling Capture — select a region, click Start, scroll the content, click Done to get a stitched long screenshot
- Vision framework (VNTranslationalImageRegistrationRequest) for sub-pixel frame alignment
- Incremental stitching with full-frame overlap (no seam artifacts)
- Scrollbar detection (SAD algorithm) and sticky header detection
- Live preview panel showing the growing screenshot in real-time
- Selection border with animated marching ants
- Cancel/Start/Done controls with smart positioning (auto-adjusts when near screen edges)
- ESC key to dismiss at any time
- Default keyboard shortcut: Option+Shift+6
- Accessibility permission handling for future auto-scroll mode
- Complete zh-Hans/ja/ko translations for all new strings + missing Settings page translations

## Test plan

- [x] Trigger via menu bar "Scrolling Capture" or Option+Shift+6
- [x] Select a region on a scrollable page (e.g. browser, long document)
- [x] Click "Start Capture", slowly scroll down, click "Done"
- [x] Verify stitched image has no visible seams or duplicate content
- [x] Verify preview panel scales to show full captured content
- [x] Verify ESC dismisses the overlay
- [x] Verify controls are visible when selection is near bottom of screen
- [x] Verify all UI text is localized in Chinese
- [x] Verify shortcut appears in Settings → Shortcuts