### PR TITLE
Keep no-update feedback non-modal in Preferences

### DIFF
--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -13,8 +13,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private(set) var recordingCoordinator: RecordingCoordinator?
     private(set) var ocrCoordinator: OCRCoordinator?
     private var preferencesWindow: PreferencesWindow?
-    /// Sparkle updater controller — manages the update lifecycle.
-    let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+    /// Sparkle update coordinator used by preferences and manual update checks.
+    let updateManager = UpdateManager()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Show tooltips faster (default is ~2s, reduce to 0.3s)
@@ -26,7 +26,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         recordingCoordinator = RecordingCoordinator(settings: settings)
         ocrCoordinator = OCRCoordinator(settings: settings)
         captureCoordinator!.ocrCoordinator = ocrCoordinator
-        preferencesWindow = PreferencesWindow(settings: settings, updater: updaterController.updater)
+        preferencesWindow = PreferencesWindow(settings: settings, updateManager: updateManager)
         menuBarController = MenuBarController(
             settings: settings,
             captureCoordinator: captureCoordinator!,

--- a/App/Sources/Preferences/Components/CheckForUpdatesView.swift
+++ b/App/Sources/Preferences/Components/CheckForUpdatesView.swift
@@ -1,37 +1,147 @@
 // App/Sources/Preferences/Components/CheckForUpdatesView.swift
+import AppKit
 import SwiftUI
 import Sparkle
 
-/// A SwiftUI wrapper that observes the Sparkle updater's `canCheckForUpdates`
-/// state and exposes a "Check for Updates" button.
-struct CheckForUpdatesView: View {
-    @ObservedObject private var checkForUpdatesViewModel: CheckForUpdatesViewModel
-
-    init(updater: SPUUpdater) {
-        self.checkForUpdatesViewModel = CheckForUpdatesViewModel(updater: updater)
-    }
-
-    var body: some View {
-        Button("Check for Updates") {
-            checkForUpdatesViewModel.updater.checkForUpdates()
-        }
-        .disabled(!checkForUpdatesViewModel.canCheckForUpdates)
-        .controlSize(.small)
-    }
-}
-
 @MainActor
-private final class CheckForUpdatesViewModel: ObservableObject {
-    @Published var canCheckForUpdates = false
-    let updater: SPUUpdater
-    private var observation: NSKeyValueObservation?
+final class UpdateManager: NSObject, ObservableObject {
+    enum StatusKind {
+        case checking
+        case success
+        case error
+    }
 
-    init(updater: SPUUpdater) {
-        self.updater = updater
+    struct Status {
+        let message: String
+        let kind: StatusKind
+    }
+
+    @Published private(set) var canCheckForUpdates = false
+    @Published private(set) var status: Status?
+
+    private enum ManualCheckState {
+        case none
+        case probing
+    }
+
+    private var manualCheckState: ManualCheckState = .none
+    private var probeFoundValidUpdate = false
+    private var observation: NSKeyValueObservation?
+    private var clearStatusTask: Task<Void, Never>?
+
+    lazy var updaterController = SPUStandardUpdaterController(
+        startingUpdater: true,
+        updaterDelegate: self,
+        userDriverDelegate: nil
+    )
+
+    var updater: SPUUpdater { updaterController.updater }
+
+    override init() {
+        super.init()
         observation = updater.observe(\.canCheckForUpdates, options: [.initial, .new]) { [weak self] updater, _ in
             Task { @MainActor in
                 self?.canCheckForUpdates = updater.canCheckForUpdates
             }
         }
+    }
+
+    func checkForUpdates() {
+        guard updater.canCheckForUpdates else { return }
+        clearStatusTask?.cancel()
+        manualCheckState = .probing
+        probeFoundValidUpdate = false
+        status = Status(message: "Checking…", kind: .checking)
+        updater.checkForUpdateInformation()
+    }
+
+    private func showStatus(_ message: String, kind: StatusKind, autoDismissAfter: Duration? = .seconds(4)) {
+        clearStatusTask?.cancel()
+        status = Status(message: message, kind: kind)
+
+        guard let autoDismissAfter else { return }
+        clearStatusTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: autoDismissAfter)
+            guard !Task.isCancelled else { return }
+            self?.status = nil
+        }
+    }
+
+    private func clearManualProbeState() {
+        manualCheckState = .none
+        probeFoundValidUpdate = false
+    }
+}
+
+extension UpdateManager: SPUUpdaterDelegate {
+    func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        guard manualCheckState == .probing else { return }
+        probeFoundValidUpdate = true
+        status = nil
+    }
+
+    func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: Error) {
+        guard manualCheckState == .probing else { return }
+        let message = error.localizedDescription.isEmpty ? String(localized: "You’re up to date!") : error.localizedDescription
+        showStatus(message, kind: .success)
+    }
+
+    func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
+        guard manualCheckState == .probing else { return }
+        let nsError = error as NSError
+        guard !(nsError.domain == SUSparkleErrorDomain && nsError.code == 1001) else { return }
+        showStatus(error.localizedDescription, kind: .error, autoDismissAfter: .seconds(6))
+    }
+
+    func updater(_ updater: SPUUpdater, didFinishUpdateCycleFor updateCheck: SPUUpdateCheck, error: (any Error)?) {
+        guard manualCheckState == .probing, updateCheck == .updateInformation else { return }
+
+        let shouldLaunchInteractiveFlow = probeFoundValidUpdate && error == nil
+        clearManualProbeState()
+
+        if shouldLaunchInteractiveFlow {
+            status = nil
+            updater.checkForUpdates()
+        }
+    }
+}
+
+/// A SwiftUI wrapper around Capso's update manager that keeps manual
+/// no-update feedback non-modal so the app remains capturable.
+struct CheckForUpdatesView: View {
+    @ObservedObject var updateManager: UpdateManager
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 6) {
+            Button("Check for Updates") {
+                updateManager.checkForUpdates()
+            }
+            .disabled(!updateManager.canCheckForUpdates)
+            .controlSize(.small)
+
+            if let status = updateManager.status {
+                HStack(spacing: 6) {
+                    switch status.kind {
+                    case .checking:
+                        ProgressView()
+                            .controlSize(.small)
+                    case .success:
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    case .error:
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.yellow)
+                    }
+
+                    Text(status.message)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.trailing)
+                }
+                .frame(maxWidth: 220, alignment: .trailing)
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: updateManager.status?.message)
     }
 }

--- a/App/Sources/Preferences/PreferencesView.swift
+++ b/App/Sources/Preferences/PreferencesView.swift
@@ -1,6 +1,5 @@
 // App/Sources/Preferences/PreferencesView.swift
 import SwiftUI
-import Sparkle
 
 enum PreferencesTab: String, CaseIterable {
     case general
@@ -39,7 +38,7 @@ enum PreferencesTab: String, CaseIterable {
 struct PreferencesView: View {
     @State private var selectedTab: PreferencesTab = .general
     let viewModel: PreferencesViewModel
-    let updater: SPUUpdater?
+    let updateManager: UpdateManager?
 
     var body: some View {
         HStack(spacing: 0) {
@@ -72,7 +71,7 @@ struct PreferencesView: View {
             VStack(alignment: .leading, spacing: 0) {
                 switch selectedTab {
                 case .general:
-                    GeneralSettingsView(viewModel: viewModel, updater: updater)
+                    GeneralSettingsView(viewModel: viewModel, updateManager: updateManager)
                 case .screenshots:
                     ScreenshotSettingsView(viewModel: viewModel)
                 case .recording:

--- a/App/Sources/Preferences/PreferencesWindow.swift
+++ b/App/Sources/Preferences/PreferencesWindow.swift
@@ -2,17 +2,16 @@
 import AppKit
 import SwiftUI
 import SharedKit
-import Sparkle
 
 @MainActor
 final class PreferencesWindow {
     private var window: NSWindow?
     private let settings: AppSettings
-    private let updater: SPUUpdater?
+    private let updateManager: UpdateManager?
 
-    init(settings: AppSettings, updater: SPUUpdater? = nil) {
+    init(settings: AppSettings, updateManager: UpdateManager? = nil) {
         self.settings = settings
-        self.updater = updater
+        self.updateManager = updateManager
     }
 
     func show() {
@@ -42,7 +41,7 @@ final class PreferencesWindow {
         window.contentView = visualEffect
 
         let viewModel = PreferencesViewModel(settings: settings)
-        let hostingView = NSHostingView(rootView: PreferencesView(viewModel: viewModel, updater: updater))
+        let hostingView = NSHostingView(rootView: PreferencesView(viewModel: viewModel, updateManager: updateManager))
         hostingView.translatesAutoresizingMaskIntoConstraints = false
         visualEffect.addSubview(hostingView)
         NSLayoutConstraint.activate([

--- a/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
@@ -1,11 +1,10 @@
 // App/Sources/Preferences/Tabs/GeneralSettingsView.swift
 import SwiftUI
 import LaunchAtLogin
-import Sparkle
 
 struct GeneralSettingsView: View {
     @Bindable var viewModel: PreferencesViewModel
-    let updater: SPUUpdater?
+    let updateManager: UpdateManager?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -42,11 +41,11 @@ struct GeneralSettingsView: View {
                 }
             }
 
-            if let updater {
+            if let updateManager {
                 SettingGroup(title: "Updates") {
                     SettingCard {
                         SettingRow(label: "Check for Updates", sublabel: "Automatically checks daily") {
-                            CheckForUpdatesView(updater: updater)
+                            CheckForUpdatesView(updateManager: updateManager)
                         }
                     }
                 }


### PR DESCRIPTION
## What changed

- replace manual `Check for Updates` behavior with a two-step flow
- use Sparkle's probing check first so the no-update case stays inside Capso's UI
- show inline non-modal status feedback in Preferences when the app is already up to date or an update check fails
- hand off to Sparkle's normal interactive update UI only when a valid update is actually found

## Related issue

Refs #31

## Screenshots / recordings

N/A

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass (`swift test --package-path Packages/<Kit>`)
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)
