### PR TITLE
chore: add Buy Me a Coffee sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,3 @@
 github: [lzhgus]
+buy_me_a_coffee: lzhgus
 custom: ["https://www.awesomemacapp.com/"]


### PR DESCRIPTION
## What changed

Adds `buy_me_a_coffee: lzhgus` to `.github/FUNDING.yml` so the Buy Me a Coffee button appears on the repo's Sponsor panel alongside the existing GitHub Sponsors and custom links.

Once merged to `main`, GitHub will render `buymeacoffee.com/lzhgus` in the "Sponsor this project" sidebar.

## Related issue

N/A — sponsorship configuration.

## Screenshots / recordings

N/A — no UI change in the app itself.

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed — N/A, docs-only
- [x] `xcodebuild ... build` passes — N/A, no code changes
- [x] Tests for any touched package pass — N/A, no code changes
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency — N/A, no Swift changes
- [x] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)

🤖 Generated with [Claude Code](https://claude.com/claude-code)