### PR TITLE
feat: add option to hide menu bar icon

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -4764,6 +4764,71 @@
         "ko" : { "stringUnit" : { "state" : "translated", "value" : "스크린샷과 녹화가 여기에 표시됩니다" } },
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "截图和录屏记录将显示在这里" } }
       }
+    },
+    "Show Menu Bar Icon" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "メニューバーアイコンを表示" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "메뉴 바 아이콘 표시" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "显示菜单栏图标" } }
+      }
+    },
+    "Hide for a minimalist menu bar — shortcuts still work" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ミニマルなメニューバーのために非表示にする — ショートカットは引き続き使えます" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "미니멀한 메뉴 바를 위해 숨기기 — 단축키는 계속 작동합니다" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "隐藏以保持菜单栏简洁——快捷键仍可使用" } }
+      }
+    },
+    "Hide menu bar icon?" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "メニューバーアイコンを非表示にしますか？" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "메뉴 바 아이콘을 숨기시겠습니까?" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "隐藏菜单栏图标？" } }
+      }
+    },
+    "Hide Icon" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "非表示にする" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "숨기기" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "隐藏图标" } }
+      }
+    },
+    "not set" : {
+      "comment" : "Shown in the hide-menu-bar-icon confirmation dialog when the user has not assigned a global shortcut for the listed action.",
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "未設定" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "설정되지 않음" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "未设置" } }
+      }
+    },
+    "Capso will keep running, and your global shortcuts still work:\n\n• Capture Area: %@\n• Record Screen: %@\n• Screenshot History: %@\n\nTo open Preferences again, launch Capso from Spotlight, Launchpad, or Finder — even while it's still running." : {
+      "comment" : "Body text of the confirmation dialog when the user is about to hide the menu bar icon. Lists the three most useful global shortcuts (Capture Area, Record Screen, Screenshot History) and tells the user how to reopen Preferences afterwards.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capso will keep running, and your global shortcuts still work:\n\n• Capture Area: %1$@\n• Record Screen: %2$@\n• Screenshot History: %3$@\n\nTo open Preferences again, launch Capso from Spotlight, Launchpad, or Finder — even while it's still running."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capsoは動作し続け、グローバルショートカットも引き続き使えます:\n\n• エリアをキャプチャ: %1$@\n• 画面を録画: %2$@\n• スクリーンショット履歴: %3$@\n\n設定を再び開くには、Spotlight、Launchpad、Finder から Capso を起動してください — 起動中でも開きます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capso는 계속 실행되며, 전역 단축키도 정상적으로 작동합니다:\n\n• 영역 캡처: %1$@\n• 화면 녹화: %2$@\n• 스크린샷 기록: %3$@\n\n환경설정을 다시 열려면 Spotlight, Launchpad 또는 Finder에서 Capso를 실행하세요 — 실행 중이어도 열립니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capso 会继续运行,全局快捷键仍可正常使用:\n\n• 截取区域: %1$@\n• 录制屏幕: %2$@\n• 截图历史: %3$@\n\n要再次打开偏好设置,从 Spotlight、Launchpad 或 Finder 启动 Capso 即可——即使它正在运行也可以。"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -4765,6 +4765,94 @@
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "截图和录屏记录将显示在这里" } }
       }
     },
+    "Report a Bug" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "バグを報告" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "버그 신고" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "报告 Bug" } }
+      }
+    },
+    "Found something broken?" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "不具合を見つけましたか？" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "문제를 발견하셨나요?" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "发现问题了吗？" } }
+      }
+    },
+    "Request a Feature" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "機能をリクエスト" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "기능 요청" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "请求新功能" } }
+      }
+    },
+    "Have an idea?" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "アイデアがありますか？" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "좋은 아이디어가 있으신가요?" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "有什么想法？" } }
+      }
+    },
+    "Source Code" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ソースコード" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "소스 코드" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "源代码" } }
+      }
+    },
+    "View on GitHub" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "GitHub で表示" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "GitHub에서 보기" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "在 GitHub 上查看" } }
+      }
+    },
+    "Report" : {
+      "comment" : "Button label in About → Report a Bug row. Opens the bug report issue template.",
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "報告" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "신고" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "报告" } }
+      }
+    },
+    "Request" : {
+      "comment" : "Button label in About → Request a Feature row. Opens the feature request issue template.",
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "リクエスト" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "요청" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "请求" } }
+      }
+    },
+    "Open" : {
+      "comment" : "Button label in About → Source Code row. Opens the GitHub repository in the browser.",
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "開く" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "열기" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "打开" } }
+      }
+    },
+    "Screenshot History..." : {
+      "comment" : "Menu bar item that opens the screenshot history window. The ellipsis follows macOS convention for items that open a window.",
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "スクリーンショット履歴..." } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "스크린샷 기록..." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "截图历史..." } }
+      }
+    },
+    "Open Editor After Recording" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "録画後にエディタを開く" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "녹화 후 편집기 열기" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "录制后打开编辑器" } }
+      }
+    },
+    "Edit, trim, and add effects before exporting" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "書き出す前に編集・トリミング・エフェクトを追加" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "내보내기 전에 편집, 자르기 및 효과 추가" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "导出前编辑、裁剪并添加特效" } }
+      }
+    },
     "Show Menu Bar Icon" : {
       "localizations" : {
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "メニューバーアイコンを表示" } },

--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -42,6 +42,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         registerGlobalShortcuts()
         historyCoordinator?.runCleanup()
 
+        // Safety net: if the menu bar icon is hidden, the user has no obvious
+        // way to access settings, so surface Preferences on launch.
+        if !settings.showMenuBarIcon {
+            DispatchQueue.main.async { [weak self] in
+                self?.showPreferences()
+            }
+        }
+
         NotificationCenter.default.addObserver(
             forName: .openScreenshotSettings,
             object: nil,
@@ -103,6 +111,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         false
+    }
+
+    /// Called when the user double-clicks the app while it's already running
+    /// (Spotlight, Launchpad, Finder). For an LSUIElement app with the menu
+    /// bar icon hidden, this is the user's only way back into Preferences.
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !settings.showMenuBarIcon {
+            showPreferences()
+        }
+        return true
     }
 
     func showPreferences() {

--- a/App/Sources/MenuBar/MenuBarController.swift
+++ b/App/Sources/MenuBar/MenuBarController.swift
@@ -3,6 +3,11 @@ import AppKit
 import SharedKit
 import KeyboardShortcuts
 
+extension Notification.Name {
+    /// Posted when `AppSettings.showMenuBarIcon` changes so the menu bar can show/hide live.
+    static let menuBarVisibilityChanged = Notification.Name("menuBarVisibilityChanged")
+}
+
 @MainActor
 final class MenuBarController: NSObject {
     private var statusItem: NSStatusItem?
@@ -21,7 +26,33 @@ final class MenuBarController: NSObject {
         self.historyCoordinator = historyCoordinator
         self.onShowPreferences = onShowPreferences
         super.init()
-        setupStatusItem()
+        applyVisibility()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleVisibilityChange),
+            name: .menuBarVisibilityChanged,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func handleVisibilityChange() {
+        applyVisibility()
+    }
+
+    /// Installs or removes the status item based on `settings.showMenuBarIcon`.
+    private func applyVisibility() {
+        if settings.showMenuBarIcon {
+            guard statusItem == nil else { return }
+            setupStatusItem()
+        } else {
+            guard let item = statusItem else { return }
+            NSStatusBar.system.removeStatusItem(item)
+            statusItem = nil
+        }
     }
 
     private func setupStatusItem() {

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -33,6 +33,7 @@ final class PreferencesViewModel {
             withMutation(keyPath: \.showMenuBarIcon) {
                 settings.showMenuBarIcon = newValue
             }
+            NotificationCenter.default.post(name: .menuBarVisibilityChanged, object: nil)
         }
     }
 

--- a/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
@@ -2,10 +2,25 @@
 import SwiftUI
 import LaunchAtLogin
 import AppKit
+import KeyboardShortcuts
 
 struct GeneralSettingsView: View {
     @Bindable var viewModel: PreferencesViewModel
     let updateManager: UpdateManager?
+    @State private var showHideMenuBarConfirmation = false
+
+    private var menuBarToggleBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.showMenuBarIcon },
+            set: { newValue in
+                if newValue {
+                    viewModel.showMenuBarIcon = true
+                } else {
+                    showHideMenuBarConfirmation = true
+                }
+            }
+        )
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -19,16 +34,11 @@ struct GeneralSettingsView: View {
                             .toggleStyle(.switch)
                             .controlSize(.small)
                     }
-                    // TODO: Re-enable "Show Menu Bar Icon" once MenuBarController
-                    // actually respects AppSettings.showMenuBarIcon. Today it
-                    // unconditionally installs the status item in
-                    // setupStatusItem(), so this toggle did nothing when flipped.
-                    // Uncomment the SettingRow below when the feature is wired.
-                    // SettingRow(label: "Show Menu Bar Icon", showDivider: true) {
-                    //     Toggle("", isOn: $viewModel.showMenuBarIcon)
-                    //         .toggleStyle(.switch)
-                    //         .controlSize(.small)
-                    // }
+                    SettingRow(label: "Show Menu Bar Icon", sublabel: "Hide for a minimalist menu bar — shortcuts still work", showDivider: true) {
+                        Toggle("", isOn: menuBarToggleBinding)
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                    }
                 }
             }
 
@@ -97,6 +107,29 @@ struct GeneralSettingsView: View {
                 }
             }
         }
+        .alert("Hide menu bar icon?", isPresented: $showHideMenuBarConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Hide Icon", role: .destructive) {
+                viewModel.showMenuBarIcon = false
+            }
+        } message: {
+            Text(hideMenuBarMessage)
+        }
+    }
+
+    private var hideMenuBarMessage: String {
+        let captureArea = shortcutDescription(for: .captureArea) ?? String(localized: "not set")
+        let recordScreen = shortcutDescription(for: .recordScreen) ?? String(localized: "not set")
+        let history = shortcutDescription(for: .screenshotHistory) ?? String(localized: "not set")
+        return String(
+            format: String(localized: "Capso will keep running, and your global shortcuts still work:\n\n• Capture Area: %@\n• Record Screen: %@\n• Screenshot History: %@\n\nTo open Preferences again, launch Capso from Spotlight, Launchpad, or Finder — even while it's still running."),
+            captureArea, recordScreen, history
+        )
+    }
+
+    private func shortcutDescription(for name: KeyboardShortcuts.Name) -> String? {
+        guard let shortcut = KeyboardShortcuts.getShortcut(for: name) else { return nil }
+        return shortcut.description
     }
 
     private func openURL(_ string: String) {

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -29,6 +29,26 @@ struct AppSettingsTests {
         #expect(settings.playShutterSound == true)
     }
 
+    @Test("Menu bar icon is shown by default")
+    func defaultShowMenuBarIcon() {
+        let suite = "test.showMenuBarIcon.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.showMenuBarIcon == true)
+    }
+
+    @Test("Hiding the menu bar icon persists across instances")
+    func showMenuBarIconPersists() {
+        let suite = "test.showMenuBarIcon.persists"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let first = AppSettings(defaults: defaults)
+        first.showMenuBarIcon = false
+        let second = AppSettings(defaults: defaults)
+        #expect(second.showMenuBarIcon == false)
+    }
+
     @Test("Default auto-close interval is 5 seconds")
     func defaultAutoCloseInterval() {
         let settings = AppSettings()


### PR DESCRIPTION
## What changed

Closes [#65](https://github.com/lzhgus/Capso/issues/65). Wires the dormant `AppSettings.showMenuBarIcon` field end-to-end so users can hide Capso's status item for a minimalist menu bar — without losing access to the app.

**Why now:** the field and the disabled toggle row already existed in code with a TODO to wire them up; the issue gave us the push to finish the job.

### Implementation

- **`MenuBarController`** — new `applyVisibility()` installs/removes the status item based on the setting, and listens for a `.menuBarVisibilityChanged` notification so the toggle takes effect live (no relaunch needed).
- **`PreferencesViewModel`** — posts the notification when the toggle flips.
- **`GeneralSettingsView`** — toggle row re-enabled with a confirmation alert that lists the user's *current* global shortcuts (Capture Area / Record Screen / Screenshot History) before hiding, so they know what still works.
- **`AppDelegate.applicationShouldHandleReopen`** — the critical safety net. Capso is `LSUIElement = true` (no Dock icon), so once the menu bar icon is hidden the user has no obvious way back in. Re-opening the app from Spotlight/Launchpad/Finder now surfaces Preferences automatically — no quit required. Cold launch with the icon hidden does the same.
- **Tests** — two new `AppSettings` tests for default value and persistence.

### Localization

All new user-facing strings localized into the four supported languages (`en`, `ja`, `ko`, `zh-Hans`), reusing the canonical translations of "Capture Area", "Record Screen", and "Screenshot History" already in the catalog. The dialog body uses positional `%1\$@..%3\$@` placeholders so future translators can reorder freely.

## Related issue

Closes #65

## Screenshots / recordings

_To be added — UI is the standard `SettingRow` toggle in **Preferences → General → Startup**, plus a native `.alert()` confirmation when turning it off._

## Checklist

- [x] \`xcodegen generate\` run if \`project.yml\` or source layout changed (no project.yml changes; ran anyway to verify)
- [x] \`xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build\` passes
- [x] Tests for any touched package pass (\`swift test --package-path Packages/SharedKit\` — 33/33 passing)
- [x] No new \`TODO\` / \`FIXME\` / debug prints left behind (one stale TODO in GeneralSettingsView removed)
- [x] Code follows Swift 6.0 strict concurrency (\`@MainActor\`, \`Sendable\` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)
