### PR TITLE
Polish screenshot selection overlay feedback

### DIFF
--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -34,8 +34,8 @@ final class CaptureOverlayView: NSView {
     // Overlay appearance
     private let overlayColor = NSColor.black.withAlphaComponent(0.3)
     private let selectionBorderColor = NSColor.white
-    private let selectionFillColor = NSColor.white.withAlphaComponent(0.08)
-    private let selectionInnerStrokeColor = NSColor.white.withAlphaComponent(0.16)
+    private let selectionFillColor = NSColor.white.withAlphaComponent(0.13)
+    private let selectionInnerStrokeColor = NSColor.white.withAlphaComponent(0.24)
     private let windowHighlightColor = NSColor.systemBlue.withAlphaComponent(0.3)
     private let windowBorderColor = NSColor.systemBlue
     private let dimensionFont = NSFont.monospacedSystemFont(ofSize: 12, weight: .medium)

--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -34,8 +34,11 @@ final class CaptureOverlayView: NSView {
     // Overlay appearance
     private let overlayColor = NSColor.black.withAlphaComponent(0.3)
     private let selectionBorderColor = NSColor.white
-    private let selectionFillColor = NSColor.white.withAlphaComponent(0.13)
-    private let selectionInnerStrokeColor = NSColor.white.withAlphaComponent(0.24)
+    // Use a neutral gray glass tint instead of pure white so the selected
+    // region still reads against bright backgrounds while remaining soft on
+    // dark ones.
+    private let selectionFillColor = NSColor(white: 0.78, alpha: 0.20)
+    private let selectionInnerStrokeColor = NSColor.white.withAlphaComponent(0.30)
     private let windowHighlightColor = NSColor.systemBlue.withAlphaComponent(0.3)
     private let windowBorderColor = NSColor.systemBlue
     private let dimensionFont = NSFont.monospacedSystemFont(ofSize: 12, weight: .medium)

--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -34,6 +34,8 @@ final class CaptureOverlayView: NSView {
     // Overlay appearance
     private let overlayColor = NSColor.black.withAlphaComponent(0.3)
     private let selectionBorderColor = NSColor.white
+    private let selectionFillColor = NSColor.white.withAlphaComponent(0.08)
+    private let selectionInnerStrokeColor = NSColor.white.withAlphaComponent(0.16)
     private let windowHighlightColor = NSColor.systemBlue.withAlphaComponent(0.3)
     private let windowBorderColor = NSColor.systemBlue
     private let dimensionFont = NSFont.monospacedSystemFont(ofSize: 12, weight: .medium)
@@ -110,11 +112,26 @@ final class CaptureOverlayView: NSView {
 
     private func drawAreaMode(in context: CGContext) {
         // The overlay is fully transparent. Nothing outside the selection
-        // changes — no dark tint, no visual disruption. Only the selection
-        // area gets a subtle white highlight to indicate what's being captured.
+        // changes — no dark tint, no visual disruption. While dragging, the
+        // selection area gets a subtle frosted fill so the chosen region reads
+        // more like an active target instead of just a border.
 
         if isDragging {
             let selectionRect = self.selectionRect
+
+            // Subtle inner tint to make the capture target feel active.
+            // Keep it very light so the desktop content remains legible.
+            context.saveGState()
+            context.setFillColor(selectionFillColor.cgColor)
+            context.fill(selectionRect.insetBy(dx: 1, dy: 1))
+            context.restoreGState()
+
+            // Inner edge to help the fill read on bright backgrounds.
+            context.saveGState()
+            context.setStrokeColor(selectionInnerStrokeColor.cgColor)
+            context.setLineWidth(1.0)
+            context.stroke(selectionRect.insetBy(dx: 1, dy: 1))
+            context.restoreGState()
 
             // Selection border with shadow glow — visible on any background.
             // Dark shadow makes it clear on light backgrounds,


### PR DESCRIPTION
## What changed

- add a subtle active fill inside the screenshot area selection rectangle
- strengthen the fill/inner stroke so the selection reads more clearly while dragging
- switch the fill to a neutral glass-like tint so it remains visible on both dark and bright backgrounds

## Related issue

Refs selection overlay UX polish

## Screenshots / recordings

N/A

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass (`swift test --package-path Packages/<Kit>`)
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)
