### PR TITLE
[codex] Update README for scrolling capture and screenshot history

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,243 @@
+<p align="right">
+  <a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | <strong>日本語</strong> | <a href="README.ko.md">한국어</a>
+</p>
+
+# Capso
+
+**macOS向けのオープンソースなスクリーンショット＆画面録画ツール**
+
+Swift 6.0 と SwiftUI で構築された、無料・ネイティブな CleanShot X 代替アプリです。macOS 15.0 以降に対応しています。
+
+[![macOS 15+](https://img.shields.io/badge/macOS-15.0%2B-blue)](https://www.apple.com/macos/)
+[![Swift 6.0](https://img.shields.io/badge/Swift-6.0-orange)](https://swift.org)
+[![License: BSL 1.1](https://img.shields.io/badge/License-BSL%201.1-green.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/lzhgus/Capso?style=social)](https://github.com/lzhgus/Capso/stargazers)
+
+<p align="center">
+  <img src=".github/assets/hero.gif" alt="Capso デモ" width="720">
+</p>
+
+<p align="center">
+  <a href="https://github.com/lzhgus/Capso/releases/latest"><strong>ダウンロード &rarr;</strong></a> &nbsp;&bull;&nbsp;
+  <a href="https://www.awesomemacapp.com/app/capso">公式サイト</a> &nbsp;&bull;&nbsp;
+  <a href="#機能">機能</a> &nbsp;&bull;&nbsp;
+  <a href="#ソースからビルド">ソースからビルド</a>
+</p>
+
+---
+
+## ダウンロード
+
+[**GitHub Releases →**](https://github.com/lzhgus/Capso/releases/latest) から、署名・公証済みの最新 DMG を入手できます。
+
+Homebrew でもインストールできます。
+
+```bash
+brew tap lzhgus/tap
+brew install --cask capso
+```
+
+または [ソースからビルド](#ソースからビルド) してください。
+
+> 初回利用時に、画面収録・カメラ・マイクの権限が必要です。アプリが案内を表示します。
+
+---
+
+## なぜオープンソースなのか
+
+macOS のスクリーンショットツールで実用的なものはたいてい有料です。CleanShot X は $29、Cap は $58。どちらも素晴らしいアプリですが、日常的な生産性機能が課金前提である必要はないと考えました。
+
+Capso はその答えです。**完全にネイティブで、機能が充実した無料の代替アプリ**であり、オープンに開発されています。CaptureKit、AnnotationKit、OCRKit などの基盤機能は独立した SPM パッケージとして分割されているため、自分のアプリに組み込むこともできます。
+
+私たちは [他のツール](https://www.awesomemacapp.com/) から収益を得ています。Capso は macOS コミュニティへの還元であり、Swift 6 ベースのモダンでモジュール化されたアプリの実例でもあります。
+
+---
+
+## 機能
+
+### スクリーンショット
+- **範囲キャプチャ** — ドラッグで範囲を選択し、サイズをリアルタイム表示
+- **フルスクリーンキャプチャ** — ワンクリックで画面全体を取得
+- **ウィンドウキャプチャ** — 任意のウィンドウをクリックして取得
+- **スクロールキャプチャ** — 長い Web ページ、チャット、ドキュメントを 1 枚の画像に結合
+- **Quick Access** — コピー・保存・注釈・OCR・ピン留め・ドラッグ&ドロップに対応するフローティングプレビュー
+
+### 画面録画
+- **動画（MP4）** と **GIF** の録画
+- **Webcam PiP** — 4 つの形状（円、正方形、縦長、横長）、ドラッグでリサイズ、角へスナップ
+- **カメラプレゼンテーションモード** — PiP をクリックして全画面表示、もう一度クリックで元に戻る
+- **システム音声 + マイク** の同時録音
+- **録画コントロール** — 一時停止、停止、再開、削除、タイマー
+- **カウントダウンオーバーレイ** — 録画開始前の 3-2-1 カウントダウン
+- **書き出し品質プリセット** — Maximum / Social / Web
+
+### 注釈エディタ
+- 矢印、矩形、楕円、テキスト、フリーハンド、ピクセル化/ぼかし、クロップ
+- ハイライターとカウンター（番号付きマーカー）
+- カラーピッカー、線幅調整、Undo/Redo
+- **スクリーンショット美化** — 背景色、余白、角丸、影
+
+### OCR（文字認識）
+- **Instant OCR** — 範囲選択後、テキストを即クリップボードへコピー
+- **Visual OCR** — 認識領域をハイライト表示し、個別のテキストブロックを選択可能
+
+### スクリーンショット履歴
+- **永続ライブラリ** — スクリーンショット、GIF、録画を 1 か所で閲覧
+- **内蔵アクション** — フィルタ、コピー、保存、Finder で表示、削除を Capso 内で実行
+- **保持期間の管理** — 履歴を自動保存し、保存期間を設定可能
+
+### その他
+- **Pin to Screen** — スクリーンショットを常に前面のウィンドウとして固定表示し、ロック/クリック透過にも対応
+- **グローバルショートカット** — すべての操作を自由に設定可能
+- **環境設定** — Apple Liquid Glass スタイルの包括的な設定画面
+- **ローカライズ** — 英語、簡体字中国語、日本語、韓国語
+
+<p align="center">
+  <img src=".github/assets/annotation.jpeg" alt="注釈エディタ" width="600"><br>
+  <em>描画ツール、カウンター、マーカーを備えた注釈エディタ</em>
+</p>
+
+<p align="center">
+  <img src=".github/assets/beautify.jpeg" alt="スクリーンショット美化" width="600"><br>
+  <em>背景、余白、角丸、影を使ったスクリーンショット美化</em>
+</p>
+
+<p align="center">
+  <img src=".github/assets/recording-pip.jpeg" alt="Webcam PiP 付き画面録画" width="600"><br>
+  <em>Webcam PiP と GIF/動画オプション付きの画面録画</em>
+</p>
+
+さらに多くのスクリーンショットや詳しい紹介は [**Capso 公式サイト →**](https://www.awesomemacapp.com/app/capso) をご覧ください。
+
+---
+
+## 比較
+
+| | CleanShot X | Shottr | Cap | **Capso** |
+|---|---|---|---|---|
+| スクリーンショット | Full | Full | Basic | **Full** |
+| 録画 | Video + GIF | No | Video + GIF | **Video + GIF** |
+| Webcam PiP | Yes | No | Yes | **Yes (4 shapes)** |
+| OCR | Yes | Yes | No | **Yes** |
+| 注釈 | Advanced | Advanced | Basic | **Advanced** |
+| Pin to Screen | Yes | Yes | No | **Yes** |
+| 美化 | Yes | No | Yes | **Yes** |
+| ネイティブ Swift | Yes | Yes | No (Tauri) | **Yes (Swift 6)** |
+| オープンソース | No | No | Partial | **Yes** |
+| 価格 | $29 | $8 | $58 | **Free** |
+
+---
+
+## ソースからビルド
+
+**必要環境:** Xcode 16+、macOS 15.0+、[XcodeGen](https://github.com/yonaskolb/XcodeGen)
+
+```bash
+# XcodeGen をインストール
+brew install xcodegen
+
+# クローンしてビルド
+git clone https://github.com/lzhgus/Capso.git
+cd Capso
+xcodegen generate
+open Capso.xcodeproj
+# Xcode で Cmd+R
+```
+
+コマンドラインからビルドすることもできます。
+
+```bash
+xcodegen generate
+xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Release build
+```
+
+---
+
+## アーキテクチャ
+
+Capso はモジュール化された SPM（Swift Package Manager）構成を採用しています。アプリ本体は薄い SwiftUI + AppKit シェルで、主要機能は 9 個の独立したパッケージに分かれています。
+
+```
+Capso/
+├── App/                     # メインアプリ（薄いシェル）
+│   ├── CapsoApp.swift       # @main エントリポイント
+│   ├── MenuBar/             # メニューバーコントローラ
+│   ├── Capture/             # キャプチャオーバーレイ、ピン留めスクリーンショット
+│   ├── Recording/           # 録画コーディネータ、コントロール、ツールバー
+│   ├── Camera/              # Webcam PiP ウィンドウ
+│   ├── AnnotationEditor/    # 注釈エディタ + 美化
+│   ├── OCR/                 # OCR コーディネータ、オーバーレイ、トースト
+│   ├── History/             # スクリーンショット履歴ウィンドウ
+│   ├── QuickAccess/         # フローティングプレビュー
+│   └── Preferences/         # 設定ウィンドウ
+├── Packages/
+│   ├── SharedKit/           # 設定、権限、ユーティリティ
+│   ├── CaptureKit/          # ScreenCaptureKit ラッパー
+│   ├── RecordingKit/        # 画面録画エンジン
+│   ├── CameraKit/           # AVFoundation ベースのカメラキャプチャ
+│   ├── AnnotationKit/       # 描画 / 注釈システム
+│   ├── OCRKit/              # Vision ベースの OCR
+│   ├── ExportKit/           # 動画 / GIF / 画像の書き出し
+│   ├── EffectsKit/          # カーソルエフェクト、クリックハイライト
+│   └── HistoryKit/          # 永続化されたスクリーンショット / 録画履歴
+└── project.yml              # XcodeGen プロジェクト定義
+```
+
+各パッケージは個別にテストできます。
+
+```bash
+swift test --package-path Packages/SharedKit
+swift test --package-path Packages/AnnotationKit
+# など
+```
+
+このパッケージ分割により、たとえば `CaptureKit` や `AnnotationKit` だけを自分のアプリに組み込むこともできます。Electron や Tauri ベースの代替製品では難しい構成です。
+
+---
+
+## ロードマップ
+
+- スポットライト、拡大鏡、定規、画像オーバーレイなどの注釈ツール
+- テキスト注釈での絵文字・カスタムフォント対応
+- 動画トリマー / エディタ
+- カーソルスムージング（書き出し時のスプリング物理）
+- 録画動画のズームアニメーション
+- 自動化向け URL Scheme API
+- Raycast / Shortcuts 連携
+
+[オープン中の Issue](https://github.com/lzhgus/Capso/issues) で現在の優先事項を、[GitHub Releases](https://github.com/lzhgus/Capso/releases) でリリース履歴を確認できます。コントリビューション歓迎です。
+
+---
+
+## コントリビュート
+
+開発環境やガイドラインについては [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。
+
+---
+
+## ライセンス
+
+Capso は [Business Source License 1.1](LICENSE) のもとで提供されています。
+
+**要点:**
+
+| やりたいこと | 可能? |
+|---|---|
+| 個人利用 | ✅ |
+| 会社内での利用 | ✅ |
+| ソースを読んで修正・ビルド | ✅ |
+| Fork して無料の派生版を配布 | ✅ |
+| Fork して競合する商用スクリーンキャプチャ製品を販売 | ❌ |
+| 2029-04-08 以降のあらゆる利用 | ✅ Apache 2.0 に移行 |
+
+各バージョンは公開から 3 年後に Apache 2.0 へ自動移行し、完全に寛容なオープンソースライセンスになります。
+
+---
+
+## サポート
+
+- [バグを報告する](https://github.com/lzhgus/Capso/issues/new?template=bug_report.yml)
+- [機能を提案する](https://github.com/lzhgus/Capso/issues/new?template=feature_request.yml)
+- [GitHub Sponsors](https://github.com/sponsors/lzhgus) — Capso が役立ったら、開発支援をご検討ください
+
+[Awesome Mac Apps](https://www.awesomemacapp.com/) により開発されています。ほかの macOS ツールもぜひご覧ください。

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,243 @@
+<p align="right">
+  <a href="README.md">English</a> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.ja.md">日本語</a> | <strong>한국어</strong>
+</p>
+
+# Capso
+
+**macOS를 위한 오픈소스 스크린샷 및 화면 녹화 도구**
+
+Swift 6.0과 SwiftUI로 만든 무료 네이티브 CleanShot X 대안입니다. macOS 15.0 이상을 지원합니다.
+
+[![macOS 15+](https://img.shields.io/badge/macOS-15.0%2B-blue)](https://www.apple.com/macos/)
+[![Swift 6.0](https://img.shields.io/badge/Swift-6.0-orange)](https://swift.org)
+[![License: BSL 1.1](https://img.shields.io/badge/License-BSL%201.1-green.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/lzhgus/Capso?style=social)](https://github.com/lzhgus/Capso/stargazers)
+
+<p align="center">
+  <img src=".github/assets/hero.gif" alt="Capso 데모" width="720">
+</p>
+
+<p align="center">
+  <a href="https://github.com/lzhgus/Capso/releases/latest"><strong>다운로드 &rarr;</strong></a> &nbsp;&bull;&nbsp;
+  <a href="https://www.awesomemacapp.com/app/capso">웹사이트</a> &nbsp;&bull;&nbsp;
+  <a href="#기능">기능</a> &nbsp;&bull;&nbsp;
+  <a href="#소스에서-빌드하기">소스에서 빌드하기</a>
+</p>
+
+---
+
+## 다운로드
+
+[**GitHub Releases →**](https://github.com/lzhgus/Capso/releases/latest) 에서 최신 서명 및 공증 완료 DMG를 내려받을 수 있습니다.
+
+또는 Homebrew로 설치할 수 있습니다.
+
+```bash
+brew tap lzhgus/tap
+brew install --cask capso
+```
+
+또는 [소스에서 직접 빌드](#소스에서-빌드하기) 할 수 있습니다.
+
+> 화면 녹화, 카메라, 마이크 권한이 필요합니다. 처음 사용할 때 앱이 안내합니다.
+
+---
+
+## 왜 오픈소스인가요?
+
+쓸 만한 macOS 스크린샷 도구는 대부분 유료입니다. CleanShot X는 $29, Cap은 $58입니다. 둘 다 훌륭한 앱이지만, 이런 핵심 생산성 기능이 꼭 유료여야 할 이유는 없다고 생각했습니다.
+
+Capso는 그에 대한 우리의 답입니다. **완전한 네이티브 경험과 풍부한 기능을 제공하는 무료 대안**이며, 공개적으로 개발됩니다. CaptureKit, AnnotationKit, OCRKit 같은 핵심 기능은 독립적인 SPM 패키지로 구성되어 있어 여러분의 앱에도 그대로 가져다 쓸 수 있습니다.
+
+우리는 [다른 도구들](https://www.awesomemacapp.com/) 로 수익을 얻고 있습니다. Capso는 macOS 커뮤니티에 대한 환원이자, 현대적인 Swift 6 모듈형 앱이 어떤 모습일 수 있는지 보여주는 예시입니다.
+
+---
+
+## 기능
+
+### 스크린샷
+- **영역 캡처** — 드래그로 영역 선택, 크기 실시간 표시
+- **전체 화면 캡처** — 한 번의 클릭으로 전체 화면 캡처
+- **윈도우 캡처** — 원하는 윈도우를 클릭해 캡처
+- **스크롤 캡처** — 긴 웹페이지, 채팅 스레드, 문서를 한 장의 이미지로 이어 붙이기
+- **Quick Access** — 복사, 저장, 주석, OCR, 핀 고정, 드래그 앤 드롭을 지원하는 플로팅 미리보기
+
+### 화면 녹화
+- **비디오(MP4)** 및 **GIF** 녹화
+- **웹캠 PiP** — 4가지 형태(원형, 사각형, 세로형, 가로형), 드래그 리사이즈, 모서리 스냅
+- **카메라 프레젠테이션 모드** — PiP를 클릭해 전체 화면으로 확장하고 다시 클릭해 복원
+- **시스템 오디오 + 마이크** 동시 녹음
+- **녹화 컨트롤** — 일시정지, 정지, 다시 시작, 삭제, 타이머
+- **카운트다운 오버레이** — 녹화 시작 전 3-2-1 카운트다운
+- **내보내기 품질 프리셋** — Maximum, Social, Web
+
+### 주석 편집기
+- 화살표, 사각형, 타원, 텍스트, 자유 그리기, 픽셀화/블러, 자르기
+- 하이라이터와 카운터(번호 마커) 도구
+- 색상 선택기, 선 두께 조절, 실행 취소/다시 실행
+- **스크린샷 꾸미기** — 배경색, 여백, 둥근 모서리, 그림자
+
+### OCR(텍스트 인식)
+- **Instant OCR** — 영역 선택 후 텍스트를 즉시 클립보드로 복사
+- **Visual OCR** — 인식된 텍스트 영역을 하이라이트하고 개별 블록을 선택 가능
+
+### 스크린샷 히스토리
+- **영구 라이브러리** — 스크린샷, GIF, 녹화본을 한 곳에서 탐색
+- **내장 액션** — 필터링, 복사, 저장, Finder에서 보기, 삭제를 Capso 안에서 바로 수행
+- **보관 정책 제어** — 히스토리를 자동 저장하고 보관 기간을 설정 가능
+
+### 기타
+- **Pin to Screen** — 스크린샷을 항상 위에 떠 있는 창으로 고정하고 잠금/클릭 통과도 지원
+- **전역 단축키** — 모든 작업을 자유롭게 설정 가능
+- **환경설정** — Apple Liquid Glass 스타일의 종합 설정 화면
+- **현지화** — 영어, 중국어 간체, 일본어, 한국어
+
+<p align="center">
+  <img src=".github/assets/annotation.jpeg" alt="주석 편집기" width="600"><br>
+  <em>그리기 도구, 카운터, 마커를 갖춘 주석 편집기</em>
+</p>
+
+<p align="center">
+  <img src=".github/assets/beautify.jpeg" alt="스크린샷 꾸미기" width="600"><br>
+  <em>배경, 여백, 모서리, 그림자를 이용한 스크린샷 꾸미기</em>
+</p>
+
+<p align="center">
+  <img src=".github/assets/recording-pip.jpeg" alt="웹캠 PiP 화면 녹화" width="600"><br>
+  <em>웹캠 PiP와 GIF/비디오 옵션을 지원하는 화면 녹화</em>
+</p>
+
+더 많은 스크린샷과 전체 소개는 [**Capso 웹사이트 →**](https://www.awesomemacapp.com/app/capso) 에서 확인할 수 있습니다.
+
+---
+
+## 비교
+
+| | CleanShot X | Shottr | Cap | **Capso** |
+|---|---|---|---|---|
+| 스크린샷 | Full | Full | Basic | **Full** |
+| 녹화 | Video + GIF | No | Video + GIF | **Video + GIF** |
+| Webcam PiP | Yes | No | Yes | **Yes (4 shapes)** |
+| OCR | Yes | Yes | No | **Yes** |
+| 주석 | Advanced | Advanced | Basic | **Advanced** |
+| Pin to Screen | Yes | Yes | No | **Yes** |
+| 꾸미기 | Yes | No | Yes | **Yes** |
+| 네이티브 Swift | Yes | Yes | No (Tauri) | **Yes (Swift 6)** |
+| 오픈소스 | No | No | Partial | **Yes** |
+| 가격 | $29 | $8 | $58 | **Free** |
+
+---
+
+## 소스에서 빌드하기
+
+**요구 사항:** Xcode 16+, macOS 15.0+, [XcodeGen](https://github.com/yonaskolb/XcodeGen)
+
+```bash
+# XcodeGen 설치
+brew install xcodegen
+
+# 클론 후 빌드
+git clone https://github.com/lzhgus/Capso.git
+cd Capso
+xcodegen generate
+open Capso.xcodeproj
+# Xcode에서 Cmd+R
+```
+
+명령줄에서도 빌드할 수 있습니다.
+
+```bash
+xcodegen generate
+xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Release build
+```
+
+---
+
+## 아키텍처
+
+Capso는 모듈형 SPM(Swift Package Manager) 아키텍처를 사용합니다. 앱 자체는 얇은 SwiftUI + AppKit 셸이고, 핵심 기능은 9개의 독립 패키지에 들어 있습니다.
+
+```
+Capso/
+├── App/                     # 메인 앱 타깃(얇은 셸)
+│   ├── CapsoApp.swift       # @main 엔트리 포인트
+│   ├── MenuBar/             # 메뉴바 컨트롤러
+│   ├── Capture/             # 캡처 오버레이, 핀 고정 스크린샷
+│   ├── Recording/           # 녹화 코디네이터, 컨트롤, 툴바
+│   ├── Camera/              # 웹캠 PiP 창
+│   ├── AnnotationEditor/    # 주석 편집기 + 꾸미기
+│   ├── OCR/                 # OCR 코디네이터, 오버레이, 토스트
+│   ├── History/             # 스크린샷 히스토리 창
+│   ├── QuickAccess/         # 플로팅 미리보기 창
+│   └── Preferences/         # 설정 창
+├── Packages/
+│   ├── SharedKit/           # 설정, 권한, 유틸리티
+│   ├── CaptureKit/          # ScreenCaptureKit 래퍼
+│   ├── RecordingKit/        # 화면 녹화 엔진
+│   ├── CameraKit/           # AVFoundation 웹캠 캡처
+│   ├── AnnotationKit/       # 그리기/주석 시스템
+│   ├── OCRKit/              # Vision 기반 OCR
+│   ├── ExportKit/           # 비디오/GIF/이미지 내보내기
+│   ├── EffectsKit/          # 커서 효과, 클릭 하이라이트
+│   └── HistoryKit/          # 영구 스크린샷/녹화 히스토리
+└── project.yml              # XcodeGen 프로젝트 정의
+```
+
+각 패키지는 독립적으로 테스트할 수 있습니다.
+
+```bash
+swift test --package-path Packages/SharedKit
+swift test --package-path Packages/AnnotationKit
+# 등등
+```
+
+이런 패키지 분리는 `CaptureKit`이나 `AnnotationKit`만 별도로 여러분의 앱에 넣을 수 있게 해 줍니다. 이는 Electron이나 Tauri 기반 대안과 차별화되는 점입니다.
+
+---
+
+## 로드맵
+
+- 스포트라이트, 돋보기, 자, 이미지 오버레이 등 추가 주석 도구
+- 텍스트 주석에서 이모지와 사용자 지정 폰트 지원
+- 비디오 트리머/편집기
+- 커서 스무딩(내보내기 시 스프링 물리)
+- 녹화 비디오 확대 애니메이션
+- 자동화를 위한 URL 스킴 API
+- Raycast / Shortcuts 연동
+
+[오픈 이슈](https://github.com/lzhgus/Capso/issues) 에서 현재 우선순위를, [GitHub Releases](https://github.com/lzhgus/Capso/releases) 에서 버전 히스토리를 확인할 수 있습니다. 기여를 환영합니다.
+
+---
+
+## 기여하기
+
+개발 환경과 가이드라인은 [CONTRIBUTING.md](CONTRIBUTING.md) 를 참고하세요.
+
+---
+
+## 라이선스
+
+Capso는 [Business Source License 1.1](LICENSE) 로 배포됩니다.
+
+**요약:**
+
+| 하고 싶은 일 | 가능 여부 |
+|---|---|
+| 개인적으로 사용 | ✅ |
+| 회사 내부에서 사용 | ✅ |
+| 소스를 읽고 수정하고 빌드 | ✅ |
+| 포크해서 무료 파생판 배포 | ✅ |
+| 포크해서 경쟁 상용 캡처 제품 판매 | ❌ |
+| 2029-04-08 이후 모든 사용 | ✅ Apache 2.0으로 전환 |
+
+각 버전은 공개 후 3년이 지나면 Apache 2.0으로 자동 전환되어 완전한 퍼미시브 오픈소스가 됩니다.
+
+---
+
+## 지원
+
+- [버그 신고](https://github.com/lzhgus/Capso/issues/new?template=bug_report.yml)
+- [기능 요청](https://github.com/lzhgus/Capso/issues/new?template=feature_request.yml)
+- [GitHub Sponsors](https://github.com/sponsors/lzhgus) — Capso가 도움이 되었다면 개발 후원을 고려해 주세요
+
+[Awesome Mac Apps](https://www.awesomemacapp.com/) 에서 만들었습니다. 다른 macOS 도구도 확인해 보세요.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ We make our money from [other tools](https://www.awesomemacapp.com/). Capso exis
 - **Area capture** — drag to select with dimension display
 - **Fullscreen capture** — one-click full screen
 - **Window capture** — click any window to capture
+- **Scrolling capture** — capture long webpages, chat threads, and documents into one stitched image
 - **Quick Access** — floating preview with copy, save, annotate, OCR, pin, and drag-and-drop
 
 ### Screen Recording
@@ -79,6 +80,11 @@ We make our money from [other tools](https://www.awesomemacapp.com/). Capso exis
 ### OCR (Text Recognition)
 - **Instant OCR** — select area, text copied to clipboard
 - **Visual OCR** — highlighted text regions, click to select individual blocks
+
+### Screenshot History
+- **Persistent library** — browse screenshots, GIFs, and recordings in one place
+- **Built-in actions** — filter captures, copy, save, show in Finder, and delete without leaving Capso
+- **Retention controls** — keep history automatically and choose how long entries stay around
 
 ### More
 - **Pin to Screen** — float screenshots as always-on-top windows with lock/click-through mode
@@ -149,7 +155,7 @@ xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Release build
 
 ## Architecture
 
-Capso uses a modular SPM (Swift Package Manager) architecture. The app is a thin SwiftUI + AppKit shell; all core capabilities live in 8 independent packages.
+Capso uses a modular SPM (Swift Package Manager) architecture. The app is a thin SwiftUI + AppKit shell; all core capabilities live in 9 independent packages.
 
 ```
 Capso/
@@ -161,6 +167,7 @@ Capso/
 │   ├── Camera/              # Webcam PiP window
 │   ├── AnnotationEditor/    # Annotation editor + beautify
 │   ├── OCR/                 # OCR coordinator, overlay, toast
+│   ├── History/             # Screenshot history window
 │   ├── QuickAccess/         # Floating preview window
 │   └── Preferences/         # Settings window
 ├── Packages/
@@ -171,7 +178,8 @@ Capso/
 │   ├── AnnotationKit/       # Drawing/annotation system
 │   ├── OCRKit/              # Vision framework OCR
 │   ├── ExportKit/           # Video/GIF/image export
-│   └── EffectsKit/          # Cursor effects, click highlights
+│   ├── EffectsKit/          # Cursor effects, click highlights
+│   └── HistoryKit/          # Persistent screenshot/recording history
 └── project.yml              # XcodeGen project definition
 ```
 
@@ -191,11 +199,9 @@ The package split means you can embed, for example, `CaptureKit` or `AnnotationK
 
 - Spotlight, magnifier, ruler, image overlay annotation tools
 - Emoji support and custom fonts in text annotations
-- Screenshot history browser
 - Video trimmer/editor
 - Cursor smoothing (spring-physics during export)
 - Zoom animation on recorded video
-- Scrolling capture (Accessibility API + Vision stitching)
 - URL scheme API for automation
 - Raycast / Shortcuts integration
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="right">
-  <strong>English</strong> | <a href="README.zh-CN.md">简体中文</a>
+  <strong>English</strong> | <a href="README.zh-CN.md">简体中文</a> | <a href="README.ja.md">日本語</a> | <a href="README.ko.md">한국어</a>
 </p>
 
 # Capso

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,5 @@
 <p align="right">
-  <a href="README.md">English</a> | <strong>简体中文</strong>
+  <a href="README.md">English</a> | <strong>简体中文</strong> | <a href="README.ja.md">日本語</a> | <a href="README.ko.md">한국어</a>
 </p>
 
 # Capso

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -61,6 +61,7 @@ brew install --cask capso
 - **区域截图**：拖拽选择，实时显示尺寸
 - **全屏截图**：一键捕获整个屏幕
 - **窗口截图**：点击任意窗口即可捕获
+- **滚动截图**：将长网页、聊天记录、文档内容拼接成一张完整长图
 - **快速操作**：浮动预览窗口，支持复制、保存、标注、OCR、钉住、拖放
 
 ### 录屏
@@ -81,6 +82,11 @@ brew install --cask capso
 ### OCR 文字识别
 - **即时 OCR**：选择区域后文字自动复制到剪贴板
 - **可视化 OCR**：高亮显示识别区域，点击选择单个文本块
+
+### 截图历史
+- **持久化记录**：在一个窗口中统一浏览截图、GIF 和录屏记录
+- **内置快捷操作**：支持筛选、复制、保存、在 Finder 中显示、删除
+- **保留策略控制**：可自动保存历史，并设置记录保留时长
 
 ### 更多
 - **钉到屏幕**：将截图悬浮为置顶窗口，支持锁定和穿透点击模式
@@ -151,7 +157,7 @@ xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Release build
 
 ## 架构
 
-Capso 采用模块化的 SPM 架构。App 本身是一个很薄的 SwiftUI + AppKit 壳层，核心能力分布在 8 个独立的包中。
+Capso 采用模块化的 SPM 架构。App 本身是一个很薄的 SwiftUI + AppKit 壳层，核心能力分布在 9 个独立的包中。
 
 ```
 Capso/
@@ -163,6 +169,7 @@ Capso/
 │   ├── Camera/              # 摄像头画中画
 │   ├── AnnotationEditor/    # 标注编辑器 + 美化
 │   ├── OCR/                 # 文字识别
+│   ├── History/             # 截图历史窗口
 │   ├── QuickAccess/         # 快速操作浮窗
 │   └── Preferences/         # 设置
 ├── Packages/
@@ -173,7 +180,8 @@ Capso/
 │   ├── AnnotationKit/       # 绘制/标注系统
 │   ├── OCRKit/              # Vision 框架 OCR
 │   ├── ExportKit/           # 视频/GIF/图片导出
-│   └── EffectsKit/          # 光标特效
+│   ├── EffectsKit/          # 光标特效
+│   └── HistoryKit/          # 持久化截图/录屏历史
 └── project.yml              # XcodeGen 项目定义
 ```
 
@@ -193,11 +201,9 @@ swift test --package-path Packages/AnnotationKit
 
 - 聚光灯、放大镜、标尺、图片叠加等标注工具
 - 文字标注支持 Emoji 和自定义字体
-- 截图历史浏览器
 - 视频剪辑编辑器
 - 光标平滑（弹簧物理）
 - 录制视频的缩放动画
-- 滚动截图（辅助功能 API + Vision 拼接）
 - URL Scheme API
 - Raycast / 快捷指令集成
 


### PR DESCRIPTION
## Summary

This PR updates the README to reflect two features that are already shipped:
- scrolling capture
- screenshot history

It also fixes the architecture section so the documented module layout matches the current app structure.

## What changed

- added **Scrolling capture** to the screenshot feature list
- added a new **Screenshot History** section describing the shipped history window
- removed scrolling capture and screenshot history from the roadmap
- updated the architecture section from 8 packages to 9 packages
- added `History/` and `HistoryKit/` to the architecture tree
- synced the same updates in both:
  - `README.md`
  - `README.zh-CN.md`

## Why it changed

The README still described these features as future roadmap items, which no longer matched the product.

## Impact

- users browsing the repo now see the current feature set more accurately
- English and Simplified Chinese documentation stay in sync
- the architecture section now reflects the actual history modules in the app

## Validation

- reviewed the README diff for both language variants

## Notes

This is a docs-only PR. No app code was changed.
