### PR TITLE
fix: merge system audio + mic into one track on export (#55)

### DIFF
--- a/Packages/ExportKit/Package.swift
+++ b/Packages/ExportKit/Package.swift
@@ -7,6 +7,6 @@ let package = Package(
     dependencies: [.package(path: "../SharedKit"), .package(path: "../EffectsKit")],
     targets: [
         .target(name: "ExportKit", dependencies: ["SharedKit", "EffectsKit"]),
-        .testTarget(name: "ExportKitTests", dependencies: ["ExportKit"]),
+        .testTarget(name: "ExportKitTests", dependencies: ["ExportKit", "SharedKit"]),
     ]
 )

--- a/Packages/ExportKit/Sources/ExportKit/MP4Exporter.swift
+++ b/Packages/ExportKit/Sources/ExportKit/MP4Exporter.swift
@@ -11,6 +11,21 @@ enum MP4Exporter {
         progress: (@Sendable (Double) -> Void)?
     ) async throws -> URL {
         let asset = AVURLAsset(url: source)
+        let audioTracks = try await asset.loadTracks(withMediaType: .audio)
+
+        // Recordings that captured system audio + microphone end up with two
+        // AAC tracks in the container. Passthrough export preserves both tracks,
+        // but most consumer tools (Slack, Linear, macOS Services) only read the
+        // first one — so the shared file sounds silent even though both tracks
+        // are present. Merge them into a single mixed track. (issue #55)
+        if audioTracks.count > 1 {
+            return try await exportWithMergedAudio(
+                asset: asset,
+                audioTracks: audioTracks,
+                destination: destination,
+                progress: progress
+            )
+        }
 
         let presetName = switch quality {
         case .maximum: AVAssetExportPresetPassthrough
@@ -54,5 +69,165 @@ enum MP4Exporter {
 
         progress?(1.0)
         return destination
+    }
+
+    /// Merge multiple source audio tracks into a single AAC track using
+    /// `AVAssetReaderAudioMixOutput` (which sums/mixes all supplied tracks
+    /// to PCM) and re-encode through `AVAssetWriter`. Video is passed
+    /// through uncompressed.
+    private static func exportWithMergedAudio(
+        asset: AVURLAsset,
+        audioTracks: [AVAssetTrack],
+        destination: URL,
+        progress: (@Sendable (Double) -> Void)?
+    ) async throws -> URL {
+        try? FileManager.default.removeItem(at: destination)
+
+        let reader: AVAssetReader
+        let writer: AVAssetWriter
+        do {
+            reader = try AVAssetReader(asset: asset)
+            writer = try AVAssetWriter(outputURL: destination, fileType: .mp4)
+        } catch {
+            throw ExportError.exportSessionFailed(error.localizedDescription)
+        }
+        writer.shouldOptimizeForNetworkUse = true
+
+        // Video track: read compressed samples, write them through unchanged.
+        var videoPair: (output: AVAssetReaderOutput, input: AVAssetWriterInput)?
+        if let sourceVideo = try await asset.loadTracks(withMediaType: .video).first {
+            let output = AVAssetReaderTrackOutput(track: sourceVideo, outputSettings: nil)
+            output.alwaysCopiesSampleData = false
+            guard reader.canAdd(output) else {
+                throw ExportError.exportSessionFailed("Could not add video reader output")
+            }
+            reader.add(output)
+
+            let formatDescriptions = try await sourceVideo.load(.formatDescriptions)
+            let input = AVAssetWriterInput(
+                mediaType: .video,
+                outputSettings: nil,
+                sourceFormatHint: formatDescriptions.first
+            )
+            input.expectsMediaDataInRealTime = false
+            input.transform = try await sourceVideo.load(.preferredTransform)
+            guard writer.canAdd(input) else {
+                throw ExportError.exportSessionFailed("Could not add video writer input")
+            }
+            writer.add(input)
+            videoPair = (output, input)
+        }
+
+        // Audio: mix all source tracks into a single PCM stream, encode as AAC.
+        let pcmSettings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: 48_000,
+            AVNumberOfChannelsKey: 2,
+            AVLinearPCMBitDepthKey: 32,
+            AVLinearPCMIsFloatKey: true,
+            AVLinearPCMIsNonInterleaved: false,
+            AVLinearPCMIsBigEndianKey: false,
+        ]
+        let audioOutput = AVAssetReaderAudioMixOutput(audioTracks: audioTracks, audioSettings: pcmSettings)
+        audioOutput.alwaysCopiesSampleData = false
+        guard reader.canAdd(audioOutput) else {
+            throw ExportError.exportSessionFailed("Could not add audio mix output")
+        }
+        reader.add(audioOutput)
+
+        let aacSettings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatMPEG4AAC,
+            AVSampleRateKey: 48_000,
+            AVNumberOfChannelsKey: 2,
+            AVEncoderBitRateKey: 256_000,
+        ]
+        let audioInput = AVAssetWriterInput(mediaType: .audio, outputSettings: aacSettings)
+        audioInput.expectsMediaDataInRealTime = false
+        guard writer.canAdd(audioInput) else {
+            throw ExportError.exportSessionFailed("Could not add audio writer input")
+        }
+        writer.add(audioInput)
+
+        guard reader.startReading() else {
+            throw ExportError.exportSessionFailed(reader.error?.localizedDescription ?? "Reader failed to start")
+        }
+        guard writer.startWriting() else {
+            throw ExportError.exportSessionFailed(writer.error?.localizedDescription ?? "Writer failed to start")
+        }
+        writer.startSession(atSourceTime: .zero)
+
+        // Round-robin drain on a dedicated thread so the reader's internal
+        // buffers for both tracks stay balanced. AVFoundation types aren't
+        // Sendable, so wrap the work in a non-Sendable closure via a
+        // continuation rather than a Swift Task.
+        try await runDrain(videoPair: videoPair, audioOutput: audioOutput, audioInput: audioInput)
+
+        if reader.status == .failed {
+            throw ExportError.exportSessionFailed(reader.error?.localizedDescription ?? "Reader failed")
+        }
+
+        await writer.finishWriting()
+        if writer.status != .completed {
+            throw ExportError.exportSessionFailed(writer.error?.localizedDescription ?? "Writer did not complete")
+        }
+
+        progress?(1.0)
+        return destination
+    }
+
+    /// Round-robin pull from each reader output into the matching writer input
+    /// until both sources are drained. Runs on a private dispatch queue so the
+    /// caller's actor isn't blocked.
+    private static func runDrain(
+        videoPair: (output: AVAssetReaderOutput, input: AVAssetWriterInput)?,
+        audioOutput: AVAssetReaderOutput,
+        audioInput: AVAssetWriterInput
+    ) async throws {
+        let queue = DispatchQueue(label: "com.capso.mp4exporter.drain")
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            queue.async {
+                var videoDone = videoPair == nil
+                var audioDone = false
+                while !videoDone || !audioDone {
+                    var madeProgress = false
+                    if !videoDone, let pair = videoPair, pair.input.isReadyForMoreMediaData {
+                        if let buffer = pair.output.copyNextSampleBuffer() {
+                            if !pair.input.append(buffer) {
+                                pair.input.markAsFinished()
+                                audioInput.markAsFinished()
+                                cont.resume(throwing: ExportError.exportSessionFailed(
+                                    "Failed to append video sample"))
+                                return
+                            }
+                            madeProgress = true
+                        } else {
+                            pair.input.markAsFinished()
+                            videoDone = true
+                            madeProgress = true
+                        }
+                    }
+                    if !audioDone, audioInput.isReadyForMoreMediaData {
+                        if let buffer = audioOutput.copyNextSampleBuffer() {
+                            if !audioInput.append(buffer) {
+                                audioInput.markAsFinished()
+                                videoPair?.input.markAsFinished()
+                                cont.resume(throwing: ExportError.exportSessionFailed(
+                                    "Failed to append audio sample"))
+                                return
+                            }
+                            madeProgress = true
+                        } else {
+                            audioInput.markAsFinished()
+                            audioDone = true
+                            madeProgress = true
+                        }
+                    }
+                    if !madeProgress {
+                        Thread.sleep(forTimeInterval: 0.001)
+                    }
+                }
+                cont.resume()
+            }
+        }
     }
 }

--- a/Packages/ExportKit/Tests/ExportKitTests/DualAudioFixture.swift
+++ b/Packages/ExportKit/Tests/ExportKitTests/DualAudioFixture.swift
@@ -1,0 +1,193 @@
+import AVFoundation
+import CoreMedia
+import Foundation
+
+/// Builds short `.mov` fixtures that mirror Capso's real recording pipeline:
+/// H.264 video + one or two AAC audio tracks in a QuickTime container.
+enum DualAudioFixture {
+    enum FixtureError: Error {
+        case writerSetupFailed
+        case pixelBufferCreateFailed
+        case audioFormatCreateFailed
+        case blockBufferCreateFailed
+        case sampleBufferCreateFailed
+        case writerFinishFailed(Error?)
+    }
+
+    static func make(audioTrackCount: Int = 2,
+                     durationSeconds: Double = 0.5) throws -> URL {
+        precondition((1...2).contains(audioTrackCount))
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-fixture-\(UUID().uuidString).mov")
+        try? FileManager.default.removeItem(at: url)
+
+        let writer = try AVAssetWriter(outputURL: url, fileType: .mov)
+
+        let width = 160
+        let height = 120
+        let fps: Int32 = 30
+
+        let videoInput = AVAssetWriterInput(mediaType: .video, outputSettings: [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: width,
+            AVVideoHeightKey: height,
+        ])
+        videoInput.expectsMediaDataInRealTime = false
+        guard writer.canAdd(videoInput) else { throw FixtureError.writerSetupFailed }
+        writer.add(videoInput)
+
+        let audioSettings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatMPEG4AAC,
+            AVSampleRateKey: 48_000,
+            AVNumberOfChannelsKey: 2,
+            AVEncoderBitRateKey: 128_000,
+        ]
+        var audioInputs: [AVAssetWriterInput] = []
+        for _ in 0..<audioTrackCount {
+            let input = AVAssetWriterInput(mediaType: .audio, outputSettings: audioSettings)
+            input.expectsMediaDataInRealTime = false
+            guard writer.canAdd(input) else { throw FixtureError.writerSetupFailed }
+            writer.add(input)
+            audioInputs.append(input)
+        }
+
+        let pbAdaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: videoInput,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+                kCVPixelBufferWidthKey as String: width,
+                kCVPixelBufferHeightKey as String: height,
+            ]
+        )
+
+        guard writer.startWriting() else { throw FixtureError.writerSetupFailed }
+        writer.startSession(atSourceTime: .zero)
+
+        let frameDuration = CMTime(value: 1, timescale: fps)
+        let frameCount = max(1, Int(Double(fps) * durationSeconds))
+
+        for i in 0..<frameCount {
+            while !videoInput.isReadyForMoreMediaData { Thread.sleep(forTimeInterval: 0.001) }
+            let pb = try makeBlackPixelBuffer(width: width, height: height)
+            let pts = CMTimeMultiply(frameDuration, multiplier: Int32(i))
+            if !pbAdaptor.append(pb, withPresentationTime: pts) {
+                throw FixtureError.writerFinishFailed(writer.error)
+            }
+        }
+        videoInput.markAsFinished()
+
+        for input in audioInputs {
+            try writeSilence(into: input, seconds: durationSeconds)
+            input.markAsFinished()
+        }
+
+        let done = DispatchGroup()
+        done.enter()
+        writer.finishWriting { done.leave() }
+        done.wait()
+        guard writer.status == .completed else {
+            throw FixtureError.writerFinishFailed(writer.error)
+        }
+        return url
+    }
+
+    // MARK: - Helpers
+
+    private static func makeBlackPixelBuffer(width: Int, height: Int) throws -> CVPixelBuffer {
+        var pb: CVPixelBuffer?
+        let status = CVPixelBufferCreate(
+            kCFAllocatorDefault, width, height, kCVPixelFormatType_32BGRA,
+            [kCVPixelBufferCGImageCompatibilityKey: true,
+             kCVPixelBufferCGBitmapContextCompatibilityKey: true] as CFDictionary,
+            &pb)
+        guard status == kCVReturnSuccess, let pb else {
+            throw FixtureError.pixelBufferCreateFailed
+        }
+        CVPixelBufferLockBaseAddress(pb, [])
+        defer { CVPixelBufferUnlockBaseAddress(pb, []) }
+        let base = CVPixelBufferGetBaseAddress(pb)!
+        let bpr = CVPixelBufferGetBytesPerRow(pb)
+        memset(base, 0, bpr * height)
+        return pb
+    }
+
+    private static func writeSilence(into input: AVAssetWriterInput, seconds: Double) throws {
+        let sampleRate: Float64 = 48_000
+        let channels: UInt32 = 2
+        let bytesPerFrame: UInt32 = 4 * channels  // Float32 interleaved
+
+        var asbd = AudioStreamBasicDescription(
+            mSampleRate: sampleRate,
+            mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kLinearPCMFormatFlagIsFloat | kLinearPCMFormatFlagIsPacked,
+            mBytesPerPacket: bytesPerFrame,
+            mFramesPerPacket: 1,
+            mBytesPerFrame: bytesPerFrame,
+            mChannelsPerFrame: channels,
+            mBitsPerChannel: 32,
+            mReserved: 0
+        )
+        var format: CMAudioFormatDescription?
+        let formatStatus = CMAudioFormatDescriptionCreate(
+            allocator: kCFAllocatorDefault,
+            asbd: &asbd, layoutSize: 0, layout: nil,
+            magicCookieSize: 0, magicCookie: nil,
+            extensions: nil, formatDescriptionOut: &format
+        )
+        guard formatStatus == noErr, let format else {
+            throw FixtureError.audioFormatCreateFailed
+        }
+
+        let totalFrames = Int(sampleRate * seconds)
+        let chunkFrames = 1024
+        var written = 0
+        while written < totalFrames {
+            let frames = min(chunkFrames, totalFrames - written)
+            let dataSize = frames * Int(bytesPerFrame)
+
+            var block: CMBlockBuffer?
+            let blockStatus = CMBlockBufferCreateWithMemoryBlock(
+                allocator: kCFAllocatorDefault,
+                memoryBlock: nil, blockLength: dataSize,
+                blockAllocator: nil, customBlockSource: nil,
+                offsetToData: 0, dataLength: dataSize,
+                flags: kCMBlockBufferAssureMemoryNowFlag,
+                blockBufferOut: &block
+            )
+            guard blockStatus == kCMBlockBufferNoErr, let block else {
+                throw FixtureError.blockBufferCreateFailed
+            }
+            CMBlockBufferFillDataBytes(with: 0, blockBuffer: block,
+                                       offsetIntoDestination: 0, dataLength: dataSize)
+
+            var timing = CMSampleTimingInfo(
+                duration: CMTime(value: 1, timescale: CMTimeScale(sampleRate)),
+                presentationTimeStamp: CMTime(value: CMTimeValue(written),
+                                              timescale: CMTimeScale(sampleRate)),
+                decodeTimeStamp: .invalid
+            )
+            var sampleSize = Int(bytesPerFrame)
+            var sample: CMSampleBuffer?
+            let sbStatus = CMSampleBufferCreate(
+                allocator: kCFAllocatorDefault,
+                dataBuffer: block, dataReady: true,
+                makeDataReadyCallback: nil, refcon: nil,
+                formatDescription: format,
+                sampleCount: CMItemCount(frames),
+                sampleTimingEntryCount: 1, sampleTimingArray: &timing,
+                sampleSizeEntryCount: 1, sampleSizeArray: &sampleSize,
+                sampleBufferOut: &sample
+            )
+            guard sbStatus == noErr, let sample else {
+                throw FixtureError.sampleBufferCreateFailed
+            }
+
+            while !input.isReadyForMoreMediaData { Thread.sleep(forTimeInterval: 0.001) }
+            if !input.append(sample) {
+                throw FixtureError.sampleBufferCreateFailed
+            }
+            written += frames
+        }
+    }
+}

--- a/Packages/ExportKit/Tests/ExportKitTests/MP4ExporterAudioMergeTests.swift
+++ b/Packages/ExportKit/Tests/ExportKitTests/MP4ExporterAudioMergeTests.swift
@@ -1,0 +1,56 @@
+import AVFoundation
+import Foundation
+import SharedKit
+import Testing
+
+@testable import ExportKit
+
+/// Regression coverage for https://github.com/lzhgus/Capso/issues/55
+///
+/// When both system audio and microphone are captured, Capso writes two
+/// separate AAC tracks into the raw `.mov`. Most consumer tools (Slack,
+/// Linear, macOS Services re-encode) only read the first audio track, so
+/// the exported `.mp4` must merge them into a single mixed track.
+struct MP4ExporterAudioMergeTests {
+    @Test
+    func exportMergesDualAudioTracksIntoOne() async throws {
+        let source = try DualAudioFixture.make()
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let dest = FileManager.default.temporaryDirectory
+            .appendingPathComponent("issue55-\(UUID().uuidString).mp4")
+        defer { try? FileManager.default.removeItem(at: dest) }
+
+        let exported = try await VideoExporter.export(
+            source: source,
+            options: ExportOptions(format: .mp4, quality: .maximum, destination: dest)
+        )
+
+        let asset = AVURLAsset(url: exported)
+        let audioTracks = try await asset.loadTracks(withMediaType: .audio)
+        let videoTracks = try await asset.loadTracks(withMediaType: .video)
+
+        #expect(audioTracks.count == 1, "Exported file must contain a single audio track")
+        #expect(videoTracks.count == 1, "Exported file must contain a single video track")
+    }
+
+    @Test
+    func exportPreservesSingleAudioTrack() async throws {
+        let source = try DualAudioFixture.make(audioTrackCount: 1)
+        defer { try? FileManager.default.removeItem(at: source) }
+
+        let dest = FileManager.default.temporaryDirectory
+            .appendingPathComponent("issue55-single-\(UUID().uuidString).mp4")
+        defer { try? FileManager.default.removeItem(at: dest) }
+
+        let exported = try await VideoExporter.export(
+            source: source,
+            options: ExportOptions(format: .mp4, quality: .maximum, destination: dest)
+        )
+
+        let asset = AVURLAsset(url: exported)
+        let audioTracks = try await asset.loadTracks(withMediaType: .audio)
+
+        #expect(audioTracks.count == 1)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [#55](https://github.com/lzhgus/Capso/issues/55) — audio disappears when shared via Slack/Linear/paste/macOS Services re-encode.

**Root cause:** Capso records system audio and microphone as two separate AAC tracks in the raw `.mov`. `AVAssetExportSession` passthrough preserves both tracks in the exported `.mp4`, but most consumer tools only read the first audio track, so the file sounds silent after sharing even though the audio is technically present.

Confirmed with `ffprobe` on real history recordings: source has 2× AAC tracks; exported `.mp4` previously kept both; after this fix, the exported `.mp4` has exactly 1 AAC track containing both sources mixed.

## Fix

When the source has >1 audio track, route the export through `AVAssetReader` + `AVAssetWriter`:
- Video is passed through uncompressed (same resolution, same bitrate).
- `AVAssetReaderAudioMixOutput` sums all audio tracks to PCM; the writer re-encodes them as a single 48 kHz stereo AAC track at 256 kbps.

Single-track recordings continue through the existing fast `AVAssetExportSession` passthrough path — no behavior change for users who only captured one audio source.

## Test plan

- [x] New unit tests (`MP4ExporterAudioMergeTests`) with a programmatic dual-audio `.mov` fixture
  - `exportMergesDualAudioTracksIntoOne` — RED first, then GREEN after fix
  - `exportPreservesSingleAudioTrack` — guards against regression in the single-track path
- [x] `swift test` in `Packages/ExportKit` — all green
- [x] Manual end-to-end verification on a real 15 s Capso recording with 2× AAC tracks
  - Before fix: shared `.mp4` keeps both tracks → audio lost in Slack/Linear
  - After fix: shared `.mp4` has 1 track, duration preserved, video bit-exact passthrough
- [x] Manual check: record with mic + system audio on, save, upload to Slack, confirm audio plays
- [x] Manual check: record with mic only (single track), save, confirm existing behavior unchanged
