### PR TITLE
feat: add Capture Area to Clipboard and Capture Area & Annotate shortcuts

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -620,6 +620,50 @@
         }
       }
     },
+    "Capture Area & Annotate" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エリアキャプチャ & 注釈"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "영역 캡처 & 주석"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截取区域并标注"
+          }
+        }
+      }
+    },
+    "Capture Area to Clipboard" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "エリアをクリップボードにキャプチャ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "영역을 클립보드에 캡처"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截取区域到剪贴板"
+          }
+        }
+      }
+    },
     "Capture Area" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -138,15 +138,30 @@ struct AnnotationToolbar: View {
     }
 
     private var actionGroup: some View {
-        HStack(spacing: 8) {
-            Button("Cancel", action: onCancel)
-                .keyboardShortcut(.escape, modifiers: [])
-            Button("Copy", action: onCopy)
-                .keyboardShortcut("c", modifiers: .command)
-            Button("Save", action: onSave)
-                .keyboardShortcut("s", modifiers: .command)
-                .buttonStyle(.borderedProminent)
+        HStack(spacing: 6) {
+            Button(action: onCancel) {
+                Label("Close", systemImage: "xmark")
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .keyboardShortcut(.escape, modifiers: [])
+
+            Button(action: onCopy) {
+                Label("Copy", systemImage: "doc.on.doc")
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .keyboardShortcut("c", modifiers: .command)
+
+            Button(action: onSave) {
+                Label("Save", systemImage: "square.and.arrow.down")
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .keyboardShortcut("s", modifiers: .command)
         }
-        .controlSize(.small)
     }
 }

--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -72,6 +72,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         KeyboardShortcuts.onKeyDown(for: .captureScrolling) { [weak self] in
             self?.captureCoordinator?.captureScrolling()
         }
+        KeyboardShortcuts.onKeyDown(for: .captureAreaToClipboard) { [weak self] in
+            self?.captureCoordinator?.captureAreaToClipboard()
+        }
+        KeyboardShortcuts.onKeyDown(for: .captureAreaAndAnnotate) { [weak self] in
+            self?.captureCoordinator?.captureAreaAndAnnotate()
+        }
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -31,18 +31,38 @@ final class CaptureCoordinator {
     var lastCaptureResult: CaptureResult?
     var ocrCoordinator: OCRCoordinator?
 
+    /// Post-capture action override. When set, ignores Settings toggles.
+    private var pendingAction: PostCaptureAction = .default
+
+    enum PostCaptureAction {
+        case `default`    // Use Settings (Show Preview / Copy / Auto Save)
+        case clipboard    // Copy to clipboard only, no preview
+        case annotate     // Open annotation editor directly
+    }
+
     init(settings: AppSettings) {
         self.settings = settings
     }
 
     func captureArea() {
+        pendingAction = .default
+        startAreaCapture()
+    }
+
+    func captureAreaToClipboard() {
+        pendingAction = .clipboard
+        startAreaCapture()
+    }
+
+    func captureAreaAndAnnotate() {
+        pendingAction = .annotate
+        startAreaCapture()
+    }
+
+    private func startAreaCapture() {
         if settings.freezeScreen {
-            // Freeze screen: synchronously capture all screens FIRST (preserving
-            // dropdowns/popups), then show overlay with frozen image as background.
-            // No delay — must be instant before anything can dismiss.
             showFrozenOverlay()
         } else {
-            // Non-frozen: small delay to let menu bar dropdown dismiss
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
                 self?.showOverlay()
             }
@@ -505,14 +525,25 @@ final class CaptureCoordinator {
             Self.shutterSound?.stop()
             Self.shutterSound?.play()
         }
-        if settings.screenshotAutoCopy {
+
+        let action = pendingAction
+        pendingAction = .default
+
+        switch action {
+        case .clipboard:
             copyImageToClipboard(result.image)
-        }
-        if settings.screenshotAutoSave {
-            saveImageToFile(result.image)
-        }
-        if settings.screenshotShowPreview {
-            showQuickAccess(for: result)
+        case .annotate:
+            openAnnotationEditor(result)
+        case .default:
+            if settings.screenshotAutoCopy {
+                copyImageToClipboard(result.image)
+            }
+            if settings.screenshotAutoSave {
+                saveImageToFile(result.image)
+            }
+            if settings.screenshotShowPreview {
+                showQuickAccess(for: result)
+            }
         }
     }
 

--- a/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
@@ -9,6 +9,8 @@ extension KeyboardShortcuts.Name {
     static let captureText = Self("captureText", default: .init(.four, modifiers: [.option, .shift]))
     static let recordScreen = Self("recordScreen", default: .init(.five, modifiers: [.option, .shift]))
     static let captureScrolling = Self("captureScrolling", default: .init(.six, modifiers: [.option, .shift]))
+    static let captureAreaToClipboard = Self("captureAreaToClipboard", default: .init(.seven, modifiers: [.option, .shift]))
+    static let captureAreaAndAnnotate = Self("captureAreaAndAnnotate", default: .init(.eight, modifiers: [.option, .shift]))
 }
 
 struct ShortcutSettingsView: View {
@@ -41,6 +43,8 @@ struct ShortcutSettingsView: View {
                     shortcutRow("Capture Window", name: .captureWindow, showDivider: true)
                     shortcutRow("Capture Text (OCR)", name: .captureText, showDivider: true)
                     shortcutRow("Scrolling Capture", name: .captureScrolling, showDivider: true)
+                    shortcutRow("Capture Area to Clipboard", name: .captureAreaToClipboard, showDivider: true)
+                    shortcutRow("Capture Area & Annotate", name: .captureAreaAndAnnotate, showDivider: true)
                 }
             }
 


### PR DESCRIPTION
## Summary

Closes #22

### New Shortcuts
Two new keyboard shortcuts for direct post-capture actions:

| Shortcut | Action |
|---|---|
| Option+Shift+7 | Capture Area → copy to clipboard (no preview) |
| Option+Shift+8 | Capture Area → open annotation editor directly |

These override the Settings toggles. The default Capture Area (Option+Shift+1) still respects Settings as before.

### Annotation Toolbar Fix
- Action buttons (Close/Copy/Save) now have icons + bordered style, visible on dark toolbar
- "Cancel" renamed to "Close" with xmark icon
- All three buttons use consistent `.bordered` / `.borderedProminent` styling

## Test plan

- [ ] Option+Shift+7: capture area → image copied to clipboard, no preview window
- [ ] Option+Shift+8: capture area → annotation editor opens directly
- [ ] Option+Shift+1: still respects Show Preview / Copy to Clipboard / Auto Save settings
- [ ] New shortcuts appear in Settings → Shortcuts and are configurable
- [ ] Annotation toolbar: Close/Copy/Save buttons clearly visible with icons
- [ ] All labels localized in Chinese