### PR TITLE
Fix About window not appearing frontmost

### DIFF
--- a/App/Sources/MenuBar/MenuBarController.swift
+++ b/App/Sources/MenuBar/MenuBarController.swift
@@ -119,6 +119,7 @@ final class MenuBarController: NSObject {
     }
 
     @objc private func openAbout() {
+        NSApp.activate()
         NSApp.orderFrontStandardAboutPanel(nil)
     }
 


### PR DESCRIPTION
## Summary
- Activate the app before showing the standard About panel so it appears as the frontmost window
- Menu-bar-only apps don't automatically become active, so the About panel was hidden behind other windows

Fixes #53

## Test plan
- [x] Click the menu bar icon → "About Capso" and verify the About window appears on top
- [x] Repeat while other apps (e.g. Safari, Terminal) are focused — window should still appear frontmost

🤖 Generated with [Claude Code](https://claude.com/claude-code)