### PR TITLE
Add Product Hunt badge to all READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -14,6 +14,10 @@ Swift 6.0 と SwiftUI で構築された、無料・ネイティブな CleanShot
 [![GitHub stars](https://img.shields.io/github/stars/lzhgus/Capso?style=social)](https://github.com/lzhgus/Capso/stargazers)
 
 <p align="center">
+  <a href="https://www.producthunt.com/products/capso?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-capso" target="_blank" rel="noopener noreferrer"><img alt="Capso - Free open-source screenshot &amp; screen recorder for Mac | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1120330&theme=light&period=daily&t=1776201173308"></a>
+</p>
+
+<p align="center">
   <img src=".github/assets/hero.gif" alt="Capso デモ" width="720">
 </p>
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -14,6 +14,10 @@ Swift 6.0과 SwiftUI로 만든 무료 네이티브 CleanShot X 대안입니다. 
 [![GitHub stars](https://img.shields.io/github/stars/lzhgus/Capso?style=social)](https://github.com/lzhgus/Capso/stargazers)
 
 <p align="center">
+  <a href="https://www.producthunt.com/products/capso?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-capso" target="_blank" rel="noopener noreferrer"><img alt="Capso - Free open-source screenshot &amp; screen recorder for Mac | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1120330&theme=light&period=daily&t=1776201173308"></a>
+</p>
+
+<p align="center">
   <img src=".github/assets/hero.gif" alt="Capso 데모" width="720">
 </p>
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ A native, feature-rich alternative to CleanShot X. Built with Swift 6.0 and Swif
 [![GitHub stars](https://img.shields.io/github/stars/lzhgus/Capso?style=social)](https://github.com/lzhgus/Capso/stargazers)
 
 <p align="center">
+  <a href="https://www.producthunt.com/products/capso?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-capso" target="_blank" rel="noopener noreferrer"><img alt="Capso - Free open-source screenshot &amp; screen recorder for Mac | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1120330&theme=light&period=daily&t=1776201173308"></a>
+</p>
+
+<p align="center">
   <img src=".github/assets/hero.gif" alt="Capso Demo" width="720">
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,6 +14,10 @@
 [![GitHub stars](https://img.shields.io/github/stars/lzhgus/Capso?style=social)](https://github.com/lzhgus/Capso/stargazers)
 
 <p align="center">
+  <a href="https://www.producthunt.com/products/capso?embed=true&utm_source=badge-top-post-badge&utm_medium=badge&utm_campaign=badge-capso" target="_blank" rel="noopener noreferrer"><img alt="Capso - Free open-source screenshot &amp; screen recorder for Mac | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/top-post-badge.svg?post_id=1120330&theme=light&period=daily&t=1776201173308"></a>
+</p>
+
+<p align="center">
   <img src=".github/assets/hero.gif" alt="Capso 演示" width="720">
 </p>
 


### PR DESCRIPTION
## Summary
- Add centered Product Hunt "#3 Product of the Day" badge to all four README files (EN, ZH-CN, JA, KO)
- Badge is placed between the shield badges and the hero GIF, wrapped in `<p align="center">` for consistent centering

## Test plan
- [x] Verify badge renders correctly on GitHub for each README
- [x] Confirm badge links to the correct Product Hunt page

🤖 Generated with [Claude Code](https://claude.com/claude-code)