### PR TITLE
fix: keep the red recording border out of the captured video (#60)

### DIFF
--- a/App/Sources/Recording/RecordingBorderWindow.swift
+++ b/App/Sources/Recording/RecordingBorderWindow.swift
@@ -3,9 +3,19 @@ import AppKit
 
 @MainActor
 final class RecordingBorderWindow: NSPanel {
+    static let borderWidth: CGFloat = 3
+    // Gap between the stroke's inner edge and the capture rect so anti-aliasing
+    // can't bleed red into the recorded video.
+    static let safetyMargin: CGFloat = 2
+    static var outset: CGFloat { borderWidth + safetyMargin }
+
+    // `frame` is the capture rect. The window is expanded outward by
+    // `outset` on each side; the stroke is drawn in the outer `borderWidth`
+    // of the window, so the red pixels sit entirely outside the capture rect.
     init(frame: CGRect, screen: NSScreen) {
+        let outsetFrame = frame.insetBy(dx: -Self.outset, dy: -Self.outset)
         super.init(
-            contentRect: frame,
+            contentRect: outsetFrame,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -17,21 +27,29 @@ final class RecordingBorderWindow: NSPanel {
         self.hasShadow = false
         self.ignoresMouseEvents = true
         self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        // Avoid the default panel fade-in so the first captured frame never
+        // sees a half-rendered border.
+        self.animationBehavior = .none
 
-        let borderView = RecordingBorderView(frame: NSRect(origin: .zero, size: frame.size))
+        let borderView = RecordingBorderView(frame: NSRect(origin: .zero, size: outsetFrame.size))
         self.contentView = borderView
     }
 
-    func show() { makeKeyAndOrderFront(nil) }
+    func show() {
+        orderFrontRegardless()
+    }
     func hide() { orderOut(nil) }
 }
 
 private class RecordingBorderView: NSView {
     override func draw(_ dirtyRect: NSRect) {
         guard let context = NSGraphicsContext.current?.cgContext else { return }
-        let borderWidth: CGFloat = 3
+        let borderWidth = RecordingBorderWindow.borderWidth
+        // Place the stroke's outer edge on the window's outer edge so the full
+        // stroke sits outside the capture rect (which starts `outset` points in).
         let inset = borderWidth / 2
         let rect = bounds.insetBy(dx: inset, dy: inset)
+        context.setShouldAntialias(false)
         context.setStrokeColor(NSColor.systemRed.cgColor)
         context.setLineWidth(borderWidth)
         context.stroke(rect)

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -336,12 +336,24 @@ final class RecordingCoordinator {
             guard let self else { return }
             Task { @MainActor in
                 do {
-                    try await self.recorder.startRecording(config: config)
+                    // Show the red border before starting the stream so its
+                    // window ID can be passed to SCContentFilter — otherwise
+                    // it gets composited into the first captured frames.
+                    self.showBorder()
+                    self.borderWindow?.displayIfNeeded()
+                    let excludeIDs: [CGWindowID]
+                    if let n = self.borderWindow?.windowNumber, n > 0 {
+                        excludeIDs = [CGWindowID(n)]
+                    } else {
+                        excludeIDs = []
+                    }
+                    try await self.recorder.startRecording(config: config, excludeWindowIDs: excludeIDs)
                     self.startClickHighlight()
                     self.showRecordingControls()
-                    self.showBorder()
                 } catch {
                     print("Recording failed to start: \(error)")
+                    self.borderWindow?.hide()
+                    self.borderWindow = nil
                     if cameraEnabled {
                         self.cameraPiPWindow?.close()
                         self.cameraPiPWindow = nil

--- a/Packages/RecordingKit/Sources/RecordingKit/ScreenRecorder.swift
+++ b/Packages/RecordingKit/Sources/RecordingKit/ScreenRecorder.swift
@@ -40,6 +40,8 @@ public enum RecordingError: Error, LocalizedError {
 @MainActor
 @Observable
 public final class ScreenRecorder {
+    private static let excludedWindowLookupDelay: Duration = .milliseconds(30)
+    private static let excludedWindowLookupAttempts = 8
 
     public private(set) var state: RecordingState = .idle
     public private(set) var elapsedTime: TimeInterval = 0
@@ -56,7 +58,10 @@ public final class ScreenRecorder {
 
     public init() {}
 
-    public func startRecording(config: RecordingConfig) async throws {
+    public func startRecording(
+        config: RecordingConfig,
+        excludeWindowIDs: [CGWindowID] = []
+    ) async throws {
         capsoLog("startRecording rect=\(config.captureRect) display=\(config.displayID)")
         guard state == .idle else { throw RecordingError.alreadyRecording }
 
@@ -74,7 +79,7 @@ public final class ScreenRecorder {
             let dims = videoDims(for: config.captureRect)
 
             // Set up SCStream first (creates the dispatch queue)
-            try await setupStream(config: config, dims: dims)
+            try await setupStream(config: config, dims: dims, excludeWindowIDs: excludeWindowIDs)
 
             // Create writer ON the recording dispatch queue (thread affinity —
             // AVAssetWriter's AAC encoder must be created and used on same thread)
@@ -152,13 +157,21 @@ public final class ScreenRecorder {
                   h: ensureEven(Int(ceil(rect.height)) * 2))
     }
 
-    private func setupStream(config: RecordingConfig, dims: VideoDims) async throws {
-        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+    private func setupStream(config: RecordingConfig, dims: VideoDims, excludeWindowIDs: [CGWindowID]) async throws {
+        let excludeSet = Set(excludeWindowIDs)
+        let content = try await shareableContent(excludingWindowIDs: excludeSet)
         guard let display = content.displays.first(where: { $0.displayID == config.displayID }) else {
             throw RecordingError.noMatchingDisplay
         }
 
-        let filter = SCContentFilter(display: display, excludingWindows: [])
+        let excludedWindows = excludeSet.isEmpty
+            ? []
+            : content.windows.filter { excludeSet.contains($0.windowID) }
+        if !excludeSet.isEmpty, excludedWindows.count != excludeSet.count {
+            let missingIDs = excludeSet.subtracting(excludedWindows.map(\.windowID))
+            capsoLog("Proceeding without excluding windows: \(missingIDs)")
+        }
+        let filter = SCContentFilter(display: display, excludingWindows: excludedWindows)
         let sc = SCStreamConfiguration()
 
         sc.width = dims.w
@@ -200,6 +213,32 @@ public final class ScreenRecorder {
         }
 
         self.stream = captureStream; self.streamOutput = output
+    }
+
+    private func shareableContent(excludingWindowIDs excludeSet: Set<CGWindowID>) async throws -> SCShareableContent {
+        var content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+        guard !excludeSet.isEmpty else { return content }
+
+        for attempt in 1...Self.excludedWindowLookupAttempts {
+            let matchedIDs = Set(content.windows.map(\.windowID)).intersection(excludeSet)
+            if matchedIDs == excludeSet {
+                if attempt > 1 {
+                    capsoLog("Excluded windows became visible after \(attempt) attempts")
+                }
+                return content
+            }
+
+            if attempt == Self.excludedWindowLookupAttempts {
+                let missingIDs = excludeSet.subtracting(matchedIDs)
+                capsoLog("Timed out waiting for excluded windows: \(missingIDs)")
+                return content
+            }
+
+            try? await Task.sleep(for: Self.excludedWindowLookupDelay)
+            content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+        }
+
+        return content
     }
 
     private func startElapsedTimer() {


### PR DESCRIPTION
## What changed

The red recording-area border was showing up in the exported video — a red stroke along each edge at the start of every recording.

**Root cause:** the border window's frame equaled the capture rect, so the 3pt stroke fell *inside* the captured area, and nothing excluded the window from `SCStream`.

**Fix — two independent layers:**

1. `RecordingBorderWindow` now expands outward by `borderWidth + safetyMargin` (5pt) and draws the stroke in the outer 3pt of the window, leaving a **2pt gap** between the red pixels and the capture rect. Anti-aliasing is disabled and the panel fade-in is suppressed so the first captured frame can't catch a half-rendered border.
2. `RecordingCoordinator` shows the border *before* starting the stream and passes its window ID to `ScreenRecorder.startRecording`. The recorder polls `SCShareableContent` until the window is registered (up to 8 × 30ms) and hands it to `SCContentFilter(excludingWindows:)` so ScreenCaptureKit never composites it.

Either layer alone should be enough; together they close the race where the panel isn't yet known to the Window Server when the stream is created.

## Related issue

Closes #60

## Screenshots / recordings

_Reviewer: please verify with a fresh recording — the red edge should be absent from the first frame onward._

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed _(no layout changes, but ran it)_
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass _(no tests in RecordingKit for this path)_
- [x] No new TODO / FIXME / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency
- [x] I agree that my contribution is licensed under BSL 1.1 per CONTRIBUTING.md
