### PR TITLE
Add feedback & GitHub links to Settings

### DIFF
--- a/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
@@ -1,6 +1,7 @@
 // App/Sources/Preferences/Tabs/GeneralSettingsView.swift
 import SwiftUI
 import LaunchAtLogin
+import AppKit
 
 struct GeneralSettingsView: View {
     @Bindable var viewModel: PreferencesViewModel
@@ -31,7 +32,7 @@ struct GeneralSettingsView: View {
                 }
             }
 
-            SettingGroup(title: "Feedback") {
+            SettingGroup(title: "Sound") {
                 SettingCard {
                     SettingRow(label: "Shutter Sound", sublabel: "Play sound after capture") {
                         Toggle("", isOn: $viewModel.playShutterSound)
@@ -78,10 +79,62 @@ struct GeneralSettingsView: View {
                             .foregroundStyle(.tertiary)
                             .fontDesign(.monospaced)
                     }
+                    SettingRow(label: "Report a Bug", sublabel: "Found something broken?", showDivider: true) {
+                        ExternalLinkButton(title: "Report", icon: "ladybug") {
+                            openURL("https://github.com/lzhgus/Capso/issues/new?template=bug_report.yml&labels=bug")
+                        }
+                    }
+                    SettingRow(label: "Request a Feature", sublabel: "Have an idea?", showDivider: true) {
+                        ExternalLinkButton(title: "Request", icon: "lightbulb") {
+                            openURL("https://github.com/lzhgus/Capso/issues/new?template=feature_request.yml&labels=enhancement")
+                        }
+                    }
+                    SettingRow(label: "Source Code", sublabel: "View on GitHub", showDivider: true) {
+                        ExternalLinkButton(title: "Open", icon: "chevron.left.forwardslash.chevron.right") {
+                            openURL("https://github.com/lzhgus/Capso")
+                        }
+                    }
                 }
             }
         }
     }
 
+    private func openURL(_ string: String) {
+        guard let url = URL(string: string) else { return }
+        NSWorkspace.shared.open(url)
+    }
+}
 
+private struct ExternalLinkButton: View {
+    let title: String
+    let icon: String
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.system(size: 10))
+                Text(title)
+                    .font(.system(size: 12))
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: 8, weight: .bold))
+                    .opacity(0.6)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(isHovered ? Color.white.opacity(0.1) : Color.white.opacity(0.05))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 5)
+                    .stroke(Color.white.opacity(0.12), lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .onHover { isHovered = $0 }
+    }
 }


### PR DESCRIPTION
## Summary
- Adds "Report a Bug", "Request a Feature", and "Source Code" links to **Settings > General > About** section
- Each link opens the corresponding GitHub Issue template or repo page via `NSWorkspace`
- Introduces a reusable `ExternalLinkButton` component with hover state and external-link indicator
- Renames the misleading "Feedback" setting group to "Sound" (it only contains the shutter sound toggle)

Closes #25

## Test plan
- [x] Open Settings > General, scroll to "About" section
- [x] Verify "Report a Bug" opens `https://github.com/lzhgus/Capso/issues/new?template=bug_report.yml&labels=bug`
- [x] Verify "Request a Feature" opens `https://github.com/lzhgus/Capso/issues/new?template=feature_request.yml&labels=enhancement`
- [x] Verify "Source Code" opens `https://github.com/lzhgus/Capso`
- [x] Verify hover states on all three buttons
- [x] Confirm "Sound" group header replaces old "Feedback" header


<img width="926" height="472" alt="image" src="https://github.com/user-attachments/assets/30e0b4df-c818-4583-b888-c07f890213a4" />
