### PR TITLE
Fix Sparkle appcast metadata and self-window capture

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -328,6 +328,9 @@ jobs:
           DMG="build/releases/${APP_NAME}-${VERSION}.dmg"
           DMG_SIZE=$(stat -f%z "$DMG")
           PUB_DATE=$(date -R)
+          APP="build/export/${APP_NAME}.app"
+          APP_BUILD_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP/Contents/Info.plist")
+          APP_SHORT_VERSION=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP/Contents/Info.plist")
 
           # Sign the DMG with Sparkle EdDSA
           SPARKLE_SIGN=$(find $HOME/Library/Developer/Xcode/DerivedData/Capso-*/SourcePackages/artifacts/sparkle/Sparkle/bin/sign_update -maxdepth 0 2>/dev/null | head -1)
@@ -337,7 +340,13 @@ jobs:
           fi
           ED_SIGNATURE=""
           if [ -n "$SPARKLE_SIGN" ] && [ -n "$SPARKLE_PRIVATE_KEY" ]; then
-            ED_SIGNATURE=$("$SPARKLE_SIGN" "$DMG" --ed-key-file <(echo "$SPARKLE_PRIVATE_KEY") | grep "sparkle:edSignature" | sed 's/.*"\(.*\)".*/\1/')
+            SIGN_OUTPUT=$("$SPARKLE_SIGN" "$DMG" --ed-key-file <(echo "$SPARKLE_PRIVATE_KEY"))
+            ED_SIGNATURE=$(printf '%s\n' "$SIGN_OUTPUT" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')
+            if [ -z "$ED_SIGNATURE" ]; then
+              echo "::error::Failed to extract Sparkle EdDSA signature from sign_update output"
+              echo "$SIGN_OUTPUT"
+              exit 1
+            fi
           fi
 
           # Clone only the gh-pages branch
@@ -354,13 +363,13 @@ jobs:
               <description>Open-source screenshot and screen recording for macOS</description>
               <language>en</language>
               <item>
-                <title>Version ${VERSION}</title>
+                <title>Version ${APP_SHORT_VERSION}</title>
                 <pubDate>${PUB_DATE}</pubDate>
-                <sparkle:version>${VERSION}</sparkle:version>
-                <sparkle:shortVersionString>${VERSION}</sparkle:shortVersionString>
+                <sparkle:version>${APP_BUILD_VERSION}</sparkle:version>
+                <sparkle:shortVersionString>${APP_SHORT_VERSION}</sparkle:shortVersionString>
                 <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
                 <enclosure
-                  url="https://github.com/lzhgus/Capso/releases/download/v${VERSION}/Capso-${VERSION}.dmg"
+                  url="https://github.com/lzhgus/Capso/releases/download/v${APP_SHORT_VERSION}/Capso-${APP_SHORT_VERSION}.dmg"
                   type="application/octet-stream"
                   sparkle:edSignature="${ED_SIGNATURE}"
                   length="${DMG_SIZE}"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Install tooling
         run: brew install xcodegen create-dmg
 
+      - name: Reset SwiftPM binary artifact caches
+        run: |
+          rm -rf "$HOME/Library/Caches/org.swift.swiftpm/artifacts"
+          find "$HOME/Library/Developer/Xcode/DerivedData" \
+            -path '*/SourcePackages/artifacts' -prune -exec rm -rf {} + 2>/dev/null || true
+
       - name: Generate Xcode project
         run: xcodegen generate
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Install XcodeGen
         run: brew install xcodegen
 
+      - name: Reset SwiftPM binary artifact caches
+        run: |
+          rm -rf "$HOME/Library/Caches/org.swift.swiftpm/artifacts"
+          find "$HOME/Library/Developer/Xcode/DerivedData" \
+            -path '*/SourcePackages/artifacts' -prune -exec rm -rf {} + 2>/dev/null || true
+
       - name: Generate Xcode project
         run: xcodegen generate
 

--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -379,7 +379,11 @@ final class CaptureOverlayView: NSView {
             if let window = windowUnderCursor(at: screenPoint) {
                 hoveredWindowID = window.id
                 hoveredWindowFrame = window.frame
-                hoveredWindowName = "\(window.appName) — \(window.title)"
+                if window.appName.isEmpty || window.title == window.appName {
+                    hoveredWindowName = window.title
+                } else {
+                    hoveredWindowName = "\(window.appName) — \(window.title)"
+                }
             } else {
                 hoveredWindowID = nil
             }

--- a/Packages/CaptureKit/Sources/CaptureKit/WindowInfo.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/WindowInfo.swift
@@ -11,8 +11,10 @@ public struct WindowInfo: Identifiable, Sendable {
     public let windowLayer: Int
 
     public init(from scWindow: SCWindow) {
+        let trimmedTitle = scWindow.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let fallbackTitle = scWindow.owningApplication?.applicationName ?? "Untitled Window"
         self.id = scWindow.windowID
-        self.title = scWindow.title ?? ""
+        self.title = trimmedTitle.isEmpty ? fallbackTitle : trimmedTitle
         self.appName = scWindow.owningApplication?.applicationName ?? ""
         self.frame = scWindow.frame
         self.isOnScreen = scWindow.isOnScreen
@@ -37,16 +39,20 @@ public struct DisplayInfo: Identifiable, Sendable {
 public enum ContentEnumerator {
     public static func windows() async throws -> [WindowInfo] {
         let content = try await SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: true)
+        let myBundleID = Bundle.main.bundleIdentifier
         return content.windows
             .filter { window in
-                // Only include normal application windows (layer 0).
-                // Status bar items, floating panels, overlays, etc. have layer > 0.
-                window.windowLayer == 0
-                && window.frame.width > 100 && window.frame.height > 50
-                && window.isOnScreen
-                && window.owningApplication != nil
-                && window.title != nil
-                && !window.title!.isEmpty
+                let trimmedTitle = window.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                let appName = window.owningApplication?.applicationName ?? ""
+                let hasUsableLabel = !trimmedTitle.isEmpty || !appName.isEmpty
+                let isOwnAppWindow = window.owningApplication?.bundleIdentifier == myBundleID
+
+                return window.frame.width > 100
+                    && window.frame.height > 50
+                    && window.isOnScreen
+                    && window.owningApplication != nil
+                    && hasUsableLabel
+                    && (window.windowLayer == 0 || isOwnAppWindow)
             }
             .map { WindowInfo(from: $0) }
     }


### PR DESCRIPTION
## What changed

- fix Sparkle release workflow so `sparkle:edSignature` is extracted correctly
- write `sparkle:version` from `CFBundleVersion` instead of the marketing version string
- allow Capso-owned auxiliary windows/panels (like About / updater windows) to appear in window capture selection
- clean up hovered window labeling when a panel has no separate title

## Related issue

Refs #30
Refs #31

## Screenshots / recordings

N/A

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass (`swift test --package-path Packages/<Kit>`)
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)
