### PR TITLE
feat: Capture & Translate with Apple Translation + UX polish

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -13,11 +13,31 @@ final class AnnotationCanvasNSView: NSView {
     var document: AnnotationDocument?
     var sourceImage: CGImage?
     var currentTool: AnnotationTool = .select
-    var currentStyle: StrokeStyle = StrokeStyle()
+    var currentStyle: StrokeStyle = StrokeStyle() {
+        didSet { syncEditorStyle() }
+    }
+    /// Font size used for newly created TextObjects and propagated live to
+    /// the inline editor. Pushed from SwiftUI by AnnotationCanvasView.
+    var currentTextFontSize: CGFloat = 48 {
+        didSet { textEditor?.fontSize = currentTextFontSize }
+    }
     var onDocumentChanged: (() -> Void)?
     var onObjectCreated: (() -> Void)?
+    /// Fired when an inline text edit begins. Passes the effective fontSize
+    /// (matches the existing object when re-editing, or `currentTextFontSize`
+    /// for a fresh edit). SwiftUI uses it to flip `isEditingText` and — for
+    /// double-click re-edits — to sync the font-size slider to the object.
+    var onTextEditingStarted: ((CGFloat) -> Void)?
+    /// Fired on commit / cancel.
+    var onTextEditingEnded: (() -> Void)?
 
-    var zoomScale: CGFloat = 1.0
+    var zoomScale: CGFloat = 1.0 {
+        didSet {
+            guard zoomScale != oldValue, let editor = textEditor else { return }
+            editor.zoomScale = zoomScale
+            repositionEditor()
+        }
+    }
 
     private var dragStart: CGPoint?
     private var dragCurrent: CGPoint?
@@ -35,6 +55,14 @@ final class AnnotationCanvasNSView: NSView {
     /// When the highlighter starts on a text line, stores the line's
     /// bounding box so the stroke is constrained to a horizontal band.
     private var highlighterSnapRect: CGRect?
+
+    // MARK: - Inline text editing state
+
+    /// The currently-visible inline editor, if any.
+    private var textEditor: AnnotationTextEditor?
+    /// When re-editing an existing TextObject (double-click), holds it so we
+    /// can mutate it on commit rather than creating a new object.
+    private var editingOriginalObject: TextObject?
 
     private let handleRadius: CGFloat = 5  // in image coords (adjusted by zoom in drawing)
 
@@ -161,6 +189,12 @@ final class AnnotationCanvasNSView: NSView {
 
         if let doc = document {
             for object in doc.objects {
+                // While a TextObject is being re-edited inline, hide it from
+                // the canvas render so we don't double-draw the text under
+                // the live editor.
+                if let text = object as? TextObject, text === editingOriginalObject {
+                    continue
+                }
                 if let pixelate = object as? PixelateObject, let src = sourceImage {
                     pixelate.renderWithSource(in: ctx, sourceImage: src)
                 } else {
@@ -238,6 +272,21 @@ final class AnnotationCanvasNSView: NSView {
     // MARK: - Mouse Handling
 
     override func mouseDown(with event: NSEvent) {
+        // If we're currently editing a text object, any click *outside* the
+        // editor commits the edit; clicks inside are forwarded to the editor.
+        if let editor = textEditor {
+            let pointInSelf = convert(event.locationInWindow, from: nil)
+            if editor.containsCanvasPoint(pointInSelf) {
+                // Let the NSTextView handle the click (focus / caret placement).
+                super.mouseDown(with: event)
+                return
+            } else {
+                commitTextEditing()
+                // Fall through: the click should still be processed as a fresh
+                // canvas interaction (e.g. create another text box, select, etc.).
+            }
+        }
+
         // Make sure we own keyboard focus so subsequent keyDown events
         // (Delete, etc.) actually reach us. Safe to call even if we already are.
         window?.makeFirstResponder(self)
@@ -251,6 +300,14 @@ final class AnnotationCanvasNSView: NSView {
         resizeOriginalTextFontSize = nil
 
         if currentTool == .select {
+            // Double-click a TextObject → enter inline edit mode.
+            if event.clickCount == 2, let obj = doc.objectAt(point: point),
+               let text = obj as? TextObject {
+                isDragging = false
+                beginTextEditing(at: text.origin, existing: text)
+                return
+            }
+
             // Check resize handles on selected object FIRST
             if let selected = doc.selectedObject {
                 if let handle = handleHitTest(point: point, bounds: selected.bounds) {
@@ -452,16 +509,17 @@ final class AnnotationCanvasNSView: NSView {
                     doc.addObject(EllipseObject(rect: rect, style: currentStyle))
                 }
             case .text:
-                let alert = NSAlert()
-                alert.messageText = String(localized: "Enter Text")
-                alert.addButton(withTitle: String(localized: "OK"))
-                alert.addButton(withTitle: String(localized: "Cancel"))
-                let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
-                input.stringValue = String(localized: "Text")
-                alert.accessoryView = input
-                if alert.runModal() == .alertFirstButtonReturn {
-                    doc.addObject(TextObject(text: input.stringValue, origin: end, style: currentStyle))
-                }
+                // Inline editor replaces the old NSAlert popup. Spawn at the
+                // click point; commit happens on Esc or outside-click.
+                beginTextEditing(at: end, existing: nil)
+                // Skip the normal post-create path — creation is deferred to
+                // commitTextEditing, and we do NOT want to switch back to
+                // select tool yet (user hasn't typed anything).
+                isDragging = false
+                dragStart = nil
+                dragCurrent = nil
+                needsDisplay = true
+                return
             case .freehand, .highlighter:
                 if let freehand = activeFreehand, freehand.points.count > 1 {
                     doc.addObject(freehand)
@@ -502,5 +560,123 @@ final class AnnotationCanvasNSView: NSView {
         } else {
             super.keyDown(with: event)
         }
+    }
+
+    // MARK: - Inline text editing
+
+    /// Begin an inline text edit at `imagePoint` (image coordinates).
+    /// Pass an `existing` TextObject for double-click re-edit; pass `nil` for
+    /// a fresh text creation.
+    private func beginTextEditing(at imagePoint: CGPoint, existing: TextObject?) {
+        // If one is already up, finish it before opening a new one.
+        if textEditor != nil { commitTextEditing() }
+
+        let editor = AnnotationTextEditor(frame: .zero)
+        editor.delegate = self
+        editor.zoomScale = zoomScale
+        editor.imageOrigin = imagePoint
+
+        if let existing {
+            editor.fontSize = existing.fontSize
+            editor.fontName = existing.fontName
+            editor.textColor = existing.style.color.nsColor
+                .withAlphaComponent(existing.style.opacity)
+            editor.beginEditing(initialText: existing.text)
+            editingOriginalObject = existing
+        } else {
+            editor.fontSize = currentTextFontSize
+            editor.textColor = currentStyle.color.nsColor
+                .withAlphaComponent(currentStyle.opacity)
+            editor.beginEditing(initialText: "")
+            editingOriginalObject = nil
+        }
+
+        addSubview(editor)
+        textEditor = editor
+        repositionEditor()
+        editor.focusTextView()
+        needsDisplay = true
+
+        // Notify SwiftUI so the toolbar can flip into font-size mode and
+        // — for re-edits — sync the slider to the object's fontSize.
+        onTextEditingStarted?(editor.fontSize)
+    }
+
+    /// Position the editor's frame based on its `imageOrigin` and the current
+    /// zoom. Called on create, on zoom change, and on content resize.
+    private func repositionEditor() {
+        guard let editor = textEditor else { return }
+        let viewOrigin = CGPoint(
+            x: editor.imageOrigin.x * zoomScale,
+            y: editor.imageOrigin.y * zoomScale
+        )
+        editor.setFrameOrigin(viewOrigin)
+    }
+
+    /// Finalize the edit: create / mutate / delete a TextObject depending on
+    /// the combination of (editingOriginalObject, text) and tear down the
+    /// inline editor.
+    private func commitTextEditing() {
+        guard let editor = textEditor, let doc = document else { return }
+
+        let finalText = editor.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let origin = editor.imageOrigin
+
+        if let existing = editingOriginalObject {
+            if finalText.isEmpty {
+                // Edited to empty → delete the original.
+                doc.removeObject(id: existing.id)
+            } else if finalText != existing.text || editor.fontSize != existing.fontSize {
+                // Mutated text or fontSize — push one undo step, then update.
+                doc.beginDrag()
+                existing.text = finalText
+                existing.fontSize = editor.fontSize
+            }
+        } else if !finalText.isEmpty {
+            // Fresh edit with content → create a new TextObject using the
+            // editor's current style (which reflects live toolbar changes).
+            let newObj = TextObject(
+                text: finalText,
+                origin: origin,
+                fontSize: editor.fontSize,
+                style: currentStyle
+            )
+            doc.addObject(newObj)
+        }
+        // else: fresh edit with empty text → just discard.
+
+        // Tear down the editor.
+        editor.removeFromSuperview()
+        textEditor = nil
+        editingOriginalObject = nil
+
+        needsDisplay = true
+        window?.makeFirstResponder(self)
+        onDocumentChanged?()
+        onTextEditingEnded?()
+
+        // Creation path: switch back to select, matching the other one-shot
+        // tools (arrow / rect / ellipse / pixelate).
+        if currentTool == .text {
+            onObjectCreated?()
+        }
+    }
+
+    /// When `currentStyle` changes (toolbar color / opacity) and we're mid-edit,
+    /// push the new color into the editor so the typed text re-renders live.
+    private func syncEditorStyle() {
+        guard let editor = textEditor else { return }
+        editor.textColor = currentStyle.color.nsColor
+            .withAlphaComponent(currentStyle.opacity)
+    }
+}
+
+// MARK: - AnnotationTextEditorDelegate
+
+extension AnnotationCanvasNSView: AnnotationTextEditorDelegate {
+    func textEditor(_ editor: AnnotationTextEditor, didCommitText text: String) {
+        // Editor is asking us to finalize (Esc pressed). Outside-click commits
+        // are handled directly in mouseDown.
+        commitTextEditing()
     }
 }

--- a/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
@@ -8,10 +8,20 @@ struct AnnotationCanvasView: NSViewRepresentable {
     let sourceImage: CGImage
     let currentTool: AnnotationTool
     let currentStyle: AnnotationKit.StrokeStyle
+    /// Font size for the text tool / active inline edit. Bound to the
+    /// font-size slider in SwiftUI.
+    let textFontSize: CGFloat
     let zoomScale: CGFloat
     let refreshTrigger: Int
     var textRegions: [CGRect] = []
     var onSwitchToSelect: (() -> Void)?
+    /// Called when the inline text editor appears. Passes the effective
+    /// fontSize (existing object's size when re-editing, current slider
+    /// value for a new edit). SwiftUI flips `isEditingText` and — for
+    /// re-edits — syncs the size slider.
+    var onTextEditingStarted: ((CGFloat) -> Void)?
+    /// Called when the inline text editor commits / dismisses.
+    var onTextEditingEnded: (() -> Void)?
 
     func makeNSView(context: Context) -> AnnotationCanvasNSView {
         let view = AnnotationCanvasNSView()
@@ -19,6 +29,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
         view.sourceImage = sourceImage
         view.currentTool = currentTool
         view.currentStyle = currentStyle
+        view.currentTextFontSize = textFontSize
         view.zoomScale = zoomScale
         view.textRegions = textRegions
         view.onObjectCreated = {
@@ -30,6 +41,8 @@ struct AnnotationCanvasView: NSViewRepresentable {
                 onSwitchToSelect?()
             }
         }
+        view.onTextEditingStarted = { fontSize in onTextEditingStarted?(fontSize) }
+        view.onTextEditingEnded = { onTextEditingEnded?() }
         return view
     }
 
@@ -37,6 +50,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
         let toolChanged = nsView.currentTool != currentTool
         nsView.currentTool = currentTool
         nsView.currentStyle = currentStyle
+        nsView.currentTextFontSize = textFontSize
         nsView.zoomScale = zoomScale
         nsView.textRegions = textRegions
         nsView.onObjectCreated = {
@@ -45,6 +59,8 @@ struct AnnotationCanvasView: NSViewRepresentable {
                 onSwitchToSelect?()
             }
         }
+        nsView.onTextEditingStarted = { fontSize in onTextEditingStarted?(fontSize) }
+        nsView.onTextEditingEnded = { onTextEditingEnded?() }
         nsView.needsDisplay = true
         if toolChanged {
             nsView.window?.invalidateCursorRects(for: nsView)

--- a/App/Sources/AnnotationEditor/AnnotationEditorView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorView.swift
@@ -18,6 +18,13 @@ struct AnnotationEditorView: View {
     @State private var savedBlockSize: CGFloat = 12
     @State private var savedCounterSize: CGFloat = 20
     @State private var savedHighlighterWidth: CGFloat = 20
+    /// Preserved font size for the Text tool. Swapped in/out of `lineWidth`
+    /// as the user toggles tools — same pattern as savedBlockSize etc.
+    @State private var savedTextFontSize: CGFloat = 48
+    /// True while an inline text editor is active. Lets the toolbar show
+    /// the font-size slider even when the tool is `.select` (happens when
+    /// re-editing via double-click).
+    @State private var isEditingText = false
     @State private var beautifySettings = BeautifySettings()
     @State private var showBeautifyPanel = false
     @State private var refreshTrigger = 0
@@ -57,6 +64,14 @@ struct AnnotationEditorView: View {
         )
     }
 
+    /// Font size currently pushed to the canvas. When the slider is in
+    /// font-size mode (text tool active OR mid-edit), the live slider value
+    /// wins so dragging it updates the editor in real time. Otherwise we
+    /// fall back to the preserved value from the last text session.
+    private var effectiveTextFontSize: CGFloat {
+        (currentTool == .text || isEditingText) ? lineWidth : savedTextFontSize
+    }
+
     /// Live preview of the Beautify background. For solid, just a filled Rect.
     /// For liquid glass, a blurred & saturation-boosted copy of the screenshot
     /// scaled to fill the background area — mirrors what `BeautifyRenderer`
@@ -89,6 +104,7 @@ struct AnnotationEditorView: View {
                 lineWidth: $lineWidth,
                 filled: $filled,
                 showBeautifyPanel: $showBeautifyPanel,
+                isEditingText: isEditingText,
                 canUndo: document.canUndo,
                 canRedo: document.canRedo,
                 onUndo: { document.undo(); refreshTrigger += 1 },
@@ -118,12 +134,28 @@ struct AnnotationEditorView: View {
                             sourceImage: sourceImage,
                             currentTool: currentTool,
                             currentStyle: currentStyle,
+                            textFontSize: effectiveTextFontSize,
                             zoomScale: zoomScale,
                             refreshTrigger: refreshTrigger,
                             textRegions: textRegions,
                             onSwitchToSelect: {
                                 document.clearSelection()
                                 currentTool = .select
+                            },
+                            onTextEditingStarted: { fontSize in
+                                isEditingText = true
+                                // Sync slider to the object's fontSize when
+                                // re-editing. Harmless for fresh edits: the
+                                // value matches what we just pushed in.
+                                if lineWidth != fontSize {
+                                    lineWidth = fontSize
+                                }
+                            },
+                            onTextEditingEnded: {
+                                isEditingText = false
+                                // Preserve the last-used font size for the
+                                // next text edit / tool switch.
+                                savedTextFontSize = lineWidth
                             }
                         )
                         .frame(
@@ -165,6 +197,7 @@ struct AnnotationEditorView: View {
                     case .pixelate: savedBlockSize = lineWidth
                     case .counter: savedCounterSize = lineWidth
                     case .highlighter: savedHighlighterWidth = lineWidth
+                    case .text: savedTextFontSize = lineWidth
                     default: savedLineWidth = lineWidth
                     }
                     // Restore incoming tool's value
@@ -172,6 +205,7 @@ struct AnnotationEditorView: View {
                     case .pixelate: lineWidth = savedBlockSize
                     case .counter: lineWidth = savedCounterSize
                     case .highlighter: lineWidth = savedHighlighterWidth
+                    case .text: lineWidth = savedTextFontSize
                     default: lineWidth = savedLineWidth
                     }
                 }

--- a/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
@@ -9,6 +9,7 @@ final class AnnotationEditorWindow: NSPanel {
 
     init(
         image: CGImage,
+        anchorScreen: NSScreen? = nil,
         onSave: @escaping (CGImage) -> Void,
         onCopy: @escaping (CGImage) -> Void,
         onClose: @escaping () -> Void
@@ -17,7 +18,11 @@ final class AnnotationEditorWindow: NSPanel {
         let imgH = CGFloat(image.height)
         self.document = AnnotationDocument(imageSize: CGSize(width: imgW, height: imgH))
 
-        let screen = NSScreen.main ?? NSScreen.screens.first!
+        // Prefer the screen where the capture originated (the one the user was
+        // focused on). Falling back to NSScreen.main unconditionally would
+        // always open the editor on the primary display, even when the capture
+        // came from a secondary one.
+        let screen = anchorScreen ?? NSScreen.main ?? NSScreen.screens.first!
         let maxW = screen.visibleFrame.width * 0.8
         let maxH = screen.visibleFrame.height * 0.8
         let chromeH: CGFloat = 110
@@ -26,11 +31,16 @@ final class AnnotationEditorWindow: NSPanel {
         let winW = imgW * scale
         let winH = imgH * scale + chromeH
 
+        // Center inside the target screen's visibleFrame. `visibleFrame` is
+        // already in absolute desktop coordinates, so this puts the window on
+        // the correct display even when that display isn't the primary one.
         let x = screen.visibleFrame.midX - winW / 2
         let y = screen.visibleFrame.midY - winH / 2
 
+        let targetFrame = NSRect(x: x, y: y, width: winW, height: winH)
+
         super.init(
-            contentRect: NSRect(x: x, y: y, width: winW, height: winH),
+            contentRect: targetFrame,
             styleMask: [.titled, .closable, .resizable, .miniaturizable],
             backing: .buffered,
             defer: false
@@ -46,6 +56,12 @@ final class AnnotationEditorWindow: NSPanel {
         // Ensure tooltip tracking and key-window behaviour work correctly.
         self.becomesKeyOnlyIfNeeded = false
         self.acceptsMouseMovedEvents = true
+        // AppKit re-applies window restoration + may snap `.titled` panels
+        // back to main display on multi-monitor setups, ignoring the
+        // contentRect passed to init. Disable restoration and explicitly
+        // re-apply the target frame so we actually land on the right screen.
+        self.isRestorable = false
+        self.setFrame(targetFrame, display: false)
 
         let view = AnnotationEditorView(
             sourceImage: image,

--- a/App/Sources/AnnotationEditor/AnnotationTextEditor.swift
+++ b/App/Sources/AnnotationEditor/AnnotationTextEditor.swift
@@ -1,0 +1,264 @@
+// App/Sources/AnnotationEditor/AnnotationTextEditor.swift
+//
+// Inline, in-canvas text editor that replaces the modal NSAlert popup the
+// annotation text tool used before. Appears at the click point, grows with
+// content, commits on **Esc or outside-click** (no Return-commit — Return and
+// Shift+Return both insert newlines, matching CleanShot X). IME composition
+// is respected so Chinese / Japanese / Korean users can confirm candidates
+// with Return without committing the whole edit.
+//
+// Visual language: refined native macOS — a hairline accent-tinted rounded
+// outline and a soft dark backdrop. Intentionally quieter than CleanShot X,
+// so it never fights the content being annotated.
+
+import AppKit
+
+@MainActor
+protocol AnnotationTextEditorDelegate: AnyObject {
+    /// Called when the user commits the edit (Return / Esc / outside-click).
+    /// `text` may be empty — the canvas decides whether to discard or delete.
+    func textEditor(_ editor: AnnotationTextEditor, didCommitText text: String)
+}
+
+@MainActor
+final class AnnotationTextEditor: NSView {
+    weak var delegate: AnnotationTextEditorDelegate?
+
+    /// Origin in **image coordinates**. The owning canvas multiplies by
+    /// `zoomScale` to position us in its view space.
+    var imageOrigin: CGPoint = .zero
+
+    /// Zoom of the owning canvas. Controls the effective on-screen font size
+    /// so typed glyphs line up 1:1 with what `TextObject.render` will draw.
+    var zoomScale: CGFloat = 1.0 {
+        didSet {
+            guard zoomScale != oldValue else { return }
+            applyAttributes()
+        }
+    }
+
+    /// Font size in **image coordinates** (what gets stored on TextObject).
+    var fontSize: CGFloat = 48 {
+        didSet {
+            guard fontSize != oldValue else { return }
+            applyAttributes()
+        }
+    }
+
+    /// Font name matches what TextObject uses when rendering.
+    var fontName: String = ".AppleSystemUIFont" {
+        didSet {
+            guard fontName != oldValue else { return }
+            applyAttributes()
+        }
+    }
+
+    /// Text color with style.opacity already applied.
+    var textColor: NSColor = .red {
+        didSet {
+            guard textColor != oldValue else { return }
+            applyAttributes()
+        }
+    }
+
+    /// String currently in the editor.
+    var text: String { textView.string }
+
+    private let textView: InlineTextView
+    private let innerPadding: CGFloat = 4
+
+    override var isFlipped: Bool { true }
+
+    override init(frame frameRect: NSRect) {
+        self.textView = InlineTextView(frame: .zero)
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.masksToBounds = false
+
+        configureTextView()
+        addSubview(textView)
+
+        textView.commitHandler = { [weak self] in
+            guard let self else { return }
+            self.delegate?.textEditor(self, didCommitText: self.textView.string)
+        }
+        textView.sizeChangeHandler = { [weak self] in
+            self?.resizeToFit()
+        }
+    }
+
+    @available(*, unavailable) required init?(coder: NSCoder) { fatalError() }
+
+    private func configureTextView() {
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.isRichText = false
+        textView.isFieldEditor = false
+        textView.drawsBackground = false
+        textView.backgroundColor = .clear
+        textView.allowsUndo = true
+        textView.usesFontPanel = false
+        textView.usesFindBar = false
+        textView.importsGraphics = false
+        textView.isAutomaticLinkDetectionEnabled = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.smartInsertDeleteEnabled = false
+
+        // Unbounded container so multi-line grows horizontally with longest line.
+        textView.textContainerInset = .zero
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainer?.widthTracksTextView = false
+        textView.textContainer?.heightTracksTextView = false
+        textView.textContainer?.containerSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.isHorizontallyResizable = true
+        textView.isVerticallyResizable = true
+        textView.minSize = .zero
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+
+        // Make the caret visible on typical dark backgrounds.
+        textView.insertionPointColor = .white
+    }
+
+    // MARK: - Lifecycle
+
+    /// Seed the editor with `initialText`, apply current style, and select-all
+    /// (so that typing replaces a double-click-restored string).
+    func beginEditing(initialText: String) {
+        textView.string = initialText
+        applyAttributes()
+        // Place caret at end (new text) or select all (existing text).
+        let len = (textView.string as NSString).length
+        if initialText.isEmpty {
+            textView.setSelectedRange(NSRange(location: 0, length: 0))
+        } else {
+            textView.setSelectedRange(NSRange(location: 0, length: len))
+        }
+        resizeToFit()
+    }
+
+    /// Ask the window to make our text view first responder. Call after the
+    /// view is installed in the window hierarchy.
+    func focusTextView() {
+        window?.makeFirstResponder(textView)
+    }
+
+    // MARK: - Attributes / layout
+
+    private var attributes: [NSAttributedString.Key: Any] {
+        let effective = max(1, fontSize * zoomScale)
+        let font = NSFont(name: fontName, size: effective)
+            ?? NSFont.systemFont(ofSize: effective, weight: .medium)
+        return [
+            .font: font,
+            .foregroundColor: textColor,
+        ]
+    }
+
+    private func applyAttributes() {
+        textView.typingAttributes = attributes
+        if let storage = textView.textStorage, storage.length > 0 {
+            storage.setAttributes(attributes, range: NSRange(location: 0, length: storage.length))
+        }
+        resizeToFit()
+    }
+
+    private func resizeToFit() {
+        guard let layoutManager = textView.layoutManager,
+              let container = textView.textContainer else { return }
+        layoutManager.ensureLayout(for: container)
+        let used = layoutManager.usedRect(for: container)
+
+        // Reserve width for the caret so it doesn't clip on empty / trailing.
+        let caretRoom = max(2, (fontSize * zoomScale) * 0.05)
+        let minWidth = max(12, fontSize * zoomScale * 0.6)
+        let contentW = max(minWidth, ceil(used.width) + caretRoom)
+        let contentH = max(ceil(fontSize * zoomScale), ceil(used.height))
+
+        let outerW = contentW + innerPadding * 2
+        let outerH = contentH + innerPadding * 2
+
+        if frame.size.width != outerW || frame.size.height != outerH {
+            setFrameSize(NSSize(width: outerW, height: outerH))
+        }
+        textView.frame = NSRect(
+            x: innerPadding, y: innerPadding,
+            width: contentW, height: contentH
+        )
+        needsDisplay = true
+    }
+
+    // MARK: - Drawing: thin solid outline + soft backdrop
+
+    override func draw(_ dirtyRect: NSRect) {
+        let outline = bounds.insetBy(dx: 0.5, dy: 0.5)
+        let path = NSBezierPath(roundedRect: outline, xRadius: 3, yRadius: 3)
+
+        // Soft, nearly-invisible backdrop — just enough to keep light text legible
+        // over messy backgrounds without visually competing with the capture.
+        NSColor.black.withAlphaComponent(0.08).setFill()
+        path.fill()
+
+        // Thin accent outline, intentionally understated.
+        NSColor.controlAccentColor.withAlphaComponent(0.55).setStroke()
+        path.lineWidth = 1
+        path.stroke()
+    }
+
+    // MARK: - Hit testing
+
+    /// True if `pointInSelfSuperview` (the canvas's coordinate space) lands
+    /// inside our frame. Used by the canvas to decide whether a click commits
+    /// (outside) or falls through to the text view (inside).
+    func containsCanvasPoint(_ pointInSelfSuperview: CGPoint) -> Bool {
+        frame.contains(pointInSelfSuperview)
+    }
+}
+
+// MARK: - Inline text view with commit-on-Return semantics
+
+/// NSTextView subclass that commits on Esc and lets every other keystroke
+/// (including Return and Shift+Return) fall through to the default multi-line
+/// NSTextView behavior — which is to insert a newline. This mirrors the
+/// behavior the user confirmed in CleanShot X: no keystroke commits; only
+/// losing focus (Esc, or clicking outside the editor) finalizes the edit.
+///
+/// IME composition (`hasMarkedText()`) always bypasses interception so that
+/// Return confirms a Chinese / Japanese / Korean candidate instead of acting
+/// on the editor itself.
+@MainActor
+private final class InlineTextView: NSTextView {
+    var commitHandler: (() -> Void)?
+    var sizeChangeHandler: (() -> Void)?
+
+    override func keyDown(with event: NSEvent) {
+        // While IME has marked text, let the input manager handle everything.
+        if hasMarkedText() {
+            super.keyDown(with: event)
+            return
+        }
+
+        // Escape (keyCode 53) commits. Everything else — including Return and
+        // Shift+Return — falls through and gets the default newline-insertion
+        // behavior for a multi-line NSTextView.
+        if event.keyCode == 53 {
+            commitHandler?()
+            return
+        }
+
+        super.keyDown(with: event)
+    }
+
+    override func didChangeText() {
+        super.didChangeText()
+        sizeChangeHandler?()
+    }
+}

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -8,6 +8,11 @@ struct AnnotationToolbar: View {
     @Binding var lineWidth: CGFloat
     @Binding var filled: Bool
     @Binding var showBeautifyPanel: Bool
+    /// True when an inline text edit is active (either via the text tool or
+    /// by double-clicking an existing TextObject in select mode). When set,
+    /// the size slider behaves as a Font Size control regardless of the
+    /// currently selected tool — so users can keep tuning size while typing.
+    var isEditingText: Bool = false
     let canUndo: Bool
     let canRedo: Bool
     let onUndo: () -> Void
@@ -15,6 +20,12 @@ struct AnnotationToolbar: View {
     let onSave: () -> Void
     let onCopy: () -> Void
     let onCancel: () -> Void
+
+    /// The size slider serves multiple tools: in text / editing mode it means
+    /// font size; for other tools it retains its existing role.
+    private var isFontSizeMode: Bool {
+        currentTool == .text || isEditingText
+    }
 
     var body: some View {
         HStack(spacing: 12) {
@@ -98,7 +109,12 @@ struct AnnotationToolbar: View {
 
     private var strokeGroup: some View {
         HStack(spacing: 8) {
-            if currentTool == .pixelate {
+            if isFontSizeMode {
+                // Text tool or mid-edit: slider becomes a font-size control.
+                Slider(value: $lineWidth, in: 12...120, step: 1)
+                    .frame(width: 80)
+                    .help("Font Size: \(Int(lineWidth))")
+            } else if currentTool == .pixelate {
                 Slider(value: $lineWidth, in: 4...48, step: 2)
                     .frame(width: 80)
                     .help("Block Size: \(Int(lineWidth))")
@@ -115,7 +131,10 @@ struct AnnotationToolbar: View {
                     .frame(width: 80)
                     .help("Line Width: \(Int(lineWidth))")
             }
-            if currentTool != .counter && currentTool != .highlighter {
+            // Fill toggle is meaningless for counter / highlighter / text.
+            if currentTool != .counter
+                && currentTool != .highlighter
+                && !isFontSizeMode {
                 Toggle(isOn: $filled) {
                     Image(systemName: filled ? "square.fill" : "square")
                         .font(.system(size: 12))

--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -12,6 +12,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private(set) var captureCoordinator: CaptureCoordinator?
     private(set) var recordingCoordinator: RecordingCoordinator?
     private(set) var ocrCoordinator: OCRCoordinator?
+    private(set) var translationCoordinator: TranslationCoordinator?
     private(set) var historyCoordinator: HistoryCoordinator?
     private var preferencesWindow: PreferencesWindow?
     /// Sparkle update coordinator used by preferences and manual update checks.
@@ -26,8 +27,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         captureCoordinator = CaptureCoordinator(settings: settings)
         recordingCoordinator = RecordingCoordinator(settings: settings)
         ocrCoordinator = OCRCoordinator(settings: settings)
+        translationCoordinator = TranslationCoordinator(settings: settings)
         historyCoordinator = HistoryCoordinator(settings: settings)
         captureCoordinator!.ocrCoordinator = ocrCoordinator
+        captureCoordinator!.translationCoordinator = translationCoordinator
         captureCoordinator!.historyCoordinator = historyCoordinator
         recordingCoordinator!.historyCoordinator = historyCoordinator
         preferencesWindow = PreferencesWindow(settings: settings, updateManager: updateManager)
@@ -36,6 +39,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             captureCoordinator: captureCoordinator!,
             recordingCoordinator: recordingCoordinator!,
             ocrCoordinator: ocrCoordinator!,
+            translationCoordinator: translationCoordinator!,
             historyCoordinator: historyCoordinator!,
             onShowPreferences: { [weak self] in self?.showPreferences() }
         )
@@ -106,6 +110,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         KeyboardShortcuts.onKeyDown(for: .screenshotHistory) { [weak self] in
             self?.historyCoordinator?.showWindow()
+        }
+        KeyboardShortcuts.onKeyDown(for: .captureAndTranslate) { [weak self] in
+            guard let self else { return }
+            // If the user pressed ⌘⇧T while a Quick Access panel has focus
+            // (hovered / clicked), translate THAT capture rather than
+            // starting a brand-new capture flow. The global hotkey otherwise
+            // always wins over the panel's local `.keyboardShortcut`.
+            if self.captureCoordinator?.invokeQuickAccessTranslateIfKey() == true {
+                return
+            }
+            self.translationCoordinator?.startCaptureAndTranslate()
         }
     }
 

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -30,6 +30,7 @@ final class CaptureCoordinator {
 
     var lastCaptureResult: CaptureResult?
     var ocrCoordinator: OCRCoordinator?
+    var translationCoordinator: TranslationCoordinator?
     var historyCoordinator: HistoryCoordinator?
 
     /// Post-capture action override. When set, ignores Settings toggles.
@@ -535,7 +536,8 @@ final class CaptureCoordinator {
         case .clipboard:
             copyImageToClipboard(result.image)
         case .annotate:
-            openAnnotationEditor(result)
+            // Open the editor on the same screen the capture came from.
+            openAnnotationEditor(result, anchorScreen: screenFor(result: result))
         case .default:
             if settings.screenshotAutoCopy {
                 copyImageToClipboard(result.image)
@@ -590,14 +592,27 @@ final class CaptureCoordinator {
         }
         window.onAnnotate = { [weak self, weak window] in
             guard let self, let window else { return }
+            let anchor = window.targetScreen
             self.dismissQuickAccessWindow(window)
-            self.openAnnotationEditor(result)
+            self.openAnnotationEditor(result, anchorScreen: anchor)
         }
         window.onPin = { [weak self, weak window] in
             guard let self, let window else { return }
             let anchor = window.frame
             self.dismissQuickAccessWindow(window)
             self.pinToScreen(result, anchor: anchor)
+        }
+        window.onOCR = { [weak self, weak window] in
+            guard let self, let window else { return }
+            let anchor = window.targetScreen
+            self.dismissQuickAccessWindow(window)
+            self.ocrCoordinator?.startVisualOCR(image: result.image, anchorScreen: anchor)
+        }
+        window.onTranslate = { [weak self, weak window] in
+            guard let self, let window else { return }
+            let anchor = window.targetScreen
+            self.dismissQuickAccessWindow(window)
+            self.translationCoordinator?.translate(image: result.image, anchorScreen: anchor)
         }
         window.onClose = { [weak self, weak window] in
             guard let self, let window else { return }
@@ -643,9 +658,14 @@ final class CaptureCoordinator {
         }
     }
 
-    private func openAnnotationEditor(_ result: CaptureResult) {
+    private func openAnnotationEditor(_ result: CaptureResult, anchorScreen: NSScreen? = nil) {
+        // If the caller didn't pass a screen explicitly, derive one from the
+        // capture's displayID so `captureAreaAndAnnotate()` (direct ⌘⇧…
+        // shortcut path) also opens on the right display.
+        let screen = anchorScreen ?? screenFor(result: result)
         annotationWindow = AnnotationEditorWindow(
             image: result.image,
+            anchorScreen: screen,
             onSave: { [weak self] (rendered: CGImage) in
                 self?.saveRenderedImage(rendered)
                 self?.annotationWindow = nil
@@ -659,6 +679,34 @@ final class CaptureCoordinator {
             }
         )
         annotationWindow?.show()
+    }
+
+    /// Look up the NSScreen whose displayID matches the capture. Returns nil
+    /// if the originating display is no longer connected (rare — user
+    /// unplugged the monitor between capture and action).
+    private func screenFor(result: CaptureResult) -> NSScreen? {
+        NSScreen.screens.first { $0.displayID == result.displayID }
+    }
+
+    /// If the currently-focused Quick Access panel can handle the Translate
+    /// action, fire it and return true. Otherwise return false so the caller
+    /// (a global shortcut handler) can fall through to its default behavior.
+    ///
+    /// This exists because the `KeyboardShortcuts` package registers a
+    /// SYSTEM-wide hotkey for `⌘⇧T`, which always wins over a SwiftUI
+    /// `.keyboardShortcut` attached to the Translate button in the Quick
+    /// Access panel. Without this fall-through, pressing ⌘⇧T while hovering
+    /// a Quick Access preview would trigger a fresh capture-and-translate
+    /// flow instead of translating the capture the user was already looking at.
+    @discardableResult
+    func invokeQuickAccessTranslateIfKey() -> Bool {
+        guard let key = NSApp.keyWindow as? QuickAccessWindow,
+              quickAccessWindows.contains(where: { $0 === key }),
+              let handler = key.onTranslate else {
+            return false
+        }
+        handler()
+        return true
     }
 
     private func pinToScreen(_ result: CaptureResult, anchor: CGRect) {

--- a/App/Sources/MenuBar/MenuBarController.swift
+++ b/App/Sources/MenuBar/MenuBarController.swift
@@ -15,14 +15,16 @@ final class MenuBarController: NSObject {
     private let captureCoordinator: CaptureCoordinator
     private let recordingCoordinator: RecordingCoordinator
     private let ocrCoordinator: OCRCoordinator
+    private let translationCoordinator: TranslationCoordinator
     private let historyCoordinator: HistoryCoordinator
     private let onShowPreferences: () -> Void
 
-    init(settings: AppSettings, captureCoordinator: CaptureCoordinator, recordingCoordinator: RecordingCoordinator, ocrCoordinator: OCRCoordinator, historyCoordinator: HistoryCoordinator, onShowPreferences: @escaping () -> Void) {
+    init(settings: AppSettings, captureCoordinator: CaptureCoordinator, recordingCoordinator: RecordingCoordinator, ocrCoordinator: OCRCoordinator, translationCoordinator: TranslationCoordinator, historyCoordinator: HistoryCoordinator, onShowPreferences: @escaping () -> Void) {
         self.settings = settings
         self.captureCoordinator = captureCoordinator
         self.recordingCoordinator = recordingCoordinator
         self.ocrCoordinator = ocrCoordinator
+        self.translationCoordinator = translationCoordinator
         self.historyCoordinator = historyCoordinator
         self.onShowPreferences = onShowPreferences
         super.init()
@@ -87,6 +89,10 @@ final class MenuBarController: NSObject {
         captureText.setShortcut(for: .captureText)
         menu.addItem(captureText)
 
+        let captureAndTranslate = menuItem(String(localized: "Capture & Translate"), action: #selector(self.captureAndTranslate))
+        captureAndTranslate.setShortcut(for: .captureAndTranslate)
+        menu.addItem(captureAndTranslate)
+
         let captureScrolling = menuItem(String(localized: "Scrolling Capture"), action: #selector(captureScrolling))
         captureScrolling.setShortcut(for: .captureScrolling)
         menu.addItem(captureScrolling)
@@ -135,6 +141,10 @@ final class MenuBarController: NSObject {
         ocrCoordinator.startInstantOCR()
     }
 
+    @objc private func captureAndTranslate() {
+        translationCoordinator.startCaptureAndTranslate()
+    }
+
     @objc private func captureScrolling() {
         captureCoordinator.captureScrolling()
     }
@@ -172,6 +182,7 @@ extension MenuBarController: NSMenuDelegate {
             case #selector(captureFullscreen): item.setShortcut(for: .captureFullscreen)
             case #selector(captureWindow): item.setShortcut(for: .captureWindow)
             case #selector(captureText): item.setShortcut(for: .captureText)
+            case #selector(captureAndTranslate): item.setShortcut(for: .captureAndTranslate)
             case #selector(recordScreen): item.setShortcut(for: .recordScreen)
             case #selector(captureScrolling): item.setShortcut(for: .captureScrolling)
             case #selector(openHistory): item.setShortcut(for: .screenshotHistory)

--- a/App/Sources/OCR/OCRCoordinator.swift
+++ b/App/Sources/OCR/OCRCoordinator.swift
@@ -98,17 +98,21 @@ final class OCRCoordinator {
 
     // MARK: - Visual OCR
 
-    func startVisualOCR(image: CGImage) {
+    /// - Parameter anchorScreen: The screen where the capture came from /
+    ///   where the user was focused. When nil, the overlay falls back to the
+    ///   primary display — use the nil form only when we genuinely don't know
+    ///   (e.g. menu-bar invocation with no prior anchor).
+    func startVisualOCR(image: CGImage, anchorScreen: NSScreen? = nil) {
         if !settings.ocrOnboardingShown {
             showOnboarding { [weak self] in
-                self?.beginVisualOCR(image: image)
+                self?.beginVisualOCR(image: image, anchorScreen: anchorScreen)
             }
         } else {
-            beginVisualOCR(image: image)
+            beginVisualOCR(image: image, anchorScreen: anchorScreen)
         }
     }
 
-    private func beginVisualOCR(image: CGImage) {
+    private func beginVisualOCR(image: CGImage, anchorScreen: NSScreen?) {
         Task {
             do {
                 let regions = try await TextRecognizer.recognize(
@@ -121,7 +125,7 @@ final class OCRCoordinator {
                     return
                 }
 
-                showOCROverlay(image: image, regions: regions)
+                showOCROverlay(image: image, regions: regions, anchorScreen: anchorScreen)
             } catch {
                 logger.error("Visual OCR failed: \(error.localizedDescription, privacy: .public)")
                 showToast("OCR: \(error.localizedDescription)", icon: "xmark.circle.fill", iconColor: .systemRed)
@@ -129,9 +133,9 @@ final class OCRCoordinator {
         }
     }
 
-    private func showOCROverlay(image: CGImage, regions: [TextRegion]) {
+    private func showOCROverlay(image: CGImage, regions: [TextRegion], anchorScreen: NSScreen?) {
         ocrOverlayWindow?.close()
-        ocrOverlayWindow = OCROverlayWindow(image: image, regions: regions)
+        ocrOverlayWindow = OCROverlayWindow(image: image, regions: regions, anchorScreen: anchorScreen)
         ocrOverlayWindow?.onClose = { [weak self] in
             self?.ocrOverlayWindow = nil
         }

--- a/App/Sources/OCR/OCROverlayView.swift
+++ b/App/Sources/OCR/OCROverlayView.swift
@@ -104,17 +104,13 @@ struct OCROverlayView: View {
             Divider()
 
             HStack(spacing: 8) {
-                Button("Select All") {
-                    copyAll()
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-
+                Spacer()
                 Button("Copy All") {
                     copyAll()
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)
+                .keyboardShortcut("c", modifiers: .command)
             }
             .padding(12)
         }

--- a/App/Sources/OCR/OCROverlayWindow.swift
+++ b/App/Sources/OCR/OCROverlayWindow.swift
@@ -7,9 +7,21 @@ import OCRKit
 final class OCROverlayWindow: NSPanel {
     var onClose: (() -> Void)?
 
-    init(image: CGImage, regions: [TextRegion]) {
+    init(image: CGImage, regions: [TextRegion], anchorScreen: NSScreen? = nil) {
+        // Pick the screen the capture came from, not the primary by default.
+        // `NSWindow.center()` centers within the window's *current* screen,
+        // which for a freshly-constructed window is the primary — so relying
+        // on it means secondary-display captures always open on main.
+        let screen = anchorScreen ?? NSScreen.main ?? NSScreen.screens.first!
+        let size = NSSize(width: 900, height: 550)
+        let visible = screen.visibleFrame
+        let origin = NSPoint(
+            x: visible.midX - size.width / 2,
+            y: visible.midY - size.height / 2
+        )
+
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: 900, height: 550),
+            contentRect: NSRect(origin: origin, size: size),
             styleMask: [.titled, .closable, .resizable, .miniaturizable],
             backing: .buffered,
             defer: false
@@ -19,7 +31,6 @@ final class OCROverlayWindow: NSPanel {
         self.title = "OCR — Text Recognition"
         self.isMovableByWindowBackground = false
         self.minSize = NSSize(width: 600, height: 400)
-        self.center()
 
         let view = OCROverlayView(
             image: image,

--- a/App/Sources/Preferences/PreferencesView.swift
+++ b/App/Sources/Preferences/PreferencesView.swift
@@ -18,7 +18,7 @@ enum PreferencesTab: String, CaseIterable {
         case .recording: "Recording"
         case .quickAccess: "Quick Access"
         case .export: "Export"
-        case .ocr: "OCR"
+        case .ocr: "Text & Translation"
         case .shortcuts: "Shortcuts"
         }
     }
@@ -95,7 +95,7 @@ struct PreferencesView: View {
                 case .export:
                     ExportSettingsView(viewModel: viewModel)
                 case .ocr:
-                    OCRSettingsView(viewModel: viewModel)
+                    TextAndTranslationSettingsView(viewModel: viewModel)
                 case .shortcuts:
                     ShortcutSettingsView()
                 }

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -401,6 +401,52 @@ final class PreferencesViewModel {
         }
     }
 
+    // MARK: Translation
+    var translationTargetLanguage: String {
+        get {
+            access(keyPath: \.translationTargetLanguage)
+            return settings.translationTargetLanguage
+        }
+        set {
+            withMutation(keyPath: \.translationTargetLanguage) {
+                settings.translationTargetLanguage = newValue
+            }
+        }
+    }
+    var translationAutoCopy: Bool {
+        get {
+            access(keyPath: \.translationAutoCopy)
+            return settings.translationAutoCopy
+        }
+        set {
+            withMutation(keyPath: \.translationAutoCopy) {
+                settings.translationAutoCopy = newValue
+            }
+        }
+    }
+    var translationShowOriginal: Bool {
+        get {
+            access(keyPath: \.translationShowOriginal)
+            return settings.translationShowOriginal
+        }
+        set {
+            withMutation(keyPath: \.translationShowOriginal) {
+                settings.translationShowOriginal = newValue
+            }
+        }
+    }
+    var translationAutoDismiss: TranslationAutoDismiss {
+        get {
+            access(keyPath: \.translationAutoDismiss)
+            return settings.translationAutoDismiss
+        }
+        set {
+            withMutation(keyPath: \.translationAutoDismiss) {
+                settings.translationAutoDismiss = newValue
+            }
+        }
+    }
+
     // MARK: Version
     // MARK: History
     var historyEnabled: Bool {

--- a/App/Sources/Preferences/Tabs/OCRSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/OCRSettingsView.swift
@@ -1,14 +1,36 @@
 // App/Sources/Preferences/Tabs/OCRSettingsView.swift
 import SwiftUI
 import Vision
+import SharedKit
 
-struct OCRSettingsView: View {
+struct TextAndTranslationSettingsView: View {
     @Bindable var viewModel: PreferencesViewModel
     @State private var supportedLanguages: [(code: String, name: String)] = []
 
+    private let translationLanguages: [(code: String, name: String)] = [
+        ("en",      "English"),
+        ("zh-Hans", "简体中文"),
+        ("zh-Hant", "繁體中文"),
+        ("ja",      "日本語"),
+        ("ko",      "한국어"),
+        ("fr",      "Français"),
+        ("de",      "Deutsch"),
+        ("es",      "Español"),
+        ("it",      "Italiano"),
+        ("pt-BR",   "Português (Brasil)"),
+        ("ru",      "Русский"),
+        ("ar",      "العربية"),
+        ("hi",      "हिन्दी"),
+        ("nl",      "Nederlands"),
+        ("pl",      "Polski"),
+        ("tr",      "Türkçe"),
+        ("uk",      "Українська"),
+        ("id",      "Bahasa Indonesia"),
+    ]
+
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
-            Text("OCR")
+            Text("Text & Translation")
                 .font(.system(size: 20, weight: .bold))
 
             SettingGroup(title: "Text Recognition") {
@@ -22,6 +44,37 @@ struct OCRSettingsView: View {
                         Toggle("", isOn: $viewModel.ocrDetectLinks)
                             .toggleStyle(.switch)
                             .controlSize(.small)
+                    }
+                }
+            }
+
+            SettingGroup(title: "Translation") {
+                SettingCard {
+                    SettingRow(label: "Target Language", sublabel: "Language to translate text into") {
+                        Picker("", selection: $viewModel.translationTargetLanguage) {
+                            ForEach(translationLanguages, id: \.code) { lang in
+                                Text(lang.name).tag(lang.code)
+                            }
+                        }
+                        .frame(width: 180)
+                    }
+                    SettingRow(label: "Auto-Copy Translation", sublabel: "Copy result to clipboard automatically") {
+                        Toggle("", isOn: $viewModel.translationAutoCopy)
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                    }
+                    SettingRow(label: "Show Original Text", sublabel: "Display source text alongside translation") {
+                        Toggle("", isOn: $viewModel.translationShowOriginal)
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                    }
+                    SettingRow(label: "Auto-Dismiss", sublabel: "When to close the translation panel", showDivider: true) {
+                        Picker("", selection: $viewModel.translationAutoDismiss) {
+                            Text("Manual").tag(TranslationAutoDismiss.manual)
+                            Text("Click outside").tag(TranslationAutoDismiss.clickOutside)
+                            Text("After delay").tag(TranslationAutoDismiss.afterDelay)
+                        }
+                        .frame(width: 140)
                     }
                 }
             }

--- a/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
@@ -12,6 +12,7 @@ extension KeyboardShortcuts.Name {
     static let captureAreaToClipboard = Self("captureAreaToClipboard", default: .init(.seven, modifiers: [.option, .shift]))
     static let captureAreaAndAnnotate = Self("captureAreaAndAnnotate", default: .init(.eight, modifiers: [.option, .shift]))
     static let screenshotHistory = Self("screenshotHistory", default: .init(.nine, modifiers: [.option, .shift]))
+    static let captureAndTranslate = Self("captureAndTranslate", default: .init(.t, modifiers: [.command, .shift]))
 }
 
 struct ShortcutSettingsView: View {
@@ -46,6 +47,7 @@ struct ShortcutSettingsView: View {
                     shortcutRow("Scrolling Capture", name: .captureScrolling, showDivider: true)
                     shortcutRow("Capture Area to Clipboard", name: .captureAreaToClipboard, showDivider: true)
                     shortcutRow("Capture Area & Annotate", name: .captureAreaAndAnnotate, showDivider: true)
+                    shortcutRow("Capture & Translate", name: .captureAndTranslate, showDivider: true)
                 }
             }
 

--- a/App/Sources/QuickAccess/QuickAccessView.swift
+++ b/App/Sources/QuickAccess/QuickAccessView.swift
@@ -1,55 +1,297 @@
 // App/Sources/QuickAccess/QuickAccessView.swift
 import SwiftUI
+import AppKit
+import CaptureKit
 
 struct QuickAccessView: View {
     let thumbnail: NSImage
+    let dimensions: String           // e.g. "1920×1080"
+    let capturedAt: Date
+    let targetLanguageDisplay: String?  // e.g. "Simplified Chinese"
     let onCopy: () -> Void
     let onSave: () -> Void
     let onAnnotate: () -> Void
+    let onOCR: () -> Void
+    let onTranslate: () -> Void
     let onPin: () -> Void
     let onClose: () -> Void
 
+    @State private var isHovering = false
+    @State private var hoveredAction: HoverAction?
+    @FocusState private var isFocused: Bool
+
+    private enum HoverAction: Hashable {
+        case copy, save, annotate, ocr, translate, pin
+    }
+
+    private var isRevealed: Bool { isHovering || isFocused }
+
+    private var reduceMotion: Bool {
+        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+    }
+
     var body: some View {
-        HStack(spacing: 0) {
+        VStack(spacing: 8) {
+            thumbnailFrame
+
+            // Caption at rest / Chrome on hover — crossfade in the same slot
+            ZStack {
+                captionRow
+                    .opacity(isRevealed ? 0 : 1)
+                chromeStrip
+                    .opacity(isRevealed ? 1 : 0)
+            }
+            .frame(height: 50)
+        }
+        .padding(8)
+        .background(hiddenEscapeButton)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.3), radius: 10, y: 4)
+        .offset(y: isRevealed ? -2 : 0)
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.26), value: isRevealed)
+        .onHover { isHovering = $0 }
+        .focusable()
+        .focused($isFocused)
+    }
+
+    // MARK: - Thumbnail
+
+    private var thumbnailFrame: some View {
+        ZStack(alignment: .topTrailing) {
             Image(nsImage: thumbnail)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
-                .frame(maxWidth: 200, maxHeight: 120)
+                .frame(maxWidth: 268, maxHeight: 116)
                 .clipShape(RoundedRectangle(cornerRadius: 6))
-                .padding(8)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color.black.opacity(0.25), lineWidth: 0.5)
+                )
 
-            VStack(spacing: 6) {
-                quickActionButton("Copy", systemImage: "doc.on.doc", action: onCopy)
-                quickActionButton("Save", systemImage: "square.and.arrow.down", action: onSave)
-                quickActionButton("Annotate", systemImage: "pencil.tip.crop.circle", action: onAnnotate)
-                quickActionButton("Pin", systemImage: "pin.fill", action: onPin)
+            if isRevealed {
+                Button(action: onClose) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 18, height: 18)
+                        .background(Circle().fill(.regularMaterial))
+                }
+                .buttonStyle(.plain)
+                .padding(6)
+                .transition(.opacity)
+                .help("Close")
             }
-            .frame(width: 110)
-            .padding(.trailing, 8)
-            .padding(.vertical, 8)
-
-            Button(action: onClose) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundStyle(.secondary)
-            }
-            .buttonStyle(.plain)
-            .padding(.trailing, 6)
-            .padding(.top, 6)
-            .frame(maxHeight: .infinity, alignment: .top)
         }
-        .background(.ultraThinMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
-        .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
     }
 
-    private func quickActionButton(_ title: LocalizedStringKey, systemImage: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Label(title, systemImage: systemImage)
-                .font(.system(size: 12))
-                .frame(maxWidth: .infinity, alignment: .leading)
+    // MARK: - Caption (at rest)
+
+    private var captionRow: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            Text("Capture,")
+                .font(.system(size: 14, design: .serif).italic())
+                .foregroundStyle(.primary)
+            Spacer()
+            Text(metaLine)
+                .font(.system(size: 9, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .tracking(0.6)
+                .textCase(.uppercase)
         }
-        .buttonStyle(.bordered)
-        .controlSize(.small)
+        .padding(.horizontal, 6)
+    }
+
+    private var metaLine: String {
+        "\(dimensions) · \(relativeTime)"
+    }
+
+    private var relativeTime: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: capturedAt, relativeTo: Date())
+    }
+
+    // MARK: - Chrome (revealed on hover/focus)
+
+    private var chromeStrip: some View {
+        VStack(spacing: 4) {
+            contextLine
+            toolbar
+        }
+    }
+
+    private var contextLine: some View {
+        HStack(alignment: .center, spacing: 8) {
+            Text(contextTitle)
+                .font(.system(size: 13, design: .serif).italic())
+                .foregroundStyle(.primary)
+            Spacer()
+            contextHintView
+        }
+        .padding(.horizontal, 4)
+        .frame(height: 20)
+    }
+
+    private var contextTitle: String {
+        guard let action = hoveredAction else { return "Quick Access" }
+        return label(action)
+    }
+
+    /// Right-aligned hint for the hovered action: a keycap-style pill
+    /// showing the shortcut (⌘S, ⌘⇧T, …) plus — for Translate — a subtle
+    /// suffix naming the target language.
+    @ViewBuilder
+    private var contextHintView: some View {
+        HStack(spacing: 5) {
+            if let key = hoveredShortcutKey {
+                ShortcutKeyPill(text: key)
+            }
+            if let suffix = hoveredHintSuffix {
+                Text(suffix)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var hoveredShortcutKey: String? {
+        guard let action = hoveredAction else { return nil }
+        switch action {
+        case .copy:      return "⌘C"
+        case .save:      return "⌘S"
+        case .annotate:  return "⌘E"
+        case .ocr:       return "⌘⇧O"
+        case .translate: return "⌘⇧T"
+        case .pin:       return "⌘P"
+        }
+    }
+
+    private var hoveredHintSuffix: String? {
+        guard hoveredAction == .translate,
+              let lang = targetLanguageDisplay, !lang.isEmpty else { return nil }
+        return "→ \(lang)"
+    }
+
+    private var toolbar: some View {
+        HStack(spacing: 2) {
+            toolButton(.copy, icon: "doc.on.doc", action: onCopy)
+            toolButton(.save, icon: "square.and.arrow.down", action: onSave)
+            toolDivider
+            toolButton(.annotate, icon: "pencil.tip.crop.circle", action: onAnnotate)
+            toolDivider
+            toolButton(.ocr, icon: "text.viewfinder", action: onOCR)
+            toolButton(.translate, icon: "character.bubble", action: onTranslate)
+            toolDivider
+            toolButton(.pin, icon: "pin", action: onPin)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(Text("Quick Access actions"))
+    }
+
+    @ViewBuilder
+    private func toolButton(_ kind: HoverAction, icon: String, action: @escaping () -> Void) -> some View {
+        let button = Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 14, weight: .regular))
+                .symbolRenderingMode(.monochrome)
+                .frame(width: 28, height: 26)
+                .background(
+                    RoundedRectangle(cornerRadius: 5)
+                        .fill(hoveredAction == kind ? Color.primary.opacity(0.10) : Color.clear)
+                )
+        }
+        .buttonStyle(.plain)
+        .onHover { hoveredAction = $0 ? kind : nil }
+        .help(Text(label(kind)))
+        .accessibilityLabel(Text(label(kind)))
+        .accessibilityHint(Text(hintForAccessibility(kind)))
+
+        // Apply local keyboard shortcut so pressing the hinted key activates the action
+        // whenever the Quick Access panel is key. `.nonactivatingPanel` + canBecomeKey=true
+        // means shortcuts work while the panel is frontmost in our app, without stealing
+        // focus from other apps.
+        if let shortcut = shortcut(for: kind) {
+            button.keyboardShortcut(shortcut.key, modifiers: shortcut.modifiers)
+        } else {
+            button
+        }
+    }
+
+    private func shortcut(for kind: HoverAction) -> (key: KeyEquivalent, modifiers: EventModifiers)? {
+        switch kind {
+        case .copy:      return ("c", [.command])
+        case .save:      return ("s", [.command])
+        case .annotate:  return ("e", [.command])
+        case .ocr:       return ("o", [.command, .shift])
+        case .translate: return ("t", [.command, .shift])
+        case .pin:       return ("p", [.command])
+        }
+    }
+
+    private var hiddenEscapeButton: some View {
+        Button(action: onClose) { EmptyView() }
+            .keyboardShortcut(.escape, modifiers: [])
+            .opacity(0)
+            .frame(width: 0, height: 0)
+            .allowsHitTesting(false)
+    }
+
+    private var toolDivider: some View {
+        Rectangle()
+            .fill(Color.primary.opacity(0.08))
+            .frame(width: 1, height: 14)
+    }
+
+    private func label(_ kind: HoverAction) -> String {
+        switch kind {
+        case .copy: return "Copy"
+        case .save: return "Save"
+        case .annotate: return "Annotate"
+        case .ocr: return "Extract Text"
+        case .translate: return "Translate"
+        case .pin: return "Pin"
+        }
+    }
+
+    private func hintForAccessibility(_ kind: HoverAction) -> String {
+        switch kind {
+        case .copy: return "Copy to clipboard"
+        case .save: return "Save screenshot"
+        case .annotate: return "Open annotation editor"
+        case .ocr: return "Extract text from screenshot"
+        case .translate: return "Translate text in screenshot"
+        case .pin: return "Pin to screen"
+        }
+    }
+}
+
+// MARK: - Shortcut keycap pill
+
+/// Renders a keyboard shortcut (e.g. "⌘S", "⌘⇧T") as a compact, slightly
+/// tinted pill — visually distinct from surrounding secondary text, which at
+/// 9pt/secondary on ultraThinMaterial was too dim to read at a glance.
+private struct ShortcutKeyPill: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 10, weight: .medium, design: .monospaced))
+            .tracking(1.5)  // breathing room between modifier + key glyphs
+            .foregroundStyle(.primary.opacity(0.85))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 1.5)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color.primary.opacity(0.10))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                    .stroke(Color.primary.opacity(0.08), lineWidth: 0.5)
+            )
     }
 }

--- a/App/Sources/QuickAccess/QuickAccessWindow.swift
+++ b/App/Sources/QuickAccess/QuickAccessWindow.swift
@@ -6,9 +6,13 @@ import SharedKit
 
 @MainActor
 final class QuickAccessWindow: NSPanel {
+    override var canBecomeKey: Bool { true }
+
     var onCopy: (() -> Void)?
     var onSave: (() -> Void)?
     var onAnnotate: (() -> Void)?
+    var onOCR: (() -> Void)?
+    var onTranslate: (() -> Void)?
     var onPin: (() -> Void)?
     var onClose: (() -> Void)?
 
@@ -21,8 +25,8 @@ final class QuickAccessWindow: NSPanel {
         self.settings = settings
         self.targetScreen = screen ?? NSScreen.main ?? NSScreen.screens.first!
 
-        let windowWidth: CGFloat = 336
-        let windowHeight: CGFloat = 172
+        let windowWidth: CGFloat = 288
+        let windowHeight: CGFloat = 200
 
         let screenFrame = targetScreen.visibleFrame
         let x: CGFloat = switch settings.quickAccessPosition {
@@ -47,27 +51,35 @@ final class QuickAccessWindow: NSPanel {
         self.collectionBehavior = [.canJoinAllSpaces, .transient]
         self.isMovableByWindowBackground = true
         self.animationBehavior = .utilityWindow
-        // NSPanel defaults hidesOnDeactivate to true, which causes the preview
-        // to be auto-hidden the moment Capso loses focus (e.g. right after the
-        // captured window's app becomes active after Capture Window). That's
-        // why the preview "only reappears when you start the next capture" —
-        // the next overlay reactivates Capso, which restores the hidden panel.
         self.hidesOnDeactivate = false
 
         let nsImage = NSImage(cgImage: result.image, size: NSSize(
             width: result.image.width, height: result.image.height
         ))
 
+        let dimensions = "\(result.image.width)×\(result.image.height)"
+        let targetDisplay = Self.targetLanguageDisplay(settings: settings)
+
         let view = QuickAccessView(
             thumbnail: nsImage,
-            onCopy: { [weak self] in self?.onCopy?() },
-            onSave: { [weak self] in self?.onSave?() },
-            onAnnotate: { [weak self] in self?.onAnnotate?() },
-            onPin: { [weak self] in self?.onPin?() },
-            onClose: { [weak self] in self?.onClose?() }
+            dimensions: dimensions,
+            capturedAt: Date(),
+            targetLanguageDisplay: targetDisplay,
+            onCopy:      { [weak self] in self?.onCopy?() },
+            onSave:      { [weak self] in self?.onSave?() },
+            onAnnotate:  { [weak self] in self?.onAnnotate?() },
+            onOCR:       { [weak self] in self?.onOCR?() },
+            onTranslate: { [weak self] in self?.onTranslate?() },
+            onPin:       { [weak self] in self?.onPin?() },
+            onClose:     { [weak self] in self?.onClose?() }
         )
 
         self.contentView = NSHostingView(rootView: view)
+    }
+
+    private static func targetLanguageDisplay(settings: AppSettings) -> String? {
+        let target = settings.translationTargetLanguage
+        return Locale.current.localizedString(forIdentifier: target) ?? target
     }
 
     func show() {
@@ -110,8 +122,6 @@ final class QuickAccessWindow: NSPanel {
     }
 
     /// Evict this preview off-screen to the left with a slide animation.
-    /// Used when the preview stack overflows (the oldest one is pushed out
-    /// of the bottom slot to make room for new captures above).
     func slideOffLeftAndClose() {
         autoDismissTimer?.invalidate()
         autoDismissTimer = nil
@@ -123,8 +133,6 @@ final class QuickAccessWindow: NSPanel {
             self.animator().setFrame(target, display: true)
             self.animator().alphaValue = 0
         }, completionHandler: { [weak self] in
-            // Bypass the close() override — we already ran our own exit
-            // animation and don't want a second fade on top of it.
             self?.orderOut(nil)
         })
     }
@@ -132,14 +140,7 @@ final class QuickAccessWindow: NSPanel {
     /// Spacing between stacked preview windows.
     private static let stackSpacing: CGFloat = 12
 
-    /// Animate (or directly set) this window's y-position so it occupies the
-    /// given slot in the preview stack. Index 0 is the bottom-most slot
-    /// (primary position, same as a single preview), index 1 sits right above
-    /// it, and so on.
-    ///
-    /// X position is re-read from `settings.quickAccessPosition` so that if
-    /// the user changes "bottom-left" ⇄ "bottom-right" between captures the
-    /// stack still lines up correctly on the next reposition.
+    /// Animate this window's y-position to occupy a given slot in the preview stack.
     func repositionForStackIndex(_ index: Int, animated: Bool = true) {
         let screenFrame = targetScreen.visibleFrame
         let windowWidth = frame.width

--- a/App/Sources/Translation/TranslationCoordinator.swift
+++ b/App/Sources/Translation/TranslationCoordinator.swift
@@ -1,0 +1,250 @@
+// App/Sources/Translation/TranslationCoordinator.swift
+import AppKit
+import SwiftUI
+import Foundation
+import Observation
+import os.log
+import Translation
+import CaptureKit
+import OCRKit
+import SharedKit
+import TranslationKit
+
+private let logger = Logger(subsystem: "com.awesomemacapps.capso", category: "Translation")
+
+@MainActor
+@Observable
+final class TranslationCoordinator {
+    private let settings: AppSettings
+    private var overlayWindows: [CaptureOverlayWindow] = []
+    private var onboardingWindow: TranslationOnboardingWindow?
+    private var resultWindow: TranslationResultWindow?
+    private var toastWindow: ToastWindow?
+
+    init(settings: AppSettings) {
+        self.settings = settings
+    }
+
+    // MARK: - Entry points
+
+    func startCaptureAndTranslate() {
+        if !settings.translationOnboardingShown {
+            showOnboarding { [weak self] in self?.beginCaptureFlow() }
+        } else {
+            beginCaptureFlow()
+        }
+    }
+
+    /// - Parameter anchorScreen: The screen where the capture came from.
+    ///   Used to place the result card on the correct display — without this,
+    ///   translating a screenshot taken on a secondary screen would bounce the
+    ///   card back to the primary.
+    func translate(image: CGImage, anchorScreen: NSScreen? = nil) {
+        if !settings.translationOnboardingShown {
+            showOnboarding { [weak self] in
+                self?.performTranslation(image: image, anchor: nil, anchorScreen: anchorScreen)
+            }
+        } else {
+            performTranslation(image: image, anchor: nil, anchorScreen: anchorScreen)
+        }
+    }
+
+    // MARK: - Capture flow
+
+    private func beginCaptureFlow() {
+        dismissOverlay()
+        for screen in NSScreen.screens {
+            let overlay = CaptureOverlayWindow(screen: screen, settings: settings, presetsDisabled: true)
+            overlay.onAreaSelected = { [weak self] rect, screen in
+                self?.dismissOverlay()
+                self?.captureAndPerform(rect: rect, screen: screen)
+            }
+            overlay.onCancelled = { [weak self] in self?.dismissOverlay() }
+            overlay.activate(mode: .area)
+            overlayWindows.append(overlay)
+        }
+    }
+
+    private func captureAndPerform(rect: CGRect, screen: NSScreen) {
+        Task {
+            do {
+                let screenFrame = screen.frame
+                let screenRect = CGRect(
+                    x: rect.origin.x,
+                    y: screenFrame.height - rect.origin.y - rect.height,
+                    width: rect.width,
+                    height: rect.height
+                )
+                let result = try await ScreenCaptureManager.captureArea(
+                    rect: screenRect,
+                    displayID: screen.displayID
+                )
+                // Convert the overlay-local rect to screen-absolute coordinates
+                // so the card can be positioned on the correct screen.
+                let screenAnchor = NSRect(
+                    x: screen.frame.origin.x + rect.origin.x,
+                    y: screen.frame.origin.y + rect.origin.y,
+                    width: rect.width,
+                    height: rect.height
+                )
+                performTranslation(
+                    image: result.image,
+                    anchor: screenAnchor,
+                    anchorScreen: screen
+                )
+            } catch {
+                showToast("Translation: \(error.localizedDescription)", icon: "xmark.circle.fill", iconColor: .systemRed, screen: screen)
+            }
+        }
+    }
+
+    // MARK: - Translation (OCR only; actual translation runs in the card)
+
+    private func performTranslation(image: CGImage, anchor: NSRect?, anchorScreen: NSScreen? = nil) {
+        Task {
+            do {
+                let regions = try await TextRecognizer.recognize(image: image, detectURLs: false)
+                if regions.isEmpty {
+                    showToast("No text detected", icon: "info.circle.fill", iconColor: .systemYellow)
+                    return
+                }
+                let target = settings.translationTargetLanguage
+                showLoadingResult(regions: regions, target: target, anchor: anchor, anchorScreen: anchorScreen)
+            } catch {
+                showToast(
+                    "OCR failed: \(error.localizedDescription)",
+                    icon: "xmark.circle.fill",
+                    iconColor: .systemRed
+                )
+                logger.error("OCR error: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    private func showLoadingResult(regions: [TextRegion], target: String, anchor: NSRect?, anchorScreen: NSScreen?) {
+        resultWindow?.close()
+        let window = TranslationResultWindow(
+            regions: regions,
+            target: target,
+            settings: settings,
+            anchor: anchor,
+            anchorScreen: anchorScreen
+        )
+        window.onClose = { [weak self] in
+            self?.resultWindow?.close()
+            self?.resultWindow = nil
+        }
+        window.onPinChanged = { [weak self] isPinned in
+            guard let window = self?.resultWindow else { return }
+            // `.screenSaver` floats above everything — including other apps'
+            // windows — making the translation card genuinely always-on-top
+            // when pinned. Unpinning returns to regular floating level.
+            window.level = isPinned ? .screenSaver : .floating
+        }
+        window.onChangeLanguage = { [weak self] in
+            guard let self else { return }
+            // Fall back includes all 20 macOS 15 target languages (adds th, vi
+            // that the earlier list missed). Apple may add more in later
+            // OS versions — `LanguageAvailability.supportedLanguages` gives
+            // the authoritative runtime list.
+            let fallbackCodes = [
+                "ar", "de", "en", "es", "fr",
+                "hi", "id", "it", "ja", "ko",
+                "nl", "pl", "pt-BR", "ru", "th",
+                "tr", "uk", "vi", "zh-Hans", "zh-Hant"
+            ]
+
+            Task { @MainActor in
+                let supportedCodes = await Self.loadSupportedLanguageCodes(fallback: fallbackCodes)
+                let popover = NSPopover()
+                let picker = TranslationLanguagePickerPopover(
+                    current: target,
+                    available: supportedCodes
+                ) { newCode in
+                    popover.performClose(nil)
+                    self.showLoadingResult(regions: regions, target: newCode, anchor: anchor, anchorScreen: anchorScreen)
+                }
+                popover.contentViewController = NSHostingController(rootView: picker)
+                popover.behavior = .transient
+                if let contentView = self.resultWindow?.contentView {
+                    popover.show(
+                        relativeTo: contentView.bounds,
+                        of: contentView,
+                        preferredEdge: .maxY
+                    )
+                }
+            }
+        }
+        resultWindow = window
+        window.show()
+    }
+
+    /// Fetches the authoritative list of target language BCP-47 codes from
+    /// Apple's `LanguageAvailability`. Falls back to the passed list if the
+    /// framework returns an empty set (shouldn't happen on supported macOS).
+    ///
+    /// `supportedLanguages` returns regional variants (e.g. en-US, en-GB, zh-Hans-CN,
+    /// zh-Hant-TW). We deduplicate to unique canonical codes: language-only for most
+    /// languages, language-script for Chinese (which has two distinct scripts).
+    static func loadSupportedLanguageCodes(fallback: [String]) async -> [String] {
+        // Create LanguageAvailability off the main actor to satisfy Swift 6
+        // Sendable checking (LanguageAvailability is non-Sendable).
+        let langs: [Locale.Language] = await Task.detached {
+            let availability = LanguageAvailability()
+            return await availability.supportedLanguages
+        }.value
+        if langs.isEmpty { return fallback }
+
+        var seen = Set<String>()
+        var result: [String] = []
+        for lang in langs {
+            guard let langCode = lang.languageCode?.identifier else { continue }
+            let canonical: String
+            if langCode == "zh", let script = lang.script?.identifier {
+                // Distinguish Simplified (Hans) from Traditional (Hant).
+                canonical = "\(langCode)-\(script)"
+            } else if langCode == "pt", let region = lang.region?.identifier, region == "BR" {
+                // Keep pt-BR distinct from pt-PT.
+                canonical = "pt-BR"
+            } else {
+                canonical = langCode
+            }
+            guard !canonical.isEmpty, seen.insert(canonical).inserted else { continue }
+            result.append(canonical)
+        }
+        return result.isEmpty ? fallback : result
+    }
+
+    // MARK: - Onboarding
+
+    private func showOnboarding(then action: @escaping () -> Void) {
+        onboardingWindow = TranslationOnboardingWindow(onDismiss: { [weak self] in
+            guard let self else { return }
+            self.settings.translationOnboardingShown = true
+            self.onboardingWindow?.close()
+            self.onboardingWindow = nil
+            DispatchQueue.main.async {
+                action()
+            }
+        })
+        onboardingWindow?.show()
+    }
+
+    // MARK: - Helpers
+
+    private func dismissOverlay() {
+        for w in overlayWindows { w.deactivate() }
+        overlayWindows.removeAll()
+    }
+
+    private func showToast(
+        _ message: String,
+        icon: String = "checkmark.circle.fill",
+        iconColor: NSColor = .systemGreen,
+        screen: NSScreen? = nil
+    ) {
+        toastWindow?.orderOut(nil)
+        toastWindow = ToastWindow(message: message, icon: icon, iconColor: iconColor, screen: screen)
+        toastWindow?.show()
+    }
+}

--- a/App/Sources/Translation/TranslationLanguagePickerPopover.swift
+++ b/App/Sources/Translation/TranslationLanguagePickerPopover.swift
@@ -1,0 +1,88 @@
+// App/Sources/Translation/TranslationLanguagePickerPopover.swift
+import SwiftUI
+
+struct TranslationLanguagePickerPopover: View {
+    let current: String
+    let available: [String]   // BCP-47 codes
+    let onPick: (String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+
+            ScrollView(.vertical, showsIndicators: true) {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(sortedLanguages, id: \.0) { code, name in
+                        row(code: code, name: name, isSelected: code == current)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .frame(maxHeight: 320)
+
+            footer
+        }
+        .frame(width: 260)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Translate to")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .tracking(1.0)
+                .padding(.horizontal, 14)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
+            Divider()
+        }
+    }
+
+    private var footer: some View {
+        VStack(spacing: 0) {
+            Divider()
+            Text("Change default in Preferences")
+                .font(.system(size: 10))
+                .foregroundStyle(.tertiary)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+        }
+    }
+
+    private func row(code: String, name: String, isSelected: Bool) -> some View {
+        Button(action: { onPick(code) }) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(name)
+                    .font(.system(size: 13, weight: isSelected ? .medium : .regular))
+                    .foregroundStyle(isSelected ? Color.accentColor : Color.primary)
+                Spacer(minLength: 8)
+                Text(code)
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(.tertiary)
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Color.accentColor)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+            .background(
+                isSelected
+                    ? Color.accentColor.opacity(0.08)
+                    : Color.clear
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var sortedLanguages: [(String, String)] {
+        let locale = Locale.current
+        return available
+            .map { code in (code, locale.localizedString(forIdentifier: code) ?? code) }
+            .sorted { a, b in a.1.localizedCaseInsensitiveCompare(b.1) == .orderedAscending }
+    }
+}

--- a/App/Sources/Translation/TranslationOnboardingView.swift
+++ b/App/Sources/Translation/TranslationOnboardingView.swift
@@ -1,0 +1,96 @@
+// App/Sources/Translation/TranslationOnboardingView.swift
+import SwiftUI
+
+struct TranslationOnboardingView: View {
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            VStack(spacing: 8) {
+                Text("How to use Translate")
+                    .font(.system(size: 24, weight: .bold))
+                Text("Translate text from any screenshot without leaving Capso")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.top, 8)
+
+            HStack(spacing: 16) {
+                stepCard(
+                    number: "01",
+                    title: "Capture & Translate",
+                    description: "Press ⌘⇧T, drag to select text",
+                    symbol: "rectangle.dashed.and.paperclip",
+                    symbolColor: .orange
+                )
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.tertiary)
+                stepCard(
+                    number: "02",
+                    title: "On-device",
+                    description: "Apple Translation runs locally, privately",
+                    symbol: "cpu",
+                    symbolColor: .orange
+                )
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.tertiary)
+                stepCard(
+                    number: "03",
+                    title: "Read or Pin",
+                    description: "Translation copies to clipboard; pin to keep",
+                    symbol: "pin.square",
+                    symbolColor: .orange
+                )
+            }
+
+            Button("Got it!") { onDismiss() }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+        }
+        .padding(32)
+        .frame(width: 700, height: 380)
+    }
+
+    private func stepCard(
+        number: String,
+        title: LocalizedStringKey,
+        description: LocalizedStringKey,
+        symbol: String,
+        symbolColor: Color
+    ) -> some View {
+        VStack(spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(
+                        LinearGradient(
+                            colors: [Color(white: 0.12), Color(white: 0.08)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                Image(systemName: symbol)
+                    .font(.system(size: 48, weight: .light))
+                    .foregroundStyle(symbolColor.opacity(0.85))
+                    .symbolRenderingMode(.hierarchical)
+            }
+            .frame(height: 140)
+
+            VStack(spacing: 4) {
+                Text("STEP \(number)")
+                    .font(.system(size: 10, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.orange)
+                Text(title)
+                    .font(.system(size: 15, weight: .semibold))
+                Text(description)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/App/Sources/Translation/TranslationOnboardingWindow.swift
+++ b/App/Sources/Translation/TranslationOnboardingWindow.swift
@@ -1,0 +1,39 @@
+// App/Sources/Translation/TranslationOnboardingWindow.swift
+import AppKit
+import SwiftUI
+
+@MainActor
+final class TranslationOnboardingWindow: NSPanel {
+    private var onDismissAction: (() -> Void)?
+
+    init(onDismiss: @escaping () -> Void) {
+        self.onDismissAction = onDismiss
+
+        super.init(
+            contentRect: NSRect(x: 0, y: 0, width: 700, height: 380),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+
+        self.title = ""
+        self.titlebarAppearsTransparent = true
+        self.titleVisibility = .hidden
+        self.isMovableByWindowBackground = true
+        self.center()
+
+        let view = TranslationOnboardingView(onDismiss: { [weak self] in
+            self?.onDismissAction?()
+        })
+        self.contentView = NSHostingView(rootView: view)
+    }
+
+    func show() {
+        NSApp.activate(ignoringOtherApps: true)
+        makeKeyAndOrderFront(nil)
+    }
+
+    override func close() {
+        super.close()
+    }
+}

--- a/App/Sources/Translation/TranslationResultView.swift
+++ b/App/Sources/Translation/TranslationResultView.swift
@@ -1,0 +1,496 @@
+// App/Sources/Translation/TranslationResultView.swift
+import SwiftUI
+import Translation
+import NaturalLanguage
+import AppKit
+import OCRKit
+import TranslationKit
+
+struct TranslationResultView: View {
+    let regions: [TextRegion]
+    let target: String
+    let autoCopy: Bool
+    let onClose: () -> Void
+    let onPinChanged: (Bool) -> Void
+    let onChangeLanguage: () -> Void
+
+    enum Phase {
+        case loading
+        case done([TranslatedRegion])
+        case failed(String)
+    }
+
+    private enum TextBlock {
+        case paragraph(String)
+        case bulletList([String])
+        case numberedList([NumberedItem])
+    }
+
+    private struct NumberedItem {
+        let number: Int
+        let text: String
+    }
+
+    private static func parseBlocks(_ text: String) -> [TextBlock] {
+        let rawLines = text.components(separatedBy: CharacterSet.newlines)
+        let lines = rawLines.map { $0.trimmingCharacters(in: .whitespaces) }
+
+        var blocks: [TextBlock] = []
+        var pendingBullets: [String] = []
+        var pendingNumbers: [NumberedItem] = []
+        var pendingParagraphLines: [String] = []
+
+        func flushBullets() {
+            if !pendingBullets.isEmpty {
+                blocks.append(.bulletList(pendingBullets))
+                pendingBullets = []
+            }
+        }
+        func flushNumbers() {
+            if !pendingNumbers.isEmpty {
+                blocks.append(.numberedList(pendingNumbers))
+                pendingNumbers = []
+            }
+        }
+        func flushParagraph() {
+            if !pendingParagraphLines.isEmpty {
+                let joined = pendingParagraphLines.joined(separator: " ")
+                if !joined.trimmingCharacters(in: .whitespaces).isEmpty {
+                    blocks.append(.paragraph(joined))
+                }
+                pendingParagraphLines = []
+            }
+        }
+        func flushAll() {
+            flushBullets()
+            flushNumbers()
+            flushParagraph()
+        }
+
+        let bulletPattern = try! NSRegularExpression(pattern: "^[•\\-\\*]\\s*", options: [])
+        let numberPattern = try! NSRegularExpression(pattern: "^(\\d+)[\\.、]\\s*", options: [])
+
+        for line in lines {
+            if line.isEmpty {
+                flushAll()
+                continue
+            }
+            let range = NSRange(line.startIndex..., in: line)
+            if let m = bulletPattern.firstMatch(in: line, options: [], range: range) {
+                flushNumbers()
+                flushParagraph()
+                let rest = (line as NSString).substring(from: m.range.upperBound)
+                pendingBullets.append(rest)
+                continue
+            }
+            if let m = numberPattern.firstMatch(in: line, options: [], range: range) {
+                flushBullets()
+                flushParagraph()
+                let numberRange = m.range(at: 1)
+                let numberText = (line as NSString).substring(with: numberRange)
+                let number = Int(numberText) ?? (pendingNumbers.count + 1)
+                let rest = (line as NSString).substring(from: m.range.upperBound)
+                pendingNumbers.append(NumberedItem(number: number, text: rest))
+                continue
+            }
+            // Plain line → accumulate into paragraph (wrapping soft-wraps into one paragraph)
+            flushBullets()
+            flushNumbers()
+            pendingParagraphLines.append(line)
+        }
+        flushAll()
+        return blocks
+    }
+
+    @State private var phase: Phase = .loading
+    @State private var runConfig: TranslationSession.Configuration?
+    @State private var originalExpanded: Bool = false
+    @State private var isPinned: Bool = false
+    @State private var manualCopyShown: Bool = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header(detectedCode: currentDetectedCode)
+
+            // One scrollview wraps the variable-height middle. Header & footer stay pinned.
+            ScrollView(.vertical, showsIndicators: true) {
+                middleContent
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            footer(copiedMessage: shouldShowCopied ? "Copied" : nil)
+        }
+        .frame(width: 360, height: 480)
+        .background(hiddenEscape)
+        .background(.ultraThinMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 0.5)
+        )
+        .onAppear { buildConfig() }
+        .translationTask(runConfig) { session in
+            await runTranslation(using: session)
+        }
+    }
+
+    // MARK: - Middle content (inside scrollview)
+
+    @ViewBuilder
+    private var middleContent: some View {
+        switch phase {
+        case .loading:
+            VStack(spacing: 12) {
+                ProgressView().controlSize(.small)
+                Text("Translating…")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 36)
+        case .done(let regions):
+            doneSections(region: regions.first)
+        case .failed(let message):
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .foregroundStyle(.orange)
+                    Text(message)
+                        .font(.system(size: 13))
+                        .foregroundStyle(.primary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 20)
+            }
+        }
+    }
+
+    private func doneSections(region: TranslatedRegion?) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let region {
+                // TRANSLATION first
+                sectionLabel("TRANSLATION")
+                renderedText(
+                    region.translation,
+                    bodyFont: .system(size: 15, weight: .medium),
+                    bodyColor: .primary,
+                    markerColor: .tertiary
+                )
+                .padding(.horizontal, 16)
+                .padding(.bottom, 14)
+
+                Divider().padding(.horizontal, 12)
+
+                // ORIGINAL (collapsible)
+                Button(action: toggleOriginal) {
+                    HStack(spacing: 8) {
+                        Text("ORIGINAL")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(.tertiary)
+                            .tracking(1.0)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(.tertiary)
+                            .rotationEffect(.degrees(originalExpanded ? 90 : 0))
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+
+                if originalExpanded {
+                    renderedText(
+                        region.original.text,
+                        bodyFont: .system(size: 13),
+                        bodyColor: .secondary,
+                        markerColor: .tertiary
+                    )
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 14)
+                    .transition(.opacity)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func renderedText<BC: ShapeStyle, MC: ShapeStyle>(
+        _ text: String,
+        bodyFont: Font,
+        bodyColor: BC,
+        markerColor: MC
+    ) -> some View {
+        let blocks = Self.parseBlocks(text)
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+                switch block {
+                case .paragraph(let body):
+                    Text(body)
+                        .font(bodyFont)
+                        .foregroundStyle(bodyColor)
+                        .lineSpacing(3)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                case .bulletList(let items):
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                                Text("•")
+                                    .font(bodyFont)
+                                    .foregroundStyle(markerColor)
+                                    .frame(width: 10, alignment: .center)
+                                Text(item)
+                                    .font(bodyFont)
+                                    .foregroundStyle(bodyColor)
+                                    .lineSpacing(3)
+                                    .textSelection(.enabled)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                        }
+                    }
+
+                case .numberedList(let items):
+                    VStack(alignment: .leading, spacing: 6) {
+                        ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                                Text("\(item.number).")
+                                    .font(.system(size: 13, weight: .semibold, design: .rounded))
+                                    .foregroundStyle(markerColor)
+                                    .frame(width: 22, alignment: .trailing)
+                                Text(item.text)
+                                    .font(bodyFont)
+                                    .foregroundStyle(bodyColor)
+                                    .lineSpacing(3)
+                                    .textSelection(.enabled)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Chrome (pinned)
+
+    private func header(detectedCode: String?) -> some View {
+        HStack(spacing: 10) {
+            closeDot
+            Spacer()
+            Button(action: onChangeLanguage) {
+                Text(languagePair(detectedCode: detectedCode))
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            Spacer()
+            Button(action: togglePin) {
+                Image(systemName: isPinned ? "pin.fill" : "pin")
+                    .foregroundStyle(isPinned ? Color.accentColor : Color.primary)
+            }
+            .buttonStyle(.plain)
+            .help(isPinned ? "Unpin" : "Pin to screen")
+            Button(action: copyCurrent) { Image(systemName: "doc.on.doc") }
+                .buttonStyle(.plain)
+                .help("Copy translation")
+                .keyboardShortcut("c", modifiers: .command)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .overlay(Divider().padding(.horizontal, 12), alignment: .bottom)
+    }
+
+    private func footer(copiedMessage: String?) -> some View {
+        HStack {
+            Text("Apple Translation")
+                .font(.system(size: 10))
+                .foregroundStyle(.tertiary)
+            if let copiedMessage {
+                Circle().fill(Color.green).frame(width: 4, height: 4)
+                Text(LocalizedStringKey(copiedMessage))
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+            }
+            Spacer()
+            Text(autoCopy ? "Esc" : "⌘C  Esc")
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(.tertiary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.primary.opacity(0.02))
+        .overlay(Divider().padding(.horizontal, 12), alignment: .top)
+    }
+
+    private func sectionLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(.tertiary)
+            .tracking(1.0)
+            .padding(.horizontal, 16)
+            .padding(.top, 10)
+            .padding(.bottom, 6)
+    }
+
+    private var closeDot: some View {
+        Button(action: onClose) {
+            Circle()
+                .fill(Color.red.opacity(0.9))
+                .frame(width: 11, height: 11)
+                .overlay(Circle().stroke(Color.black.opacity(0.2), lineWidth: 0.5))
+        }
+        .buttonStyle(.plain)
+        .help("Close")
+    }
+
+    private func languagePair(detectedCode: String?) -> String {
+        let source = detectedCode?.uppercased() ?? "—"
+        let targetName = Locale.current.localizedString(forIdentifier: target) ?? target
+        return "\(source) → \(targetName)"
+    }
+
+    private func toggleOriginal() {
+        withAnimation(.easeOut(duration: 0.22)) {
+            originalExpanded.toggle()
+        }
+    }
+
+    private func togglePin() {
+        isPinned.toggle()
+        onPinChanged(isPinned)
+    }
+
+    // MARK: - Derived state
+
+    private var currentDetectedCode: String? {
+        if case .done(let regions) = phase {
+            return regions.first?.detectedSource.languageCode?.identifier
+        }
+        return nil
+    }
+
+    private var isDone: Bool {
+        if case .done = phase { return true }
+        return false
+    }
+
+    private var shouldShowCopied: Bool {
+        if autoCopy && isDone { return true }
+        return manualCopyShown
+    }
+
+    // MARK: - Logic
+
+    private func buildConfig() {
+        let combined = regions.map(\.text).joined(separator: "\n")
+        let recognizer = NLLanguageRecognizer()
+        recognizer.processString(combined)
+        let detected = recognizer.dominantLanguage?.rawValue
+
+        // Pre-check: if NLLanguageRecognizer confidently detected the source
+        // and it already matches the target, Apple's TranslationSession would
+        // fail with a generic "Unable to Translate" — surface a helpful message
+        // BEFORE calling Apple at all.
+        if let detected, Self.normalizedCode(detected) == Self.normalizedCode(target) {
+            let name = Locale.current.localizedString(forIdentifier: target) ?? target
+            phase = .failed("Source is already \(name). Change target via the language pill above.")
+            runConfig = nil   // don't trigger the translationTask
+            return
+        }
+
+        runConfig = TranslationSession.Configuration(
+            source: detected.map { Locale.Language(identifier: $0) },
+            target: Locale.Language(identifier: target)
+        )
+    }
+
+    /// Normalizes codes for comparison (e.g. NLLanguageRecognizer returns
+    /// "zh-Hans" / "zh-Hant"; our target stores the same form). Makes matching
+    /// robust to minor casing/encoding differences.
+    private static func normalizedCode(_ code: String) -> String {
+        code.lowercased()
+    }
+
+    private func runTranslation(using session: TranslationSession) async {
+        let meaningful = regions.filter {
+            !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        guard !meaningful.isEmpty else {
+            phase = .failed("No text to translate")
+            return
+        }
+
+        let joinedOriginal = meaningful.map(\.text).joined(separator: "\n")
+
+        nonisolated(unsafe) let s = session
+        do {
+            let response = try await s.translate(joinedOriginal)
+            let translation = response.targetText.trimmingCharacters(in: .whitespacesAndNewlines)
+            let detectedSource = response.sourceLanguage.languageCode?.identifier ?? ""
+
+            if !detectedSource.isEmpty && detectedSource == target {
+                let name = Locale.current.localizedString(forIdentifier: target) ?? target
+                phase = .failed("Source is already \(name). Change target via the language pill above.")
+                return
+            }
+
+            if translation.isEmpty {
+                phase = .failed("Translation returned no results. Try changing the target language.")
+                return
+            }
+
+            if autoCopy {
+                let pb = NSPasteboard.general
+                pb.clearContents()
+                pb.setString(response.targetText, forType: .string)
+            }
+
+            let merged = TextRegion(
+                text: joinedOriginal,
+                boundingBox: meaningful.first?.boundingBox ?? .zero,
+                confidence: 1.0
+            )
+            let result = TranslatedRegion(
+                original: merged,
+                translation: response.targetText,
+                detectedSource: Locale.Language(identifier: detectedSource.isEmpty ? "en" : detectedSource)
+            )
+            phase = .done([result])
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+    }
+
+    private func copyCurrent() {
+        guard case .done(let regions) = phase, let region = regions.first else { return }
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(region.translation, forType: .string)
+
+        // Show a brief "Copied" feedback so manual copy doesn't feel silent.
+        // When `autoCopy` is on, the indicator is already visible; this still
+        // re-asserts it, harmlessly.
+        withAnimation(.easeOut(duration: 0.2)) {
+            manualCopyShown = true
+        }
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            withAnimation(.easeOut(duration: 0.3)) {
+                manualCopyShown = false
+            }
+        }
+    }
+
+    private var hiddenEscape: some View {
+        Button(action: onClose) { EmptyView() }
+            .keyboardShortcut(.escape, modifiers: [])
+            .opacity(0)
+            .frame(width: 0, height: 0)
+            .allowsHitTesting(false)
+    }
+}

--- a/App/Sources/Translation/TranslationResultWindow.swift
+++ b/App/Sources/Translation/TranslationResultWindow.swift
@@ -1,0 +1,126 @@
+// App/Sources/Translation/TranslationResultWindow.swift
+import AppKit
+import SwiftUI
+import SharedKit
+import OCRKit
+import TranslationKit
+
+@MainActor
+final class TranslationResultWindow: NSPanel {
+    private let settings: AppSettings
+    private let regions: [TextRegion]
+    private let target: String
+    private var dismissTimer: Timer?
+
+    var onClose: (() -> Void)?
+    var onPinChanged: ((Bool) -> Void)?
+    var onChangeLanguage: (() -> Void)?
+
+    override var canBecomeKey: Bool { true }
+
+    init(
+        regions: [TextRegion],
+        target: String,
+        settings: AppSettings,
+        anchor: NSRect?,
+        anchorScreen: NSScreen?
+    ) {
+        self.regions = regions
+        self.target = target
+        self.settings = settings
+
+        // Fixed window size matching the SwiftUI view's `.frame(width: 360, height: 480)`.
+        // No auto-resize — internal ScrollView handles overflow.
+        let frame = Self.positionedFrame(
+            size: NSSize(width: 360, height: 480),
+            anchor: anchor,
+            anchorScreen: anchorScreen,
+            position: settings.translationCardPosition
+        )
+
+        super.init(
+            contentRect: frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        level = .floating
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = true
+        collectionBehavior = [.canJoinAllSpaces, .transient]
+        isMovableByWindowBackground = true
+        hidesOnDeactivate = false
+        isReleasedWhenClosed = false
+    }
+
+    func show() {
+        let view = TranslationResultView(
+            regions: regions,
+            target: target,
+            autoCopy: settings.translationAutoCopy,
+            onClose:          { [weak self] in self?.onClose?() },
+            onPinChanged:     { [weak self] isPinned in self?.onPinChanged?(isPinned) },
+            onChangeLanguage: { [weak self] in self?.onChangeLanguage?() }
+        )
+        // Plain NSHostingView (no NSHostingController sizingOptions) — prevents
+        // the window <=> SwiftUI layout feedback loop that was causing stack overflow.
+        contentView = NSHostingView(rootView: view)
+
+        makeKeyAndOrderFront(nil)
+
+        if settings.translationAutoDismiss == .afterDelay {
+            dismissTimer = Timer.scheduledTimer(
+                withTimeInterval: settings.translationAutoDismissDelay,
+                repeats: false
+            ) { [weak self] _ in
+                Task { @MainActor in self?.onClose?() }
+            }
+        }
+    }
+
+    override func close() {
+        dismissTimer?.invalidate()
+        dismissTimer = nil
+        super.close()
+    }
+
+    private static func positionedFrame(
+        size: NSSize,
+        anchor: NSRect?,
+        anchorScreen: NSScreen?,
+        position: TranslationCardPosition
+    ) -> NSRect {
+        let screen = anchorScreen ?? NSScreen.main ?? NSScreen.screens.first!
+        let visible = screen.visibleFrame
+        let padding: CGFloat = 12
+
+        func centered() -> NSRect {
+            NSRect(
+                x: visible.midX - size.width / 2,
+                y: visible.midY - size.height / 2,
+                width: size.width,
+                height: size.height
+            )
+        }
+
+        switch position {
+        case .centerScreen, .rememberLast:
+            return centered()
+
+        case .belowSelection:
+            guard let anchor else { return centered() }
+            let rawX = anchor.midX - size.width / 2
+            let x = max(visible.minX + padding, min(visible.maxX - size.width - padding, rawX))
+            let belowY = anchor.minY - size.height - padding
+            if belowY >= visible.minY + padding {
+                return NSRect(x: x, y: belowY, width: size.width, height: size.height)
+            }
+            let aboveY = anchor.maxY + padding
+            if aboveY + size.height <= visible.maxY - padding {
+                return NSRect(x: x, y: aboveY, width: size.width, height: size.height)
+            }
+            return centered()
+        }
+    }
+}

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -18,6 +18,18 @@ public enum RecordingFormat: String, CaseIterable, Sendable {
     case gif
 }
 
+public enum TranslationCardPosition: String, CaseIterable, Sendable {
+    case belowSelection
+    case centerScreen
+    case rememberLast
+}
+
+public enum TranslationAutoDismiss: String, CaseIterable, Sendable {
+    case manual
+    case clickOutside
+    case afterDelay
+}
+
 public enum ExportQuality: String, CaseIterable, Sendable {
     case maximum
     case social
@@ -323,6 +335,73 @@ public final class AppSettings: @unchecked Sendable {
     public var ocrOnboardingShown: Bool {
         get { defaults.object(forKey: "ocrOnboardingShown") as? Bool ?? false }
         set { defaults.set(newValue, forKey: "ocrOnboardingShown") }
+    }
+
+    // MARK: Translation
+    public var translationTargetLanguage: String {
+        get {
+            defaults.string(forKey: "translationTargetLanguage") ?? Self.systemDefaultLanguage()
+        }
+        set { defaults.set(newValue, forKey: "translationTargetLanguage") }
+    }
+
+    public var translationAutoCopy: Bool {
+        get { defaults.object(forKey: "translationAutoCopy") as? Bool ?? true }
+        set { defaults.set(newValue, forKey: "translationAutoCopy") }
+    }
+
+    public var translationShowOriginal: Bool {
+        get { defaults.object(forKey: "translationShowOriginal") as? Bool ?? true }
+        set { defaults.set(newValue, forKey: "translationShowOriginal") }
+    }
+
+    public var translationCardPosition: TranslationCardPosition {
+        get {
+            guard let raw = defaults.string(forKey: "translationCardPosition"),
+                  let value = TranslationCardPosition(rawValue: raw) else { return .centerScreen }
+            return value
+        }
+        set { defaults.set(newValue.rawValue, forKey: "translationCardPosition") }
+    }
+
+    public var translationAutoDismiss: TranslationAutoDismiss {
+        get {
+            guard let raw = defaults.string(forKey: "translationAutoDismiss"),
+                  let value = TranslationAutoDismiss(rawValue: raw) else { return .manual }
+            return value
+        }
+        set { defaults.set(newValue.rawValue, forKey: "translationAutoDismiss") }
+    }
+
+    public var translationAutoDismissDelay: TimeInterval {
+        get { defaults.object(forKey: "translationAutoDismissDelay") as? TimeInterval ?? 10 }
+        set { defaults.set(newValue, forKey: "translationAutoDismissDelay") }
+    }
+
+    public var translationOnboardingShown: Bool {
+        get { defaults.object(forKey: "translationOnboardingShown") as? Bool ?? false }
+        set { defaults.set(newValue, forKey: "translationOnboardingShown") }
+    }
+
+    /// Chosen at first launch; falls back to English for unsupported locales.
+    /// Kept here (rather than in TranslationKit) so SharedKit has no extra dependency.
+    private static func systemDefaultLanguage() -> String {
+        let locale = Locale.current
+        guard let code = locale.language.languageCode?.identifier else { return "en" }
+        if code == "zh" {
+            let script = locale.language.script?.identifier
+            let region = locale.region?.identifier
+            let traditionalRegions: Set<String> = ["TW", "HK", "MO"]
+            let isTraditional = script == "Hant"
+                || (script == nil && region.map(traditionalRegions.contains) == true)
+            return isTraditional ? "zh-Hant" : "zh-Hans"
+        }
+        if code == "pt" { return "pt-BR" }
+        let supported: Set<String> = [
+            "ar", "de", "en", "es", "fr", "hi", "id", "it", "ja", "ko",
+            "nl", "pl", "ru", "tr", "uk"
+        ]
+        return supported.contains(code) ? code : "en"
     }
 
     // MARK: Licensing

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -86,4 +86,64 @@ struct AppSettingsTests {
             FileNaming.generateFileName(for: .recording, format: .mov, date: date).hasSuffix(".mov")
         )
     }
+
+    @Test("Default translation target language is non-empty")
+    func defaultTranslationTargetLanguage() {
+        let settings = AppSettings()
+        #expect(!settings.translationTargetLanguage.isEmpty)
+    }
+
+    @Test("Default translationAutoCopy is true")
+    func defaultTranslationAutoCopy() {
+        let suite = "test.translationAutoCopy.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.translationAutoCopy == true)
+    }
+
+    @Test("Default translationShowOriginal is true")
+    func defaultTranslationShowOriginal() {
+        let suite = "test.translationShowOriginal.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.translationShowOriginal == true)
+    }
+
+    @Test("Default card position is .centerScreen")
+    func defaultCardPosition() {
+        let suite = "test.translationCardPosition.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.translationCardPosition == .centerScreen)
+    }
+
+    @Test("Default auto-dismiss is .manual")
+    func defaultAutoDismiss() {
+        let suite = "test.translationAutoDismiss.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.translationAutoDismiss == .manual)
+    }
+
+    @Test("Translation onboarding flag defaults false")
+    func defaultOnboardingShown() {
+        let suite = "test.translationOnboardingShown.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.translationOnboardingShown == false)
+    }
+
+    @Test("Default auto-dismiss delay is 10 seconds")
+    func defaultAutoDismissDelay() {
+        let suite = "test.translationAutoDismissDelay.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.translationAutoDismissDelay == 10)
+    }
 }

--- a/Packages/TranslationKit/Package.swift
+++ b/Packages/TranslationKit/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "TranslationKit",
+    platforms: [.macOS(.v15)],
+    products: [.library(name: "TranslationKit", targets: ["TranslationKit"])],
+    dependencies: [
+        .package(path: "../SharedKit"),
+        .package(path: "../OCRKit"),
+    ],
+    targets: [
+        .target(name: "TranslationKit", dependencies: ["SharedKit", "OCRKit"]),
+        .testTarget(name: "TranslationKitTests", dependencies: ["TranslationKit"]),
+    ]
+)

--- a/Packages/TranslationKit/Sources/TranslationKit/LanguagePreference.swift
+++ b/Packages/TranslationKit/Sources/TranslationKit/LanguagePreference.swift
@@ -1,0 +1,47 @@
+// Packages/TranslationKit/Sources/TranslationKit/LanguagePreference.swift
+import Foundation
+
+/// Utilities around the target language for translation.
+public enum LanguagePreference {
+    /// Languages Apple's Translation framework supports on macOS 15.
+    /// Source: developer.apple.com/documentation/translation — keep in sync.
+    /// Note: tags here are what Apple's framework accepts — `pt-BR` (not `pt`),
+    /// `zh-Hans` / `zh-Hant` (not bare `zh`).
+    private static let supportedLanguageCodes: Set<String> = [
+        "ar", "de", "en", "es", "fr", "hi", "id", "it", "ja", "ko",
+        "nl", "pl", "pt-BR", "ru", "tr", "uk",
+        "zh-Hans", "zh-Hant"
+    ]
+
+    /// Regions where Chinese defaults to Traditional script even without an
+    /// explicit `script` subtag on the Locale.
+    private static let traditionalChineseRegions: Set<String> = ["TW", "HK", "MO"]
+
+    /// Returns a reasonable default target given a locale.
+    /// Prefers the locale's own language when supported; otherwise falls back to "en".
+    public static func defaultTarget(for locale: Locale = .current) -> String {
+        guard let code = locale.language.languageCode?.identifier else { return "en" }
+
+        // Chinese: resolve Simplified vs Traditional from script or region.
+        if code == "zh" {
+            let script = locale.language.script?.identifier
+            let region = locale.region?.identifier
+            let isTraditional = script == "Hant"
+                || (script == nil && region.map(traditionalChineseRegions.contains) == true)
+            let bcp = isTraditional ? "zh-Hant" : "zh-Hans"
+            return isSupported(bcp) ? bcp : "en"
+        }
+
+        // Portuguese: Apple ships pt-BR only.
+        if code == "pt" {
+            return isSupported("pt-BR") ? "pt-BR" : "en"
+        }
+
+        return isSupported(code) ? code : "en"
+    }
+
+    /// Whether Apple's framework accepts this BCP-47 code as a target/source.
+    public static func isSupported(_ code: String) -> Bool {
+        supportedLanguageCodes.contains(code)
+    }
+}

--- a/Packages/TranslationKit/Sources/TranslationKit/TranslatedRegion.swift
+++ b/Packages/TranslationKit/Sources/TranslationKit/TranslatedRegion.swift
@@ -1,0 +1,23 @@
+// Packages/TranslationKit/Sources/TranslationKit/TranslatedRegion.swift
+import Foundation
+import OCRKit
+
+/// A translated text region. Pairs the original `TextRegion` (with bounding box)
+/// with the translated string and the source language Apple actually detected.
+public struct TranslatedRegion: Identifiable, Sendable {
+    public let id: UUID
+    public let original: TextRegion
+    public let translation: String
+    public let detectedSource: Locale.Language
+
+    public init(
+        original: TextRegion,
+        translation: String,
+        detectedSource: Locale.Language
+    ) {
+        self.id = original.id
+        self.original = original
+        self.translation = translation
+        self.detectedSource = detectedSource
+    }
+}

--- a/Packages/TranslationKit/Sources/TranslationKit/TranslationError.swift
+++ b/Packages/TranslationKit/Sources/TranslationKit/TranslationError.swift
@@ -1,0 +1,53 @@
+// Packages/TranslationKit/Sources/TranslationKit/TranslationError.swift
+import Foundation
+
+/// Typed errors thrown by ``TranslationService``.
+///
+/// `TranslationError` conforms to `@unchecked Sendable` because
+/// `sessionFailed(underlying:)` wraps an `any Error` existential, which the
+/// Swift 6 compiler cannot statically verify as `Sendable`. The enum itself
+/// carries no mutable shared state, so the unchecked annotation is safe.
+public enum TranslationError: Error, @unchecked Sendable {
+    /// Apple's framework does not support the detected source language.
+    case sourceUnsupported(language: String)
+    /// Detected source language equals the requested target.
+    case sourceEqualsTarget(language: String)
+    /// Needed language pack is not installed and the device is offline.
+    case needsLanguagePackDownloadOffline
+    /// Session returned a different number of translations than inputs.
+    case translationCountMismatch(expected: Int, got: Int)
+    /// Underlying `TranslationSession` failure.
+    case sessionFailed(underlying: any Error)
+}
+
+extension TranslationError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .sourceUnsupported(let language):
+            return String(
+                localized: "Translation doesn't support \(language.uppercased()) yet.",
+                comment: "Shown when the source language is not supported by Apple Translation."
+            )
+        case .sourceEqualsTarget(let language):
+            return String(
+                localized: "This text is already in \(language.uppercased()).",
+                comment: "Shown when source and target language match."
+            )
+        case .needsLanguagePackDownloadOffline:
+            return String(
+                localized: "Connect to the Internet to download the translation languages.",
+                comment: "Shown when a language pack is missing and the device is offline."
+            )
+        case .translationCountMismatch(let expected, let got):
+            return String(
+                localized: "Translation mismatch: expected \(expected), got \(got).",
+                comment: "Shown when the translation session returns a wrong number of translations."
+            )
+        case .sessionFailed(let underlying):
+            return String(
+                localized: "Translation failed: \(underlying.localizedDescription)",
+                comment: "Generic translation failure wrapping an underlying system error."
+            )
+        }
+    }
+}

--- a/Packages/TranslationKit/Sources/TranslationKit/TranslationKit.swift
+++ b/Packages/TranslationKit/Sources/TranslationKit/TranslationKit.swift
@@ -1,0 +1,2 @@
+// TranslationKit — on-device translation for Capso.
+// Public API is exported from individual files.

--- a/Packages/TranslationKit/Sources/TranslationKit/TranslationService.swift
+++ b/Packages/TranslationKit/Sources/TranslationKit/TranslationService.swift
@@ -1,0 +1,71 @@
+// Packages/TranslationKit/Sources/TranslationKit/TranslationService.swift
+import Foundation
+import OCRKit
+import NaturalLanguage
+
+/// High-level translation façade used by the app.
+/// Input: already-OCR'd `TextRegion`s + a target BCP-47 code.
+/// Output: `TranslatedRegion`s in the same order, or a typed `TranslationError`.
+///
+/// Declared as an `actor` to serialize in-flight requests and host future
+/// caching / TranslationSession lifecycle state.
+public actor TranslationService {
+    private let session: TranslationSessioning
+
+    public init(session: TranslationSessioning) {
+        self.session = session
+    }
+
+    public func translate(
+        regions: [TextRegion],
+        target: String
+    ) async throws -> [TranslatedRegion] {
+        // Filter empty / whitespace-only text up front — Apple's API doesn't like
+        // empty strings and we'd waste a round-trip.
+        let meaningful = regions.filter { !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        guard !meaningful.isEmpty else { return [] }
+
+        // Pre-detect source language with NaturalLanguage to avoid Apple's
+        // auto-detection dialog, which requires a visible UI host and crashes
+        // when attached to our hidden driver window. Fall back to the user's
+        // current locale if detection is inconclusive.
+        let combined = meaningful.map(\.text).joined(separator: "\n")
+        let detectedFrom = Self.detectLanguage(combined)
+
+        let sessionResult = try await session.translate(
+            meaningful.map(\.text),
+            from: detectedFrom,
+            to: target
+        )
+
+        guard sessionResult.translations.count == meaningful.count else {
+            throw TranslationError.translationCountMismatch(
+                expected: meaningful.count,
+                got: sessionResult.translations.count
+            )
+        }
+
+        if sessionResult.detectedSource == target {
+            throw TranslationError.sourceEqualsTarget(language: target)
+        }
+
+        return zip(meaningful, sessionResult.translations).map { region, translation in
+            TranslatedRegion(
+                original: region,
+                translation: translation,
+                detectedSource: Locale.Language(identifier: sessionResult.detectedSource)
+            )
+        }
+    }
+
+    /// Detect the dominant language of a piece of text using Apple's
+    /// NaturalLanguage framework. Returns a BCP-47 code (e.g. "en", "zh-Hans").
+    /// Returns `nil` if detection is inconclusive — caller decides the fallback.
+    private static func detectLanguage(_ text: String) -> String? {
+        let recognizer = NLLanguageRecognizer()
+        recognizer.processString(text)
+        guard let lang = recognizer.dominantLanguage else { return nil }
+        // NLLanguage raw values are BCP-47 already (e.g. "en", "zh-Hans", "ja")
+        return lang.rawValue
+    }
+}

--- a/Packages/TranslationKit/Sources/TranslationKit/TranslationSessioning.swift
+++ b/Packages/TranslationKit/Sources/TranslationKit/TranslationSessioning.swift
@@ -1,0 +1,37 @@
+// Packages/TranslationKit/Sources/TranslationKit/TranslationSessioning.swift
+import Foundation
+
+/// Result returned by a translation session batch call.
+/// Named struct (not a tuple) so the API can evolve without breaking consumers.
+public struct TranslationSessionResult: Sendable {
+    public let translations: [String]
+    public let detectedSource: String
+
+    public init(translations: [String], detectedSource: String) {
+        self.translations = translations
+        self.detectedSource = detectedSource
+    }
+}
+
+/// Abstraction over Apple's `TranslationSession` so `TranslationService` is testable.
+/// Real implementation wraps `TranslationSession`; tests provide an in-memory fake.
+public protocol TranslationSessioning: Sendable {
+    /// Translate strings in order, returning translations in matching order.
+    /// On success, returns an array of the same length as `sources`.
+    /// Throws `TranslationError` on failure.
+    func translate(
+        _ sources: [String],
+        from: String?,      // BCP-47; nil = auto-detect
+        to target: String
+    ) async throws -> TranslationSessionResult
+
+    /// Non-blocking check of whether the language pair is installed.
+    /// Used to preflight before showing the system download prompt.
+    func status(from: String, to: String) async -> LanguagePairStatus
+}
+
+public enum LanguagePairStatus: Sendable {
+    case installed
+    case supported        // can be downloaded
+    case unsupported
+}

--- a/Packages/TranslationKit/Tests/TranslationKitTests/LanguagePreferenceTests.swift
+++ b/Packages/TranslationKit/Tests/TranslationKitTests/LanguagePreferenceTests.swift
@@ -1,0 +1,54 @@
+// Packages/TranslationKit/Tests/TranslationKitTests/LanguagePreferenceTests.swift
+import Foundation
+import Testing
+@testable import TranslationKit
+
+@Suite("LanguagePreference")
+struct LanguagePreferenceTests {
+    @Test("defaultTarget returns system language code for supported locales")
+    func defaultTargetSupported() {
+        let en = Locale(identifier: "en_US")
+        #expect(LanguagePreference.defaultTarget(for: en) == "en")
+
+        let zh = Locale(identifier: "zh_Hans_CN")
+        #expect(LanguagePreference.defaultTarget(for: zh) == "zh-Hans")
+
+        let ja = Locale(identifier: "ja_JP")
+        #expect(LanguagePreference.defaultTarget(for: ja) == "ja")
+
+        let ko = Locale(identifier: "ko_KR")
+        #expect(LanguagePreference.defaultTarget(for: ko) == "ko")
+    }
+
+    @Test("defaultTarget falls back to English for unsupported locales")
+    func defaultTargetFallback() {
+        let th = Locale(identifier: "th_TH")
+        #expect(LanguagePreference.defaultTarget(for: th) == "en")
+    }
+
+    @Test("isSupported matches Apple's documented language list")
+    func isSupported() {
+        #expect(LanguagePreference.isSupported("en"))
+        #expect(LanguagePreference.isSupported("zh-Hans"))
+        #expect(LanguagePreference.isSupported("ja"))
+        #expect(!LanguagePreference.isSupported("th"))
+        #expect(!LanguagePreference.isSupported("vi"))
+    }
+
+    @Test("Chinese regional locales without script map correctly")
+    func chineseRegions() {
+        #expect(LanguagePreference.defaultTarget(for: Locale(identifier: "zh_TW")) == "zh-Hant")
+        #expect(LanguagePreference.defaultTarget(for: Locale(identifier: "zh_HK")) == "zh-Hant")
+        #expect(LanguagePreference.defaultTarget(for: Locale(identifier: "zh_MO")) == "zh-Hant")
+        #expect(LanguagePreference.defaultTarget(for: Locale(identifier: "zh_CN")) == "zh-Hans")
+        #expect(LanguagePreference.defaultTarget(for: Locale(identifier: "zh_SG")) == "zh-Hans")
+    }
+
+    @Test("Portuguese locales map to pt-BR")
+    func portuguese() {
+        #expect(LanguagePreference.defaultTarget(for: Locale(identifier: "pt_BR")) == "pt-BR")
+        #expect(LanguagePreference.defaultTarget(for: Locale(identifier: "pt_PT")) == "pt-BR")
+        #expect(LanguagePreference.isSupported("pt-BR"))
+        #expect(!LanguagePreference.isSupported("pt"))
+    }
+}

--- a/Packages/TranslationKit/Tests/TranslationKitTests/SmokeTests.swift
+++ b/Packages/TranslationKit/Tests/TranslationKitTests/SmokeTests.swift
@@ -1,0 +1,10 @@
+import Testing
+@testable import TranslationKit
+
+@Suite("TranslationKit")
+struct TranslationKitSmokeTests {
+    @Test("Module compiles")
+    func compiles() {
+        #expect(true)
+    }
+}

--- a/Packages/TranslationKit/Tests/TranslationKitTests/TranslatedRegionTests.swift
+++ b/Packages/TranslationKit/Tests/TranslationKitTests/TranslatedRegionTests.swift
@@ -1,0 +1,25 @@
+// Packages/TranslationKit/Tests/TranslationKitTests/TranslatedRegionTests.swift
+import Foundation
+import Testing
+import OCRKit
+@testable import TranslationKit
+
+@Suite("TranslatedRegion")
+struct TranslatedRegionTests {
+    @Test("stores original region and translation")
+    func stores() {
+        let region = TextRegion(
+            text: "Hello",
+            boundingBox: CGRect(x: 0, y: 0, width: 100, height: 20),
+            confidence: 0.99
+        )
+        let translated = TranslatedRegion(
+            original: region,
+            translation: "你好",
+            detectedSource: Locale.Language(identifier: "en")
+        )
+        #expect(translated.original.text == "Hello")
+        #expect(translated.translation == "你好")
+        #expect(translated.detectedSource.languageCode?.identifier == "en")
+    }
+}

--- a/Packages/TranslationKit/Tests/TranslationKitTests/TranslationErrorTests.swift
+++ b/Packages/TranslationKit/Tests/TranslationKitTests/TranslationErrorTests.swift
@@ -1,0 +1,31 @@
+// Packages/TranslationKit/Tests/TranslationKitTests/TranslationErrorTests.swift
+import Foundation
+import Testing
+@testable import TranslationKit
+
+@Suite("TranslationError")
+struct TranslationErrorTests {
+    @Test("sourceUnsupported carries the language identifier")
+    func sourceUnsupported() {
+        let err = TranslationError.sourceUnsupported(language: "th")
+        if case .sourceUnsupported(let lang) = err {
+            #expect(lang == "th")
+        } else {
+            Issue.record("Expected .sourceUnsupported")
+        }
+    }
+
+    @Test("localizedDescription is human readable for every case")
+    func descriptions() {
+        let cases: [TranslationError] = [
+            .sourceUnsupported(language: "th"),
+            .sourceEqualsTarget(language: "en"),
+            .needsLanguagePackDownloadOffline,
+            .translationCountMismatch(expected: 3, got: 2),
+            .sessionFailed(underlying: NSError(domain: "x", code: 1))
+        ]
+        for err in cases {
+            #expect(!err.localizedDescription.isEmpty)
+        }
+    }
+}

--- a/Packages/TranslationKit/Tests/TranslationKitTests/TranslationServiceTests.swift
+++ b/Packages/TranslationKit/Tests/TranslationKitTests/TranslationServiceTests.swift
@@ -1,0 +1,97 @@
+// Packages/TranslationKit/Tests/TranslationKitTests/TranslationServiceTests.swift
+import Foundation
+import Testing
+import OCRKit
+@testable import TranslationKit
+
+actor FakeSession: TranslationSessioning {
+    enum Scenario { case happy, unsupported, sessionThrows(Error) }
+    var scenario: Scenario = .happy
+    var installed = true
+    var detectedSource = "en"
+    var transform: @Sendable (String) -> String = { "【\($0)】" }
+
+    func translate(_ sources: [String], from: String?, to target: String) async throws
+        -> TranslationSessionResult
+    {
+        switch scenario {
+        case .happy:
+            return TranslationSessionResult(
+                translations: sources.map(transform),
+                detectedSource: detectedSource
+            )
+        case .unsupported:
+            throw TranslationError.sourceUnsupported(language: "xx")
+        case .sessionThrows(let e):
+            throw TranslationError.sessionFailed(underlying: e)
+        }
+    }
+    func status(from: String, to: String) async -> LanguagePairStatus {
+        installed ? .installed : .supported
+    }
+
+    func setScenario(_ s: Scenario) { self.scenario = s }
+    func setDetectedSource(_ d: String) { self.detectedSource = d }
+}
+
+@Suite("TranslationService")
+struct TranslationServiceTests {
+    private func sampleRegion(_ text: String) -> TextRegion {
+        TextRegion(
+            text: text,
+            boundingBox: CGRect(x: 0, y: 0, width: 100, height: 20),
+            confidence: 0.99
+        )
+    }
+
+    @Test("happy path returns one translation per region")
+    func happy() async throws {
+        let fake = FakeSession()
+        let service = TranslationService(session: fake)
+        let regions = [sampleRegion("Hello"), sampleRegion("World")]
+        let result = try await service.translate(regions: regions, target: "zh-Hans")
+        #expect(result.count == 2)
+        #expect(result[0].translation == "【Hello】")
+        #expect(result[1].translation == "【World】")
+    }
+
+    @Test("filters empty-text regions before calling the session")
+    func filtersEmpty() async throws {
+        let fake = FakeSession()
+        let service = TranslationService(session: fake)
+        let regions = [sampleRegion("Hello"), sampleRegion("   "), sampleRegion("")]
+        let result = try await service.translate(regions: regions, target: "zh-Hans")
+        #expect(result.count == 1)
+        #expect(result[0].original.text == "Hello")
+    }
+
+    @Test("rejects source == target with .sourceEqualsTarget")
+    func sourceEqualsTarget() async throws {
+        let fake = FakeSession()
+        await fake.setDetectedSource("zh-Hans")
+        let service = TranslationService(session: fake)
+        do {
+            _ = try await service.translate(regions: [sampleRegion("你好")], target: "zh-Hans")
+            Issue.record("Expected throw")
+        } catch let TranslationError.sourceEqualsTarget(lang) {
+            #expect(lang == "zh-Hans")
+        } catch {
+            Issue.record("Wrong error: \(error)")
+        }
+    }
+
+    @Test("propagates session-level errors")
+    func sessionError() async throws {
+        let fake = FakeSession()
+        await fake.setScenario(.sessionThrows(NSError(domain: "x", code: 42)))
+        let service = TranslationService(session: fake)
+        do {
+            _ = try await service.translate(regions: [sampleRegion("Hi")], target: "zh-Hans")
+            Issue.record("Expected throw")
+        } catch let TranslationError.sessionFailed(err as NSError) {
+            #expect(err.code == 42)
+        } catch {
+            Issue.record("Wrong error: \(error)")
+        }
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -33,6 +33,8 @@ packages:
     path: Packages/AnnotationKit
   OCRKit:
     path: Packages/OCRKit
+  TranslationKit:
+    path: Packages/TranslationKit
   ExportKit:
     path: Packages/ExportKit
   EffectsKit:
@@ -78,6 +80,7 @@ targets:
       - package: CameraKit
       - package: AnnotationKit
       - package: OCRKit
+      - package: TranslationKit
       - package: ExportKit
       - package: EffectsKit
       - package: EditorKit


### PR DESCRIPTION
## Summary

Ships the **Capture & Translate** feature (closes #71) using Apple's on-device Translation framework, plus a handful of ancillary UX polish items that came out of the same session.

### New feature — Capture & Translate (Apple Translation, macOS 15+)
- Select area → Apple OCR → Apple Translation → floating result card, all locally / on-device.
- Entry points: `⌘⇧T` global shortcut, Quick Access button, menu-bar item.
- Result card: translation first with collapsible original, numbered-list / bullet / paragraph-aware rendering preserving source numbers, Pin, manual Copy with feedback, conditional `⌘C` hint.
- Smart positioning: below → above → center fallback.
- Onboarding panel mirrors the OCR pattern (NSPanel + `[weak self]` deferral) so dismissal never crashes.
- Source-language pre-detection via `NLLanguageRecognizer` so pure CN→CN short-circuits before Apple's generic "Unable to Translate" error.
- Joined-translation pipeline (one Apple call, better prose continuity) rather than per-block.
- `Preferences → Text & Translation`: default target language, auto-copy, show-original default, auto-dismiss, card position.

### Quick Access — Editorial Plate D2 redesign (+#72)
- Thumbnail + caption at rest; hover reveals a 6-icon chrome strip (Copy / Save / Annotate / OCR / Translate / Pin) with grouped dividers.
- Per-action `⌘C / ⌘S / ⌘E / ⌘⇧O / ⌘⇧T / ⌘P` keyboard shortcuts (#72).
- Overridden `canBecomeKey` so shortcuts actually fire on the non-activating panel.
- Latest polish: ~10% tighter panel (288×200), keycap-style pill for the shortcut hint with tracking so ⌘ and the key glyph don't smoosh together.

### Inline annotation text editor (follow-up to #73)
- Replaces the modal `NSAlert "Enter Text"` popup with in-place canvas editing, matching CleanShot X's direct-manipulation model.
- Click with the text tool (or double-click an existing TextObject in select mode) → live editor appears at the click point with the currently-selected font size and color.
- Esc or outside-click commits; Return and Shift+Return both insert newlines; `hasMarkedText()` guard so IME composition (CN/JP/KR) is never mis-committed on Return.
- Font-size slider (12–120) drives the editor live; double-click re-edit syncs the slider to the existing object's size.

### Other fixes
- OCR: reliably bring Visual OCR overlay to front on macOS 14+, with subsequent revert back to the simple path after a regression — net behavior is the pre-regression working version.
- Translation: fixed result card window size + single outer ScrollView to stop the `NSISEngine` layout-feedback stack overflow; dropped the hidden-window adapter entirely in favor of driving `.translationTask` from the visible card; card position default shifted to `.centerScreen` for predictability.

## Test plan
- [ ] `⌘⇧T` triggers capture → OCR → translation card; auto-copy and show-original toggles honored.
- [ ] Quick Access: hover reveals chrome; each shortcut (⌘C/⌘S/⌘E/⌘⇧O/⌘⇧T/⌘P) fires; keycap pills for ⌘S, ⌘⇧T render clearly.
- [ ] Annotation text tool: click opens inline editor; Enter/Shift+Enter insert newlines; Esc commits; empty-on-commit discards.
- [ ] Annotation text: double-click existing text re-edits; empty-on-commit deletes; undo restores.
- [ ] IME: Chinese input — Return while composing confirms the IME candidate, does not commit the edit.
- [ ] Translation card: numbered lists preserve source numbers (e.g. `1.` `5.` `10.`).
- [ ] Preferences → Text & Translation tab saves and reloads all fields.
- [ ] Source language = target language (e.g. zh→zh) short-circuits before calling Apple.

Closes #71
Closes #72
