### PR TITLE
feat: predefined capture sizes & aspect ratios for area capture

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -243,6 +243,20 @@
         }
       }
     },
+    "Add" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "追加" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "추가" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "添加" } }
+      }
+    },
+    "Add Custom Preset" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "カスタムプリセットを追加" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "커스텀 프리셋 추가" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "添加自定义预设" } }
+      }
+    },
     "After Capture" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -310,6 +324,20 @@
             "value" : "适用于视频和 GIF 导出"
           }
         }
+      }
+    },
+    "ASPECT RATIOS" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "アスペクト比" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "화면 비율" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "宽高比" } }
+      }
+    },
+    "Aspect Ratio" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "アスペクト比" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "화면 비율" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "宽高比" } }
       }
     },
     "Arrow" : {
@@ -565,6 +593,13 @@
         }
       }
     },
+    "Built-in" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "組み込み" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "기본 제공" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "内置" } }
+      }
+    },
     "Camera" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -768,6 +803,13 @@
             "value" : "截取窗口"
           }
         }
+      }
+    },
+    "Capture Presets" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "キャプチャプリセット" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "캡처 프리셋" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "截图预设" } }
       }
     },
     "Capture Window Shadow" : {
@@ -1217,6 +1259,13 @@
         }
       }
     },
+    "Constrain area capture to preset aspect ratios or fixed sizes" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "エリアキャプチャをプリセットのアスペクト比や固定サイズに制限する" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "영역 캡처를 사전 설정된 화면 비율 또는 고정 크기로 제한" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "将区域截图限制为预设的宽高比或固定尺寸" } }
+      }
+    },
     "Delete from History" : {
       "localizations" : {
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "履歴から削除" } },
@@ -1590,6 +1639,20 @@
         }
       }
     },
+    "FIXED SIZES" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "固定サイズ" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "고정 크기" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "固定尺寸" } }
+      }
+    },
+    "Fixed Size" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "固定サイズ" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "고정 크기" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "固定尺寸" } }
+      }
+    },
     "Feedback" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1694,6 +1757,20 @@
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "古いキャプチャを自動削除" } },
         "ko" : { "stringUnit" : { "state" : "translated", "value" : "오래된 캡처 자동 삭제" } },
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "自动删除过期截图" } }
+      }
+    },
+    "Height (px)" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "高さ (px)" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "높이 (px)" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "高度 (px)" } }
+      }
+    },
+    "Height ratio" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "高さの比率" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "높이 비율" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "高度比例" } }
       }
     },
     "History" : {
@@ -2080,6 +2157,13 @@
         }
       }
     },
+    "Manage Presets…" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "プリセットを管理…" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "프리셋 관리…" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "管理预设…" } }
+      }
+    },
     "Mirror" : {
       "localizations" : {
         "ja" : {
@@ -2100,6 +2184,13 @@
             "value" : "镜像"
           }
         }
+      }
+    },
+    "Name (optional)" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "名前（任意）" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "이름 (선택 사항)" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "名称（可选）" } }
       }
     },
     "None" : {
@@ -2167,6 +2258,13 @@
             "value" : "好"
           }
         }
+      }
+    },
+    "Other" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "その他" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "기타" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "其他" } }
       }
     },
     "Padding" : {
@@ -2398,6 +2496,13 @@
         }
       }
     },
+    "Press **R** to cycle presets during area capture" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "**R** キーでエリアキャプチャ中にプリセットを切り替え" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "**R**키로 영역 캡처 중 프리셋 전환" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "按 **R** 键在区域截图时切换预设" } }
+      }
+    },
     "Preview Position" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -2487,6 +2592,13 @@
             "value" : "退出 Capso"
           }
         }
+      }
+    },
+    "**Right-click** to open the preset picker" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "**右クリック**でプリセット選択を開く" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "**우클릭**으로 프리셋 선택기 열기" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "**右键**打开预设选择器" } }
       }
     },
     "Radial pulse on mouse click" : {
@@ -3126,6 +3238,13 @@
         }
       }
     },
+    "**Shift + R** to cycle in reverse" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "**Shift + R** で逆順に切り替え" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "**Shift + R**로 역방향 전환" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "**Shift + R** 反向切换" } }
+      }
+    },
     "Shortcuts" : {
       "localizations" : {
         "ja" : {
@@ -3670,6 +3789,13 @@
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "今天" } }
       }
     },
+    "Type" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "種類" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "유형" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "类型" } }
+      }
+    },
     "Undo" : {
       "localizations" : {
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "元に戻す" } },
@@ -3721,6 +3847,20 @@
             "value" : "视频"
           }
         }
+      }
+    },
+    "Width (px)" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "幅 (px)" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "너비 (px)" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "宽度 (px)" } }
+      }
+    },
+    "Width ratio" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "幅の比率" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "너비 비율" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "宽度比例" } }
       }
     },
     "Window" : {

--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -41,6 +41,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         registerGlobalShortcuts()
         historyCoordinator?.runCleanup()
+
+        NotificationCenter.default.addObserver(
+            forName: .openScreenshotSettings,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let tabRaw = (notification.object as? PreferencesTab)?.rawValue
+            MainActor.assumeIsolated {
+                let tab = tabRaw.flatMap(PreferencesTab.init(rawValue:)) ?? .screenshots
+                self?.preferencesWindow?.show(tab: tab)
+            }
+        }
         Task {
             await permissionManager.checkScreenRecordingPermission()
             // Request camera permission early so the system dialog
@@ -83,6 +95,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         KeyboardShortcuts.onKeyDown(for: .captureAreaAndAnnotate) { [weak self] in
             self?.captureCoordinator?.captureAreaAndAnnotate()
+        }
+        KeyboardShortcuts.onKeyDown(for: .screenshotHistory) { [weak self] in
+            self?.historyCoordinator?.showWindow()
         }
     }
 

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -123,7 +123,7 @@ final class CaptureCoordinator {
     private func showOverlay(mode: CaptureOverlayMode = .area, isScrollingCapture: Bool = false) {
         dismissOverlay()
         for screen in NSScreen.screens {
-            let overlay = CaptureOverlayWindow(screen: screen)
+            let overlay = CaptureOverlayWindow(screen: screen, settings: settings)
             overlay.onAreaSelected = { [weak self] rect, screen in
                 self?.dismissOverlay()
                 if isScrollingCapture {
@@ -193,7 +193,7 @@ final class CaptureCoordinator {
 
         // Step 2: Create transparent overlay windows (top layer) for selection
         for (screen, frozenImage) in frozenScreens {
-            let overlay = CaptureOverlayWindow(screen: screen)
+            let overlay = CaptureOverlayWindow(screen: screen, settings: settings)
             overlay.onAreaSelected = { [weak self] rect, screen in
                 self?.dismissOverlay()
                 let screenFrame = screen.frame

--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -1,6 +1,14 @@
 // App/Sources/Capture/CaptureOverlayView.swift
 import AppKit
 import CaptureKit
+import SharedKit
+
+// MARK: - Notification extensions
+
+extension Notification.Name {
+    static let openScreenshotSettings = Notification.Name("openScreenshotSettings")
+    static let capturePresetChanged = Notification.Name("capturePresetChanged")
+}
 
 enum CaptureOverlayMode {
     case area
@@ -13,11 +21,20 @@ final class CaptureOverlayView: NSView {
     var onWindowSelected: ((CGWindowID) -> Void)?
     var onCancel: (() -> Void)?
 
+    private let settings: AppSettings
+    /// When true, preset features (badge, R-key, right-click menu, ratio lock) are disabled.
+    /// Used by OCR and Recording overlays which always use freeform selection.
+    private let presetsDisabled: Bool
+
     private var mode: CaptureOverlayMode = .area
     private var isDragging = false
     private var dragStart: NSPoint = .zero
     private var dragEnd: NSPoint = .zero
     private var currentMouseLocation: NSPoint?
+
+    /// The currently active capture preset. Starts from settings and can be
+    /// changed at runtime via R-key cycling or the right-click context menu.
+    private var activePreset: CapturePreset
 
     // Window selection state
     private var hoveredWindowID: CGWindowID?
@@ -45,7 +62,19 @@ final class CaptureOverlayView: NSView {
     private let dimensionBgColor = NSColor.black.withAlphaComponent(0.7)
     private let dimensionTextColor = NSColor.white
 
-    override init(frame: NSRect) {
+    // MARK: - Context menu
+
+    /// Maps NSMenuItem tag values to presets for the right-click menu.
+    private var presetMenuMap: [Int: CapturePreset] = [:]
+
+    nonisolated(unsafe) private var presetObserver: Any?
+
+    init(frame: NSRect, settings: AppSettings, presetsDisabled: Bool = false) {
+        self.settings = settings
+        // Presets are disabled when explicitly requested (OCR/Recording) or when
+        // the user has turned off the feature in Settings.
+        self.presetsDisabled = presetsDisabled || !settings.capturePresetsEnabled
+        self.activePreset = self.presetsDisabled ? .freeform : settings.capturePreset
         super.init(frame: frame)
         addTrackingArea(NSTrackingArea(
             rect: bounds,
@@ -53,6 +82,37 @@ final class CaptureOverlayView: NSView {
             owner: self,
             userInfo: nil
         ))
+
+        // Listen for preset changes from other overlay views (multi-screen sync)
+        guard !presetsDisabled else { return }
+        presetObserver = NotificationCenter.default.addObserver(
+            forName: .capturePresetChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                let newPreset = self.settings.capturePreset
+                guard newPreset != self.activePreset else { return }
+                self.activePreset = newPreset
+
+                if self.activePreset.isFixedSize {
+                    self.restoreCursorIfNeeded()
+                } else if !self.cursorHidden, case .area = self.mode {
+                    NSCursor.hide()
+                    self.cursorHidden = true
+                }
+
+                self.setNeedsDisplay(self.bounds)
+                self.display()
+            }
+        }
+    }
+
+    deinit {
+        if let presetObserver {
+            NotificationCenter.default.removeObserver(presetObserver)
+        }
     }
 
     @available(*, unavailable)
@@ -77,7 +137,10 @@ final class CaptureOverlayView: NSView {
         // In window selection mode, keep the normal cursor visible so
         // the user can see where they're pointing.
         if case .area = mode {
-            if !cursorHidden {
+            if activePreset.isFixedSize {
+                // Fixed-size mode: keep system cursor visible (the rectangle replaces the reticle)
+                restoreCursorIfNeeded()
+            } else if !cursorHidden {
                 NSCursor.hide()
                 cursorHidden = true
             }
@@ -131,6 +194,39 @@ final class CaptureOverlayView: NSView {
             self.availableWindows = []
         }
         needsDisplay = true
+    }
+
+    // MARK: - Preset Cycling
+
+    /// Cycle through visible presets. `forward == true` means +1, `false` means -1.
+    private func cyclePreset(forward: Bool) {
+        let presets = settings.visiblePresets
+        guard !presets.isEmpty else { return }
+
+        let currentIndex = presets.firstIndex(of: activePreset) ?? 0
+        let count = presets.count
+        let newIndex = forward
+            ? (currentIndex + 1) % count
+            : (currentIndex - 1 + count) % count
+
+        activePreset = presets[newIndex]
+        settings.capturePreset = activePreset
+
+        // Update cursor visibility: fixed-size shows system cursor, others hide it
+        if activePreset.isFixedSize {
+            restoreCursorIfNeeded()
+        } else if !cursorHidden {
+            NSCursor.hide()
+            cursorHidden = true
+        }
+
+        // Force synchronous redraw — needsDisplay alone may not flush
+        // at .screenSaver window level without a mouse event to drive the run loop
+        setNeedsDisplay(bounds)
+        display()
+
+        // Notify other overlay views (multi-screen) to sync their preset
+        NotificationCenter.default.post(name: .capturePresetChanged, object: self)
     }
 
     // MARK: - Drawing
@@ -188,12 +284,106 @@ final class CaptureOverlayView: NSView {
                 drawReticle(at: currentMouseLocation, in: context)
             }
         } else {
-            // Before dragging: fully transparent, just crosshair
-            if let currentMouseLocation {
-                drawReticle(at: currentMouseLocation, in: context)
-                drawCoordinateLabel(at: currentMouseLocation, in: context)
+            // Before dragging: either fixed-size rectangle preview or crosshair
+
+            if let fixedSize = activePreset.fixedPixelSize {
+                // Fixed-size mode: draw a centered rectangle at cursor position
+                if let loc = currentMouseLocation {
+                    let fixedRect = CGRect(
+                        x: loc.x - CGFloat(fixedSize.width) / 2,
+                        y: loc.y - CGFloat(fixedSize.height) / 2,
+                        width: CGFloat(fixedSize.width),
+                        height: CGFloat(fixedSize.height)
+                    )
+
+                    // Same visual style as the drag selection
+                    context.saveGState()
+                    context.setFillColor(selectionFillColor.cgColor)
+                    context.fill(fixedRect.insetBy(dx: 1, dy: 1))
+                    context.restoreGState()
+
+                    context.saveGState()
+                    context.setStrokeColor(selectionInnerStrokeColor.cgColor)
+                    context.setLineWidth(1.0)
+                    context.stroke(fixedRect.insetBy(dx: 1, dy: 1))
+                    context.restoreGState()
+
+                    context.saveGState()
+                    context.setShadow(
+                        offset: .zero,
+                        blur: 10,
+                        color: NSColor.black.withAlphaComponent(0.5).cgColor
+                    )
+                    context.setStrokeColor(NSColor.white.withAlphaComponent(0.9).cgColor)
+                    context.setLineWidth(1.5)
+                    context.stroke(fixedRect)
+                    context.restoreGState()
+
+                    drawDimensionLabel(for: fixedRect, in: context)
+                }
+                // Still draw badge even without a mouse location
+                drawPresetBadge(in: context)
+            } else {
+                // Freeform or aspect-ratio mode: standard crosshair
+                if let currentMouseLocation {
+                    drawReticle(at: currentMouseLocation, in: context)
+                    drawCoordinateLabel(at: currentMouseLocation, in: context)
+                }
+                drawPresetBadge(in: context)
             }
         }
+    }
+
+    // MARK: - Preset Badge
+
+    /// Draw a centered badge at the top of the screen showing the active
+    /// preset and a hint to press R to change it.
+    private func drawPresetBadge(in context: CGContext) {
+        let presetName = activePreset.displayName
+        let hintText = "   R to change"
+        let fullText = "\(presetName)\(hintText)"
+
+        let presetFont = NSFont.systemFont(ofSize: 12, weight: .semibold)
+        let hintFont = NSFont.systemFont(ofSize: 12, weight: .regular)
+
+        let presetAttrs: [NSAttributedString.Key: Any] = [
+            .font: presetFont,
+            .foregroundColor: NSColor.white
+        ]
+        let hintAttrs: [NSAttributedString.Key: Any] = [
+            .font: hintFont,
+            .foregroundColor: NSColor.white.withAlphaComponent(0.6)
+        ]
+
+        let presetStr = NSAttributedString(string: presetName, attributes: presetAttrs)
+        let hintStr = NSAttributedString(string: hintText, attributes: hintAttrs)
+        let combined = NSMutableAttributedString(attributedString: presetStr)
+        combined.append(hintStr)
+
+        let textSize = combined.size()
+        let hPadding: CGFloat = 14
+        let vPadding: CGFloat = 7
+        let badgeWidth = textSize.width + hPadding * 2
+        let badgeHeight = textSize.height + vPadding * 2
+
+        let badgeX = (bounds.width - badgeWidth) / 2
+        let badgeY = bounds.height - badgeHeight - 20   // near top of screen
+
+        let bgRect = CGRect(x: badgeX, y: badgeY, width: badgeWidth, height: badgeHeight)
+        let pillRadius = badgeHeight / 2
+
+        // Dark pill background
+        context.saveGState()
+        context.setFillColor(NSColor.black.withAlphaComponent(0.75).cgColor)
+        let pillPath = CGPath(roundedRect: bgRect, cornerWidth: pillRadius, cornerHeight: pillRadius, transform: nil)
+        context.addPath(pillPath)
+        context.fillPath()
+        context.restoreGState()
+
+        // Draw text
+        let textX = badgeX + hPadding
+        let textY = badgeY + (badgeHeight - textSize.height) / 2
+        combined.draw(at: NSPoint(x: textX, y: textY))
     }
 
     private func drawWindowSelectionMode(in context: CGContext) {
@@ -285,13 +475,31 @@ final class CaptureOverlayView: NSView {
         ]
         let size = (text as NSString).size(withAttributes: attributes)
         let padding: CGFloat = 6
-        let labelWidth = size.width + padding * 2
+        let textLabelWidth = size.width + padding * 2
         let labelHeight = size.height + padding
 
-        let labelX = rect.midX - labelWidth / 2
+        // Calculate badge dimensions if needed
+        var badgeWidth: CGFloat = 0
+        var badgeText: String? = nil
+        var badgeColor: NSColor = .systemBlue
+
+        if let badge = activePreset.badgeText {
+            badgeText = badge
+            badgeColor = activePreset.isFixedSize ? .systemGreen : .systemBlue
+            let badgeFont = NSFont.monospacedSystemFont(ofSize: 10, weight: .semibold)
+            let badgeAttrs: [NSAttributedString.Key: Any] = [.font: badgeFont]
+            let badgeSize = (badge as NSString).size(withAttributes: badgeAttrs)
+            badgeWidth = badgeSize.width + 8
+        }
+
+        let gap: CGFloat = badgeText != nil ? 6 : 0
+        let totalWidth = textLabelWidth + gap + badgeWidth
+
+        let labelX = rect.midX - totalWidth / 2
         let labelY = rect.minY - labelHeight - 8
 
-        let bgRect = CGRect(x: labelX, y: labelY, width: labelWidth, height: labelHeight)
+        // Draw main dimension pill
+        let bgRect = CGRect(x: labelX, y: labelY, width: textLabelWidth, height: labelHeight)
         context.setFillColor(dimensionBgColor.cgColor)
         let path = CGPath(roundedRect: bgRect, cornerWidth: 4, cornerHeight: 4, transform: nil)
         context.addPath(path)
@@ -299,6 +507,28 @@ final class CaptureOverlayView: NSView {
 
         let textPoint = NSPoint(x: labelX + padding, y: labelY + (labelHeight - size.height) / 2)
         (text as NSString).draw(at: textPoint, withAttributes: attributes)
+
+        // Draw preset badge pill
+        if let badge = badgeText {
+            let badgeFont = NSFont.monospacedSystemFont(ofSize: 10, weight: .semibold)
+            let badgeTextAttrs: [NSAttributedString.Key: Any] = [
+                .font: badgeFont,
+                .foregroundColor: NSColor.white
+            ]
+            let badgeX = labelX + textLabelWidth + gap
+            let bRect = CGRect(x: badgeX, y: labelY, width: badgeWidth, height: labelHeight)
+            context.setFillColor(badgeColor.cgColor)
+            let bPath = CGPath(roundedRect: bRect, cornerWidth: 4, cornerHeight: 4, transform: nil)
+            context.addPath(bPath)
+            context.fillPath()
+
+            let badgeTextSize = (badge as NSString).size(withAttributes: badgeTextAttrs)
+            let btPoint = NSPoint(
+                x: badgeX + (badgeWidth - badgeTextSize.width) / 2,
+                y: labelY + (labelHeight - badgeTextSize.height) / 2
+            )
+            (badge as NSString).draw(at: btPoint, withAttributes: badgeTextAttrs)
+        }
     }
 
     /// Draw a small crosshair reticle at the cursor position.
@@ -392,6 +622,20 @@ final class CaptureOverlayView: NSView {
     override func mouseDown(with event: NSEvent) {
         switch mode {
         case .area:
+            // Fixed-size: no drag — capture immediately centered on cursor
+            if let fixedSize = activePreset.fixedPixelSize {
+                let loc = convert(event.locationInWindow, from: nil)
+                let fixedRect = CGRect(
+                    x: loc.x - CGFloat(fixedSize.width) / 2,
+                    y: loc.y - CGFloat(fixedSize.height) / 2,
+                    width: CGFloat(fixedSize.width),
+                    height: CGFloat(fixedSize.height)
+                )
+                restoreCursorIfNeeded()
+                onSelectionComplete?(fixedRect)
+                return
+            }
+
             isDragging = true
             dragStart = convert(event.locationInWindow, from: nil)
             dragEnd = dragStart
@@ -405,21 +649,90 @@ final class CaptureOverlayView: NSView {
         }
     }
 
+    /// Apply aspect-ratio constraint to a raw drag endpoint, clamped to view bounds.
+    private func constrainedDragEnd(rawEnd: NSPoint) -> NSPoint {
+        guard let ratio = activePreset.ratio, !activePreset.isFixedSize else {
+            return rawEnd
+        }
+
+        let dx = rawEnd.x - dragStart.x
+        let dy = rawEnd.y - dragStart.y
+
+        var endX: CGFloat
+        var endY: CGFloat
+
+        // Use the axis with the larger absolute delta as the controlling axis
+        if abs(dx) >= abs(dy) {
+            let constrainedH = abs(dx) / ratio
+            endX = dragStart.x + dx
+            endY = dragStart.y + (dy >= 0 ? constrainedH : -constrainedH)
+        } else {
+            let constrainedW = abs(dy) * ratio
+            endX = dragStart.x + (dx >= 0 ? constrainedW : -constrainedW)
+            endY = dragStart.y + dy
+        }
+
+        // Clamp to view bounds while maintaining the aspect ratio.
+        // If either axis goes out of bounds, shrink back along both axes.
+        let minX: CGFloat = 0
+        let minY: CGFloat = 0
+        let maxX = bounds.width
+        let maxY = bounds.height
+
+        if endX < minX {
+            let clampedWidth = dragStart.x - minX
+            let clampedHeight = clampedWidth / ratio
+            endX = minX
+            endY = dragStart.y + (endY >= dragStart.y ? clampedHeight : -clampedHeight)
+        } else if endX > maxX {
+            let clampedWidth = maxX - dragStart.x
+            let clampedHeight = clampedWidth / ratio
+            endX = maxX
+            endY = dragStart.y + (endY >= dragStart.y ? clampedHeight : -clampedHeight)
+        }
+
+        if endY < minY {
+            let clampedHeight = dragStart.y - minY
+            let clampedWidth = clampedHeight * ratio
+            endY = minY
+            endX = dragStart.x + (endX >= dragStart.x ? clampedWidth : -clampedWidth)
+        } else if endY > maxY {
+            let clampedHeight = maxY - dragStart.y
+            let clampedWidth = clampedHeight * ratio
+            endY = maxY
+            endX = dragStart.x + (endX >= dragStart.x ? clampedWidth : -clampedWidth)
+        }
+
+        return NSPoint(x: endX, y: endY)
+    }
+
     override func mouseDragged(with event: NSEvent) {
         guard case .area = mode else { return }
-        dragEnd = convert(event.locationInWindow, from: nil)
+        let rawEnd = convert(event.locationInWindow, from: nil)
+        dragEnd = constrainedDragEnd(rawEnd: rawEnd)
+        // Reticle tracks the constrained corner so it stays on the selection edge
         currentMouseLocation = dragEnd
+
+        // Ensure cursor stays hidden during drag (it can reappear on screen edges)
+        if !cursorHidden {
+            NSCursor.hide()
+            cursorHidden = true
+        }
+
         needsDisplay = true
     }
 
     override func mouseUp(with event: NSEvent) {
         guard case .area = mode else { return }
-        dragEnd = convert(event.locationInWindow, from: nil)
+        // Fixed-size mode already captured in mouseDown — skip mouseUp
+        guard !activePreset.isFixedSize else { return }
+        let rawEnd = convert(event.locationInWindow, from: nil)
+        dragEnd = constrainedDragEnd(rawEnd: rawEnd)
         isDragging = false
 
         let rect = selectionRect
         if rect.width > 5 && rect.height > 5 {
-            NSCursor.unhide()
+            restoreCursorIfNeeded()
             onSelectionComplete?(rect)
         }
         needsDisplay = true
@@ -458,6 +771,10 @@ final class CaptureOverlayView: NSView {
         case .area:
             if isDragging {
                 cancelCurrentSelection()
+            } else if !presetsDisabled {
+                // Show preset picker instead of cancelling
+                let loc = convert(event.locationInWindow, from: nil)
+                showPresetMenu(at: loc)
             } else {
                 cancelOverlay()
             }
@@ -470,6 +787,11 @@ final class CaptureOverlayView: NSView {
     override func keyDown(with event: NSEvent) {
         if event.keyCode == 53 { // ESC
             cancelOverlay()
+        } else if event.keyCode == 15 { // R key
+            guard case .area = mode, !isDragging, !presetsDisabled else { return }
+            let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let backward = flags.contains(.shift)
+            cyclePreset(forward: !backward)
         }
     }
 
@@ -488,5 +810,124 @@ final class CaptureOverlayView: NSView {
     private func cancelOverlay() {
         restoreCursorIfNeeded()
         onCancel?()
+    }
+
+    // MARK: - Right-click Preset Menu
+
+    private func showPresetMenu(at location: NSPoint) {
+        let menu = NSMenu(title: "")
+        presetMenuMap.removeAll()
+        var tagCounter = 1
+
+        let presets = settings.visiblePresets
+
+        // Collect visible ratios (freeform + aspect ratios) and fixed sizes
+        let ratioPresets = presets.filter {
+            if case .fixedSize = $0 { return false }
+            return true
+        }
+        let fixedPresets = presets.filter {
+            if case .fixedSize = $0 { return true }
+            return false
+        }
+
+        // --- Aspect Ratios section ---
+        if !ratioPresets.isEmpty {
+            let ratioHeader = makeHeaderItem(String(localized: "ASPECT RATIOS"))
+            menu.addItem(ratioHeader)
+
+            for preset in ratioPresets {
+                let item = NSMenuItem(
+                    title: preset.displayName,
+                    action: #selector(presetMenuItemSelected(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = self
+                item.tag = tagCounter
+                if preset == activePreset {
+                    item.state = .on
+                }
+                presetMenuMap[tagCounter] = preset
+                tagCounter += 1
+                menu.addItem(item)
+            }
+        }
+
+        // --- Fixed Sizes section ---
+        if !fixedPresets.isEmpty {
+            menu.addItem(.separator())
+            let fixedHeader = makeHeaderItem(String(localized: "FIXED SIZES"))
+            menu.addItem(fixedHeader)
+
+            for preset in fixedPresets {
+                let item = NSMenuItem(
+                    title: preset.displayName,
+                    action: #selector(presetMenuItemSelected(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = self
+                item.tag = tagCounter
+                if preset == activePreset {
+                    item.state = .on
+                }
+                presetMenuMap[tagCounter] = preset
+                tagCounter += 1
+                menu.addItem(item)
+            }
+        }
+
+        menu.addItem(.separator())
+        let manageItem = NSMenuItem(
+            title: String(localized: "Manage Presets\u{2026}"),
+            action: #selector(openPresetSettings),
+            keyEquivalent: ""
+        )
+        manageItem.target = self
+        menu.addItem(manageItem)
+
+        menu.popUp(positioning: nil, at: location, in: self)
+    }
+
+    /// Create a non-interactive section header menu item.
+    private func makeHeaderItem(_ title: String) -> NSMenuItem {
+        let font = NSFont.systemFont(ofSize: 10, weight: .semibold)
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.secondaryLabelColor
+        ]
+        let attributed = NSAttributedString(string: title.uppercased(), attributes: attrs)
+        let item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        item.attributedTitle = attributed
+        item.isEnabled = false
+        return item
+    }
+
+    @objc private func presetMenuItemSelected(_ sender: NSMenuItem) {
+        guard let preset = presetMenuMap[sender.tag] else { return }
+        activePreset = preset
+        settings.capturePreset = preset
+
+        // Update cursor visibility after preset change
+        if activePreset.isFixedSize {
+            restoreCursorIfNeeded()
+        } else if !cursorHidden {
+            NSCursor.hide()
+            cursorHidden = true
+        }
+
+        setNeedsDisplay(bounds)
+        display()
+
+        // Notify other overlay views (multi-screen) to sync their preset
+        NotificationCenter.default.post(name: .capturePresetChanged, object: self)
+    }
+
+    @objc private func openPresetSettings() {
+        // Cancel the overlay first so Settings isn't hidden behind the .screenSaver level window
+        cancelOverlay()
+        // Delay slightly to let the overlay dismiss before opening Settings
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            NotificationCenter.default.post(name: .openScreenshotSettings, object: nil)
+        }
     }
 }

--- a/App/Sources/Capture/CaptureOverlayWindow.swift
+++ b/App/Sources/Capture/CaptureOverlayWindow.swift
@@ -1,6 +1,7 @@
 // App/Sources/Capture/CaptureOverlayWindow.swift
 import AppKit
 import CaptureKit
+import SharedKit
 
 @MainActor
 final class CaptureOverlayWindow: NSPanel {
@@ -8,11 +9,13 @@ final class CaptureOverlayWindow: NSPanel {
     var onWindowSelected: ((CGWindowID) -> Void)?
     var onCancelled: (() -> Void)?
 
+    private let settings: AppSettings
     private var overlayView: CaptureOverlayView!
     private var globalEscMonitor: Any?
     private var localEscMonitor: Any?
 
-    init(screen: NSScreen) {
+    init(screen: NSScreen, settings: AppSettings, presetsDisabled: Bool = false) {
+        self.settings = settings
         super.init(
             contentRect: screen.frame,
             styleMask: [.borderless, .nonactivatingPanel],
@@ -36,7 +39,7 @@ final class CaptureOverlayWindow: NSPanel {
             perform(preventsActivationSel, with: NSNumber(value: true))
         }
 
-        overlayView = CaptureOverlayView(frame: NSRect(origin: .zero, size: screen.frame.size))
+        overlayView = CaptureOverlayView(frame: NSRect(origin: .zero, size: screen.frame.size), settings: settings, presetsDisabled: presetsDisabled)
         overlayView.onSelectionComplete = { [weak self] rect in
             guard let self, let screen = self.screen else { return }
             self.onAreaSelected?(rect, screen)

--- a/App/Sources/MenuBar/MenuBarController.swift
+++ b/App/Sources/MenuBar/MenuBarController.swift
@@ -68,7 +68,9 @@ final class MenuBarController: NSObject {
 
         menu.addItem(.separator())
 
-        menu.addItem(menuItem(String(localized: "Screenshot History..."), action: #selector(openHistory)))
+        let screenshotHistory = menuItem(String(localized: "Screenshot History..."), action: #selector(openHistory))
+        screenshotHistory.setShortcut(for: .screenshotHistory)
+        menu.addItem(screenshotHistory)
         menu.addItem(.separator())
 
         menu.addItem(menuItem(String(localized: "Preferences..."), action: #selector(openPreferences), key: ",", modifiers: [.command]))
@@ -140,6 +142,7 @@ extension MenuBarController: NSMenuDelegate {
             case #selector(captureText): item.setShortcut(for: .captureText)
             case #selector(recordScreen): item.setShortcut(for: .recordScreen)
             case #selector(captureScrolling): item.setShortcut(for: .captureScrolling)
+            case #selector(openHistory): item.setShortcut(for: .screenshotHistory)
             default: break
             }
         }

--- a/App/Sources/OCR/OCRCoordinator.swift
+++ b/App/Sources/OCR/OCRCoordinator.swift
@@ -42,7 +42,7 @@ final class OCRCoordinator {
     private func showOverlayForOCR() {
         dismissOverlay()
         for screen in NSScreen.screens {
-            let overlay = CaptureOverlayWindow(screen: screen)
+            let overlay = CaptureOverlayWindow(screen: screen, settings: settings, presetsDisabled: true)
             overlay.onAreaSelected = { [weak self] rect, screen in
                 self?.dismissOverlay()
                 self?.performInstantOCR(rect: rect, screen: screen)

--- a/App/Sources/Preferences/PreferencesView.swift
+++ b/App/Sources/Preferences/PreferencesView.swift
@@ -1,4 +1,5 @@
 // App/Sources/Preferences/PreferencesView.swift
+import Combine
 import SwiftUI
 
 enum PreferencesTab: String, CaseIterable {
@@ -36,9 +37,15 @@ enum PreferencesTab: String, CaseIterable {
 }
 
 struct PreferencesView: View {
-    @State private var selectedTab: PreferencesTab = .general
+    @State private var selectedTab: PreferencesTab
     let viewModel: PreferencesViewModel
     let updateManager: UpdateManager?
+
+    init(viewModel: PreferencesViewModel, updateManager: UpdateManager?, initialTab: PreferencesTab? = nil) {
+        self.viewModel = viewModel
+        self.updateManager = updateManager
+        self._selectedTab = State(initialValue: initialTab ?? .general)
+    }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -48,6 +55,13 @@ struct PreferencesView: View {
             content
         }
         .frame(width: 680, height: 480)
+        .onReceive(NotificationCenter.default.publisher(for: .openScreenshotSettings)) { notification in
+            if let tab = notification.object as? PreferencesTab {
+                selectedTab = tab
+            } else {
+                selectedTab = .screenshots
+            }
+        }
     }
 
     private var sidebar: some View {

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -126,6 +126,52 @@ final class PreferencesViewModel {
         }
     }
 
+    // MARK: Capture Presets
+    var capturePresetsEnabled: Bool {
+        get {
+            access(keyPath: \.capturePresetsEnabled)
+            return settings.capturePresetsEnabled
+        }
+        set {
+            withMutation(keyPath: \.capturePresetsEnabled) {
+                settings.capturePresetsEnabled = newValue
+            }
+        }
+    }
+    var capturePreset: CapturePreset {
+        get {
+            access(keyPath: \.capturePreset)
+            return settings.capturePreset
+        }
+        set {
+            withMutation(keyPath: \.capturePreset) {
+                settings.capturePreset = newValue
+            }
+        }
+    }
+    var customCapturePresets: [CapturePreset] {
+        get {
+            access(keyPath: \.customCapturePresets)
+            return settings.customCapturePresets
+        }
+        set {
+            withMutation(keyPath: \.customCapturePresets) {
+                settings.customCapturePresets = newValue
+            }
+        }
+    }
+    var hiddenBuiltinPresets: Set<CapturePreset> {
+        get {
+            access(keyPath: \.hiddenBuiltinPresets)
+            return settings.hiddenBuiltinPresets
+        }
+        set {
+            withMutation(keyPath: \.hiddenBuiltinPresets) {
+                settings.hiddenBuiltinPresets = newValue
+            }
+        }
+    }
+
     // MARK: Recording
     var recordingFormat: RecordingFormat {
         get {

--- a/App/Sources/Preferences/PreferencesWindow.swift
+++ b/App/Sources/Preferences/PreferencesWindow.swift
@@ -14,10 +14,14 @@ final class PreferencesWindow {
         self.updateManager = updateManager
     }
 
-    func show() {
+    func show(tab: PreferencesTab? = nil) {
         if let window {
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
+            // Navigate to requested tab if window already exists
+            if let tab {
+                NotificationCenter.default.post(name: .openScreenshotSettings, object: tab)
+            }
             return
         }
 
@@ -41,7 +45,7 @@ final class PreferencesWindow {
         window.contentView = visualEffect
 
         let viewModel = PreferencesViewModel(settings: settings)
-        let hostingView = NSHostingView(rootView: PreferencesView(viewModel: viewModel, updateManager: updateManager))
+        let hostingView = NSHostingView(rootView: PreferencesView(viewModel: viewModel, updateManager: updateManager, initialTab: tab))
         hostingView.translatesAutoresizingMaskIntoConstraints = false
         visualEffect.addSubview(hostingView)
         NSLayoutConstraint.activate([

--- a/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
@@ -5,6 +5,12 @@ import SharedKit
 struct ScreenshotSettingsView: View {
     @Bindable var viewModel: PreferencesViewModel
 
+    @State private var showingAddPreset = false
+    @State private var newPresetType = 0  // 0 = aspect ratio, 1 = fixed size
+    @State private var newWidth = ""
+    @State private var newHeight = ""
+    @State private var newName = ""
+
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             Text("Screenshots")
@@ -43,6 +49,105 @@ struct ScreenshotSettingsView: View {
                 }
             }
 
+            SettingGroup(title: "Capture Presets") {
+                SettingCard {
+                    SettingRow(
+                        label: "Capture Presets",
+                        sublabel: "Constrain area capture to preset aspect ratios or fixed sizes"
+                    ) {
+                        Toggle("", isOn: $viewModel.capturePresetsEnabled)
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                    }
+                }
+
+                if viewModel.capturePresetsEnabled {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Label("Press **R** to cycle presets during area capture", systemImage: "keyboard")
+                        Label("**Right-click** to open the preset picker", systemImage: "cursorarrow.click.2")
+                        Label("**Shift + R** to cycle in reverse", systemImage: "arrow.left.arrow.right")
+                    }
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 2)
+
+                    SettingCard {
+                    // Built-in aspect ratios (skip .freeform)
+                    let aspectRatios = CapturePreset.builtinAspectRatios.filter {
+                        if case .freeform = $0 { return false }
+                        return true
+                    }
+                    ForEach(Array(aspectRatios.enumerated()), id: \.element.id) { index, preset in
+                        let isHidden = viewModel.hiddenBuiltinPresets.contains(preset)
+                        SettingRow(
+                            label: LocalizedStringKey(preset.displayName),
+                            showDivider: index > 0
+                        ) {
+                            Toggle("", isOn: Binding(
+                                get: { !isHidden },
+                                set: { isOn in
+                                    if isOn {
+                                        viewModel.hiddenBuiltinPresets.remove(preset)
+                                    } else {
+                                        viewModel.hiddenBuiltinPresets.insert(preset)
+                                    }
+                                }
+                            ))
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                        }
+                    }
+
+                    // Built-in fixed sizes
+                    ForEach(Array(CapturePreset.builtinFixedSizes.enumerated()), id: \.element.id) { index, preset in
+                        let isHidden = viewModel.hiddenBuiltinPresets.contains(preset)
+                        SettingRow(
+                            label: LocalizedStringKey(preset.displayName),
+                            showDivider: true
+                        ) {
+                            Toggle("", isOn: Binding(
+                                get: { !isHidden },
+                                set: { isOn in
+                                    if isOn {
+                                        viewModel.hiddenBuiltinPresets.remove(preset)
+                                    } else {
+                                        viewModel.hiddenBuiltinPresets.insert(preset)
+                                    }
+                                }
+                            ))
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                        }
+                    }
+
+                    // Custom presets
+                    ForEach(viewModel.customCapturePresets) { preset in
+                        SettingRow(
+                            label: LocalizedStringKey(preset.displayName),
+                            showDivider: true
+                        ) {
+                            Button {
+                                viewModel.customCapturePresets.removeAll { $0.id == preset.id }
+                            } label: {
+                                Image(systemName: "minus.circle.fill")
+                                    .foregroundStyle(.red)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+
+                    Button("Add Custom Preset") {
+                        showingAddPreset = true
+                    }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 13))
+                    .foregroundStyle(Color.accentColor)
+                    .padding(.leading, 2)
+                } // if capturePresetsEnabled
+            }
+
             SettingGroup(title: "Format") {
                 SettingCard {
                     SettingRow(label: "Screenshot Format") {
@@ -56,7 +161,90 @@ struct ScreenshotSettingsView: View {
                 }
             }
         }
+        .sheet(isPresented: $showingAddPreset) {
+            addPresetSheet
+        }
     }
 
+    // MARK: - Add Preset Sheet
 
+    @ViewBuilder
+    private var addPresetSheet: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("Add Custom Preset")
+                .font(.system(size: 17, weight: .semibold))
+
+            Picker("", selection: $newPresetType) {
+                Text("Aspect Ratio").tag(0)
+                Text("Fixed Size").tag(1)
+            }
+            .pickerStyle(.segmented)
+
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 12) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(newPresetType == 0 ? LocalizedStringKey("Width ratio") : LocalizedStringKey("Width (px)"))
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                        TextField("e.g. 16", text: $newWidth)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(newPresetType == 0 ? LocalizedStringKey("Height ratio") : LocalizedStringKey("Height (px)"))
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                        TextField("e.g. 9", text: $newHeight)
+                            .textFieldStyle(.roundedBorder)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(LocalizedStringKey("Name (optional)"))
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                    TextField("e.g. Widescreen", text: $newName)
+                        .textFieldStyle(.roundedBorder)
+                }
+            }
+
+            HStack {
+                Button("Cancel") {
+                    showingAddPreset = false
+                    resetNewPresetFields()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Spacer()
+
+                Button("Add") {
+                    addCustomPreset()
+                    showingAddPreset = false
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(Int(newWidth) == nil || Int(newHeight) == nil)
+            }
+        }
+        .padding(24)
+        .frame(width: 360)
+    }
+
+    // MARK: - Helpers
+
+    private func addCustomPreset() {
+        guard let w = Int(newWidth), let h = Int(newHeight) else { return }
+        let name: String? = newName.trimmingCharacters(in: .whitespaces).isEmpty ? nil : newName.trimmingCharacters(in: .whitespaces)
+        let preset: CapturePreset = newPresetType == 0
+            ? .aspectRatio(width: w, height: h, name: name)
+            : .fixedSize(width: w, height: h, name: name)
+        viewModel.customCapturePresets.append(preset)
+        resetNewPresetFields()
+    }
+
+    private func resetNewPresetFields() {
+        newPresetType = 0
+        newWidth = ""
+        newHeight = ""
+        newName = ""
+    }
 }

--- a/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
@@ -11,6 +11,7 @@ extension KeyboardShortcuts.Name {
     static let captureScrolling = Self("captureScrolling", default: .init(.six, modifiers: [.option, .shift]))
     static let captureAreaToClipboard = Self("captureAreaToClipboard", default: .init(.seven, modifiers: [.option, .shift]))
     static let captureAreaAndAnnotate = Self("captureAreaAndAnnotate", default: .init(.eight, modifiers: [.option, .shift]))
+    static let screenshotHistory = Self("screenshotHistory", default: .init(.nine, modifiers: [.option, .shift]))
 }
 
 struct ShortcutSettingsView: View {
@@ -51,6 +52,12 @@ struct ShortcutSettingsView: View {
             SettingGroup(title: "Recording") {
                 SettingCard {
                     shortcutRow("Start / Stop Recording", name: .recordScreen)
+                }
+            }
+
+            SettingGroup(title: "Other") {
+                SettingCard {
+                    shortcutRow("Screenshot History", name: .screenshotHistory)
                 }
             }
         }

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -69,7 +69,7 @@ final class RecordingCoordinator {
         dismissOverlay()
 
         for screen in NSScreen.screens {
-            let overlay = CaptureOverlayWindow(screen: screen)
+            let overlay = CaptureOverlayWindow(screen: screen, settings: settings, presetsDisabled: true)
             overlay.onAreaSelected = { [weak self] rect, screen in
                 self?.dismissOverlay()
                 self?.handleAreaSelected(rect: rect, screen: screen)

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -226,6 +226,64 @@ public final class AppSettings: @unchecked Sendable {
         set { defaults.set(newValue, forKey: "rememberLastCaptureArea") }
     }
 
+    // MARK: Capture Presets
+
+    public var capturePresetsEnabled: Bool {
+        get { defaults.object(forKey: "capturePresetsEnabled") as? Bool ?? true }
+        set { defaults.set(newValue, forKey: "capturePresetsEnabled") }
+    }
+
+    public var capturePreset: CapturePreset {
+        get {
+            guard let data = defaults.data(forKey: "capturePreset"),
+                  let value = try? JSONDecoder().decode(CapturePreset.self, from: data) else {
+                return .freeform
+            }
+            return value
+        }
+        set {
+            if let data = try? JSONEncoder().encode(newValue) {
+                defaults.set(data, forKey: "capturePreset")
+            }
+        }
+    }
+
+    public var customCapturePresets: [CapturePreset] {
+        get {
+            guard let data = defaults.data(forKey: "customCapturePresets"),
+                  let value = try? JSONDecoder().decode([CapturePreset].self, from: data) else {
+                return []
+            }
+            return value
+        }
+        set {
+            if let data = try? JSONEncoder().encode(newValue) {
+                defaults.set(data, forKey: "customCapturePresets")
+            }
+        }
+    }
+
+    public var hiddenBuiltinPresets: Set<CapturePreset> {
+        get {
+            guard let data = defaults.data(forKey: "hiddenBuiltinPresets"),
+                  let value = try? JSONDecoder().decode(Set<CapturePreset>.self, from: data) else {
+                return []
+            }
+            return value
+        }
+        set {
+            if let data = try? JSONEncoder().encode(newValue) {
+                defaults.set(data, forKey: "hiddenBuiltinPresets")
+            }
+        }
+    }
+
+    /// All visible presets in display order: visible built-ins then custom.
+    public var visiblePresets: [CapturePreset] {
+        let builtins = CapturePreset.allBuiltins.filter { !hiddenBuiltinPresets.contains($0) }
+        return builtins + customCapturePresets
+    }
+
     // MARK: History
     public var historyEnabled: Bool {
         get { defaults.object(forKey: "historyEnabled") as? Bool ?? true }

--- a/Packages/SharedKit/Sources/SharedKit/Settings/CapturePreset.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/CapturePreset.swift
@@ -1,0 +1,102 @@
+import CoreGraphics
+import Foundation
+
+/// A capture size constraint: freeform, locked aspect ratio, or fixed pixel dimensions.
+public enum CapturePreset: Codable, Hashable, Sendable {
+    case freeform
+    case aspectRatio(width: Int, height: Int, name: String?)
+    case fixedSize(width: Int, height: Int, name: String?)
+}
+
+// MARK: - Identifiable
+
+extension CapturePreset: Identifiable {
+    public var id: String {
+        switch self {
+        case .freeform:
+            return "freeform"
+        case .aspectRatio(let w, let h, _):
+            return "ratio-\(w)-\(h)"
+        case .fixedSize(let w, let h, _):
+            return "fixed-\(w)-\(h)"
+        }
+    }
+}
+
+// MARK: - Display
+
+extension CapturePreset {
+    /// Human-readable label for menus and badges.
+    public var displayName: String {
+        switch self {
+        case .freeform:
+            return "Freeform"
+        case .aspectRatio(let w, let h, let name):
+            let ratio = "\(w):\(h)"
+            if let name { return "\(ratio) (\(name))" }
+            return ratio
+        case .fixedSize(let w, let h, let name):
+            let size = "\(w) × \(h)"
+            if let name { return "\(size) (\(name))" }
+            return size
+        }
+    }
+
+    /// Short badge text shown next to the dimension label during capture.
+    public var badgeText: String? {
+        switch self {
+        case .freeform:
+            return nil
+        case .aspectRatio(let w, let h, _):
+            return "\(w):\(h)"
+        case .fixedSize:
+            return "Fixed"
+        }
+    }
+
+    /// True when the preset defines exact pixel dimensions (no drag needed).
+    public var isFixedSize: Bool {
+        if case .fixedSize = self { return true }
+        return false
+    }
+
+    /// The aspect ratio as a CGFloat (width / height), or nil for freeform.
+    public var ratio: CGFloat? {
+        switch self {
+        case .freeform:
+            return nil
+        case .aspectRatio(let w, let h, _):
+            return CGFloat(w) / CGFloat(h)
+        case .fixedSize(let w, let h, _):
+            return CGFloat(w) / CGFloat(h)
+        }
+    }
+
+    /// The fixed pixel size, or nil for freeform/ratio presets.
+    public var fixedPixelSize: (width: Int, height: Int)? {
+        if case .fixedSize(let w, let h, _) = self {
+            return (w, h)
+        }
+        return nil
+    }
+}
+
+// MARK: - Built-in Presets
+
+extension CapturePreset {
+    public static let builtinAspectRatios: [CapturePreset] = [
+        .freeform,
+        .aspectRatio(width: 1, height: 1, name: "Square"),
+        .aspectRatio(width: 4, height: 3, name: nil),
+        .aspectRatio(width: 16, height: 9, name: nil),
+        .aspectRatio(width: 3, height: 2, name: nil),
+    ]
+
+    public static let builtinFixedSizes: [CapturePreset] = [
+        .fixedSize(width: 512, height: 512, name: nil),
+        .fixedSize(width: 1280, height: 720, name: "720p"),
+        .fixedSize(width: 1920, height: 1080, name: "1080p"),
+    ]
+
+    public static let allBuiltins: [CapturePreset] = builtinAspectRatios + builtinFixedSizes
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/CapturePresetTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/CapturePresetTests.swift
@@ -1,0 +1,132 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import SharedKit
+
+@Suite("CapturePreset")
+struct CapturePresetTests {
+    @Test("Display name for freeform")
+    func freeformDisplayName() {
+        #expect(CapturePreset.freeform.displayName == "Freeform")
+    }
+
+    @Test("Display name for ratio with name")
+    func ratioWithName() {
+        let preset = CapturePreset.aspectRatio(width: 1, height: 1, name: "Square")
+        #expect(preset.displayName == "1:1 (Square)")
+    }
+
+    @Test("Display name for ratio without name")
+    func ratioWithoutName() {
+        let preset = CapturePreset.aspectRatio(width: 16, height: 9, name: nil)
+        #expect(preset.displayName == "16:9")
+    }
+
+    @Test("Display name for fixed size with name")
+    func fixedSizeWithName() {
+        let preset = CapturePreset.fixedSize(width: 1280, height: 720, name: "720p")
+        #expect(preset.displayName == "1280 × 720 (720p)")
+    }
+
+    @Test("Display name for fixed size without name")
+    func fixedSizeWithoutName() {
+        let preset = CapturePreset.fixedSize(width: 512, height: 512, name: nil)
+        #expect(preset.displayName == "512 × 512")
+    }
+
+    @Test("Badge text is nil for freeform")
+    func freeformBadge() {
+        #expect(CapturePreset.freeform.badgeText == nil)
+    }
+
+    @Test("Badge text for ratio")
+    func ratioBadge() {
+        let preset = CapturePreset.aspectRatio(width: 4, height: 3, name: nil)
+        #expect(preset.badgeText == "4:3")
+    }
+
+    @Test("Badge text for fixed size")
+    func fixedSizeBadge() {
+        let preset = CapturePreset.fixedSize(width: 512, height: 512, name: nil)
+        #expect(preset.badgeText == "Fixed")
+    }
+
+    @Test("isFixedSize returns true only for fixedSize")
+    func isFixedSize() {
+        #expect(CapturePreset.freeform.isFixedSize == false)
+        #expect(CapturePreset.aspectRatio(width: 4, height: 3, name: nil).isFixedSize == false)
+        #expect(CapturePreset.fixedSize(width: 512, height: 512, name: nil).isFixedSize == true)
+    }
+
+    @Test("Ratio calculation")
+    func ratioCalculation() {
+        #expect(CapturePreset.freeform.ratio == nil)
+        #expect(CapturePreset.aspectRatio(width: 16, height: 9, name: nil).ratio == CGFloat(16) / CGFloat(9))
+        #expect(CapturePreset.fixedSize(width: 1920, height: 1080, name: nil).ratio == CGFloat(1920) / CGFloat(1080))
+    }
+
+    @Test("Fixed pixel size extraction")
+    func fixedPixelSize() {
+        #expect(CapturePreset.freeform.fixedPixelSize == nil)
+        #expect(CapturePreset.aspectRatio(width: 4, height: 3, name: nil).fixedPixelSize == nil)
+        let size = CapturePreset.fixedSize(width: 512, height: 512, name: nil).fixedPixelSize
+        #expect(size?.width == 512)
+        #expect(size?.height == 512)
+    }
+
+    @Test("Unique IDs for all built-in presets")
+    func uniqueBuiltinIDs() {
+        let ids = CapturePreset.allBuiltins.map(\.id)
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test("Codable round-trip")
+    func codableRoundTrip() throws {
+        let presets: [CapturePreset] = [
+            .freeform,
+            .aspectRatio(width: 4, height: 3, name: "Test"),
+            .fixedSize(width: 800, height: 600, name: nil),
+        ]
+        let data = try JSONEncoder().encode(presets)
+        let decoded = try JSONDecoder().decode([CapturePreset].self, from: data)
+        #expect(decoded == presets)
+    }
+
+    @Test("Built-in counts")
+    func builtinCounts() {
+        #expect(CapturePreset.builtinAspectRatios.count == 5)
+        #expect(CapturePreset.builtinFixedSizes.count == 3)
+        #expect(CapturePreset.allBuiltins.count == 8)
+    }
+
+    @Test("AppSettings defaults to freeform preset")
+    func settingsDefaultPreset() {
+        let settings = AppSettings(defaults: UserDefaults(suiteName: "test-presets-\(UUID())")!)
+        #expect(settings.capturePreset == .freeform)
+        #expect(settings.customCapturePresets.isEmpty)
+        #expect(settings.hiddenBuiltinPresets.isEmpty)
+    }
+
+    @Test("AppSettings persists capture preset round-trip")
+    func settingsPersistPreset() {
+        let suite = UserDefaults(suiteName: "test-presets-\(UUID())")!
+        let settings = AppSettings(defaults: suite)
+        settings.capturePreset = .aspectRatio(width: 16, height: 9, name: nil)
+
+        let settings2 = AppSettings(defaults: suite)
+        #expect(settings2.capturePreset == .aspectRatio(width: 16, height: 9, name: nil))
+    }
+
+    @Test("visiblePresets excludes hidden built-ins")
+    func visiblePresetsFiltering() {
+        let suite = UserDefaults(suiteName: "test-presets-\(UUID())")!
+        let settings = AppSettings(defaults: suite)
+        settings.hiddenBuiltinPresets = [.aspectRatio(width: 3, height: 2, name: nil)]
+        settings.customCapturePresets = [.fixedSize(width: 800, height: 600, name: "Custom")]
+
+        let visible = settings.visiblePresets
+        #expect(!visible.contains(.aspectRatio(width: 3, height: 2, name: nil)))
+        #expect(visible.contains(.fixedSize(width: 800, height: 600, name: "Custom")))
+        #expect(visible.first == .freeform)
+    }
+}


### PR DESCRIPTION
## Summary
- Add aspect ratio constraints (1:1, 4:3, 16:9, 3:2) and fixed pixel size presets (512×512, 720p, 1080p) to area capture mode
- Press `R` to cycle presets, `Shift+R` to reverse, right-click for full preset picker menu
- Settings toggle to enable/disable the feature with usage tips
- Custom presets can be added/removed in Settings > Screenshots > Capture Presets
- Add Screenshot History keyboard shortcut (`Option+Shift+9`)

Closes #50

## Key Changes
| Area | Details |
|---|---|
| **Data Model** | `CapturePreset` enum in SharedKit with `Codable`/`Hashable`/`Sendable` |
| **Persistence** | `capturePreset`, `customCapturePresets`, `hiddenBuiltinPresets` in AppSettings |
| **Overlay UX** | Preset badge, R-key cycling, right-click NSMenu, ratio-constrained drag, fixed-size click-to-capture |
| **Multi-screen** | Preset changes sync across all overlay windows via NotificationCenter |
| **Settings UI** | Feature toggle, usage tips, built-in show/hide, custom preset add/remove |
| **Scoping** | OCR and Recording overlays always use freeform (presets disabled) |
| **Localization** | All new strings translated to zh-Hans, ja, ko |
| **Shortcut** | Screenshot History → `Option+Shift+9` |

## Test plan
- [x] Trigger area capture → verify "Freeform  R to change" badge at top
- [x] Press R → badge cycles through presets on all screens simultaneously
- [x] Shift+R → cycles in reverse
- [x] Right-click → preset menu with sections, checkmark, "Manage Presets..."
- [x] Select 1:1 → drag → verify square constraint, reticle stays at corner
- [x] Drag to screen edge → verify ratio is maintained (clamped)
- [x] Select 512×512 → verify fixed rectangle follows cursor, click captures
- [x] Release mouse → verify captured image matches the constrained selection exactly
- [x] OCR capture → verify no preset badge, no R-key, freeform only
- [x] Recording area select → verify freeform only
- [x] Settings > Screenshots > toggle off "Capture Presets" → verify freeform only
- [x] "Manage Presets..." → verify Settings opens on Screenshots tab
- [x] Add/remove custom preset → verify it appears/disappears in R-cycle and menu
- [x] Option+Shift+9 → verify Screenshot History opens
- [x] Verify zh-Hans/ja/ko translations in Settings UI
<img width="1360" height="1024" alt="image" src="https://github.com/user-attachments/assets/da247c21-b5f2-4d1f-a408-4c603249c34d" />
