### PR TITLE
fix: initialize area capture cursor correctly

### DIFF
--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -17,7 +17,7 @@ final class CaptureOverlayView: NSView {
     private var isDragging = false
     private var dragStart: NSPoint = .zero
     private var dragEnd: NSPoint = .zero
-    private var currentMouseLocation: NSPoint = .zero
+    private var currentMouseLocation: NSPoint?
 
     // Window selection state
     private var hoveredWindowID: CGWindowID?
@@ -63,7 +63,16 @@ final class CaptureOverlayView: NSView {
         dragStart = .zero
         dragEnd = .zero
         hoveredWindowID = nil
+        currentMouseLocation = nil
         needsDisplay = true
+    }
+
+    /// Prepare the overlay after the window is on-screen and key so the
+    /// cursor/reticle are initialized from the current mouse position instead
+    /// of waiting for the first mouse-moved event.
+    func prepareForPresentation() {
+        syncCurrentMouseLocation()
+
         // Only hide cursor in area mode — we draw our own crosshair reticle.
         // In window selection mode, keep the normal cursor visible so
         // the user can see where they're pointing.
@@ -75,6 +84,10 @@ final class CaptureOverlayView: NSView {
         } else {
             restoreCursorIfNeeded()
         }
+
+        window?.invalidateCursorRects(for: self)
+        needsDisplay = true
+        displayIfNeeded()
     }
 
     /// Restore cursor if hidden — safe to call multiple times
@@ -87,6 +100,26 @@ final class CaptureOverlayView: NSView {
 
     private func restoreCursor() {
         restoreCursorIfNeeded()
+    }
+
+    /// Seed the reticle from the current pointer location so area capture
+    /// starts with the crosshair under the cursor even before the first
+    /// mouse-moved event arrives.
+    private func syncCurrentMouseLocation() {
+        guard let window else {
+            currentMouseLocation = nil
+            return
+        }
+
+        let screenLocation = NSEvent.mouseLocation
+        guard let screenFrame = window.screen?.frame,
+              screenFrame.contains(screenLocation) else {
+            currentMouseLocation = nil
+            return
+        }
+
+        let windowPoint = window.convertPoint(fromScreen: screenLocation)
+        currentMouseLocation = convert(windowPoint, from: nil)
     }
 
     func setMode(_ mode: CaptureOverlayMode) {
@@ -151,11 +184,15 @@ final class CaptureOverlayView: NSView {
             context.restoreGState()
 
             drawDimensionLabel(for: selectionRect, in: context)
-            drawReticle(at: currentMouseLocation, in: context)
+            if let currentMouseLocation {
+                drawReticle(at: currentMouseLocation, in: context)
+            }
         } else {
             // Before dragging: fully transparent, just crosshair
-            drawReticle(at: currentMouseLocation, in: context)
-            drawCoordinateLabel(at: currentMouseLocation, in: context)
+            if let currentMouseLocation {
+                drawReticle(at: currentMouseLocation, in: context)
+                drawCoordinateLabel(at: currentMouseLocation, in: context)
+            }
         }
     }
 
@@ -265,10 +302,10 @@ final class CaptureOverlayView: NSView {
     }
 
     /// Draw a small crosshair reticle at the cursor position.
-    /// Short arms (~18px) with a gap in the center — no full-screen lines.
+    /// Short arms (~12px) with a gap in the center — no full-screen lines.
     private func drawReticle(at point: NSPoint, in context: CGContext) {
-        let armLength: CGFloat = 20
-        let gap: CGFloat = 4
+        let armLength: CGFloat = 12
+        let gap: CGFloat = 2.5
 
         // Draw each arm with dark outline + white fill for visibility on any background
         let arms: [(CGPoint, CGPoint)] = [
@@ -280,7 +317,7 @@ final class CaptureOverlayView: NSView {
 
         // Dark outline (draw first, thicker)
         context.setStrokeColor(NSColor.black.withAlphaComponent(0.5).cgColor)
-        context.setLineWidth(3.0)
+        context.setLineWidth(2.5)
         for (start, end) in arms {
             context.move(to: start)
             context.addLine(to: end)
@@ -289,7 +326,7 @@ final class CaptureOverlayView: NSView {
 
         // White fill (draw on top, thinner)
         context.setStrokeColor(NSColor.white.cgColor)
-        context.setLineWidth(1.5)
+        context.setLineWidth(1.25)
         for (start, end) in arms {
             context.move(to: start)
             context.addLine(to: end)
@@ -395,14 +432,18 @@ final class CaptureOverlayView: NSView {
         case .area:
             break
         case .windowSelection:
-            let screenPoint = viewPointToScreenPoint(currentMouseLocation)
-            if let window = windowUnderCursor(at: screenPoint) {
-                hoveredWindowID = window.id
-                hoveredWindowFrame = window.frame
-                if window.appName.isEmpty || window.title == window.appName {
-                    hoveredWindowName = window.title
+            if let currentMouseLocation {
+                let screenPoint = viewPointToScreenPoint(currentMouseLocation)
+                if let window = windowUnderCursor(at: screenPoint) {
+                    hoveredWindowID = window.id
+                    hoveredWindowFrame = window.frame
+                    if window.appName.isEmpty || window.title == window.appName {
+                        hoveredWindowName = window.title
+                    } else {
+                        hoveredWindowName = "\(window.appName) — \(window.title)"
+                    }
                 } else {
-                    hoveredWindowName = "\(window.appName) — \(window.title)"
+                    hoveredWindowID = nil
                 }
             } else {
                 hoveredWindowID = nil
@@ -438,8 +479,9 @@ final class CaptureOverlayView: NSView {
 
     private func cancelCurrentSelection() {
         isDragging = false
-        dragStart = currentMouseLocation
-        dragEnd = currentMouseLocation
+        let currentLocation = currentMouseLocation ?? .zero
+        dragStart = currentLocation
+        dragEnd = currentLocation
         needsDisplay = true
     }
 

--- a/App/Sources/Capture/CaptureOverlayWindow.swift
+++ b/App/Sources/Capture/CaptureOverlayWindow.swift
@@ -36,7 +36,7 @@ final class CaptureOverlayWindow: NSPanel {
             perform(preventsActivationSel, with: NSNumber(value: true))
         }
 
-        overlayView = CaptureOverlayView(frame: screen.frame)
+        overlayView = CaptureOverlayView(frame: NSRect(origin: .zero, size: screen.frame.size))
         overlayView.onSelectionComplete = { [weak self] rect in
             guard let self, let screen = self.screen else { return }
             self.onAreaSelected?(rect, screen)
@@ -58,11 +58,6 @@ final class CaptureOverlayWindow: NSPanel {
         overlayView.setMode(mode)
         overlayView.resetSelection()
 
-        // Force synchronous render BEFORE showing the window.
-        // This eliminates the flash — the first visible frame already
-        // has the frozen image + dark overlay drawn.
-        overlayView.displayIfNeeded()
-
         // Show the window. Non-activating panel won't activate our app.
         orderFrontRegardless()
 
@@ -70,6 +65,11 @@ final class CaptureOverlayWindow: NSPanel {
         // On a .nonactivatingPanel, makeKey() does NOT activate the app.
         makeKey()
         makeFirstResponder(overlayView)
+
+        // Prime the reticle/cursor only after the window is visible and key.
+        // Doing this earlier can leave the first frame using a stale or zero
+        // cursor position until the user moves the mouse.
+        overlayView.prepareForPresentation()
 
         // Also install global ESC monitor as fallback
         // (in case the window doesn't receive key events)


### PR DESCRIPTION
## Summary

This PR fixes area capture cursor initialization so keyboard-triggered capture starts in the correct visual state.

It addresses the cases where:
- the normal select pointer could remain visible at first
- the custom crosshair could briefly appear in the lower-left corner
- moving the mouse would then "fix" the cursor position

It also makes the custom capture reticle a bit smaller so it feels lighter during area selection.

## What changed

- moved capture cursor / reticle priming to a post-presentation step after the overlay window is visible and key
- changed the overlay view to use zero-based local coordinates instead of a screen-frame-based view frame
- seeded the initial mouse location by converting the live screen cursor position through the active overlay window
- kept the custom reticle approach, but reduced its size slightly
- kept the existing non-activating overlay behavior so target-app popovers and menus are not dismissed during capture

## Why it changed

Area capture was being initialized too early.

The overlay tried to establish cursor state before the panel was fully presented, and the view itself was created in screen-frame coordinates instead of a local window coordinate space. That made the first rendered state unreliable until a later mouse-moved event corrected it.

## Impact

### User impact
- area capture should now open with the custom crosshair already positioned under the current cursor
- the crosshair should no longer jump to the lower-left corner on first frame
- the reticle is slightly smaller and less visually heavy

### Developer impact
- capture cursor initialization now happens in a clearer lifecycle step instead of being mixed into pre-presentation reset logic
- overlay coordinate handling is more correct and easier to reason about

## Root cause

The first-frame capture cursor state depended on pre-presentation setup and an incorrect view coordinate basis:
- `resetSelection()` was trying to initialize cursor state too early
- the overlay view was created with `screen.frame` rather than a local zero-origin frame
- the first reliable correction only arrived after mouse movement

## Validation

- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build`

## Notes

- `xcodebuild test -project Capso.xcodeproj -scheme Capso -configuration Debug` is not currently runnable because the `Capso` scheme has no test action configured.
- manual verification is still recommended for hotkey-triggered area capture and multi-display behavior.
