### PR TITLE
feat(annotation): sticky drawing tools + persist tool preferences

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
@@ -23,6 +23,16 @@ struct AnnotationCanvasView: NSViewRepresentable {
     /// Called when the inline text editor commits / dismisses.
     var onTextEditingEnded: (() -> Void)?
 
+    /// Tools that stay active after each stroke so the user can keep drawing
+    /// without reaching back to the toolbar (issue #75). Shape tools (arrow,
+    /// rectangle, ellipse) and pixelate behave the same way — most users add
+    /// several in a row. Text and crop intentionally stay one-shot: text has
+    /// its own inline-edit flow and crop is naturally one-per-image.
+    private static let stickyTools: Set<AnnotationTool> = [
+        .arrow, .rectangle, .ellipse, .pixelate,
+        .counter, .freehand, .highlighter
+    ]
+
     func makeNSView(context: Context) -> AnnotationCanvasNSView {
         let view = AnnotationCanvasNSView()
         view.document = document
@@ -33,11 +43,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
         view.zoomScale = zoomScale
         view.textRegions = textRegions
         view.onObjectCreated = {
-            // Continuous-drawing tools stay active after each stroke;
-            // one-shot tools (arrow, rect, ellipse, text, pixelate) switch
-            // back to select after creation.
-            let keepActive: Set<AnnotationTool> = [.counter, .freehand, .highlighter]
-            if !keepActive.contains(currentTool) {
+            if !Self.stickyTools.contains(currentTool) {
                 onSwitchToSelect?()
             }
         }
@@ -54,8 +60,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
         nsView.zoomScale = zoomScale
         nsView.textRegions = textRegions
         nsView.onObjectCreated = {
-            let keepActive: Set<AnnotationTool> = [.counter, .freehand, .highlighter]
-            if !keepActive.contains(currentTool) {
+            if !Self.stickyTools.contains(currentTool) {
                 onSwitchToSelect?()
             }
         }

--- a/App/Sources/AnnotationEditor/AnnotationEditorView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorView.swift
@@ -10,17 +10,23 @@ struct AnnotationEditorView: View {
     let onCopy: (CGImage) -> Void
     let onCancel: () -> Void
 
-    @State private var currentTool: AnnotationTool = .arrow
-    @State private var currentColor: AnnotationColor = .red
-    @State private var lineWidth: CGFloat = 3
-    @State private var filled: Bool = false
-    @State private var savedLineWidth: CGFloat = 3
-    @State private var savedBlockSize: CGFloat = 12
-    @State private var savedCounterSize: CGFloat = 20
-    @State private var savedHighlighterWidth: CGFloat = 20
+    // MARK: - Persisted tool preferences (issue #75)
+    // Tool / color / filled / per-tool sizes survive across editor sessions
+    // via UserDefaults. `lineWidth` itself is session-local because its
+    // meaning changes with the active tool; it is synced on every change into
+    // the correct per-tool store below.
+    @AppStorage("annotationLastTool") private var currentTool: AnnotationTool = .arrow
+    @AppStorage("annotationLastColor") private var currentColor: AnnotationColor = .red
+    @AppStorage("annotationFilled") private var filled: Bool = false
+    @AppStorage("annotationShapeWidth") private var savedLineWidth: Double = 3
+    @AppStorage("annotationBlockSize") private var savedBlockSize: Double = 12
+    @AppStorage("annotationCounterSize") private var savedCounterSize: Double = 20
+    @AppStorage("annotationHighlighterWidth") private var savedHighlighterWidth: Double = 20
     /// Preserved font size for the Text tool. Swapped in/out of `lineWidth`
     /// as the user toggles tools — same pattern as savedBlockSize etc.
-    @State private var savedTextFontSize: CGFloat = 48
+    @AppStorage("annotationTextFontSize") private var savedTextFontSize: Double = 48
+
+    @State private var lineWidth: CGFloat = 3
     /// True while an inline text editor is active. Lets the toolbar show
     /// the font-size slider even when the tool is `.select` (happens when
     /// re-editing via double-click).
@@ -69,7 +75,32 @@ struct AnnotationEditorView: View {
     /// wins so dragging it updates the editor in real time. Otherwise we
     /// fall back to the preserved value from the last text session.
     private var effectiveTextFontSize: CGFloat {
-        (currentTool == .text || isEditingText) ? lineWidth : savedTextFontSize
+        (currentTool == .text || isEditingText) ? lineWidth : CGFloat(savedTextFontSize)
+    }
+
+    /// Preserved width for the given tool. Bridges between the `Double`
+    /// UserDefaults stores and the canvas's `CGFloat` slider value.
+    private func savedWidth(for tool: AnnotationTool) -> CGFloat {
+        switch tool {
+        case .pixelate: return CGFloat(savedBlockSize)
+        case .counter: return CGFloat(savedCounterSize)
+        case .highlighter: return CGFloat(savedHighlighterWidth)
+        case .text: return CGFloat(savedTextFontSize)
+        default: return CGFloat(savedLineWidth)
+        }
+    }
+
+    /// Persist the current slider value into the store that owns the given
+    /// tool. Called on every slider change so a dragged-then-closed editor
+    /// still saves the user's choice.
+    private func persistWidth(_ width: CGFloat, for tool: AnnotationTool) {
+        switch tool {
+        case .pixelate: savedBlockSize = Double(width)
+        case .counter: savedCounterSize = Double(width)
+        case .highlighter: savedHighlighterWidth = Double(width)
+        case .text: savedTextFontSize = Double(width)
+        default: savedLineWidth = Double(width)
+        }
     }
 
     /// Live preview of the Beautify background. For solid, just a filled Rect.
@@ -155,7 +186,7 @@ struct AnnotationEditorView: View {
                                 isEditingText = false
                                 // Preserve the last-used font size for the
                                 // next text edit / tool switch.
-                                savedTextFontSize = lineWidth
+                                savedTextFontSize = Double(lineWidth)
                             }
                         )
                         .frame(
@@ -178,6 +209,9 @@ struct AnnotationEditorView: View {
                 .background(Color(white: 0.12))
                 .onAppear {
                     fitToWindow(availableSize: geo.size)
+                    // Sync the session-local slider to the persisted width
+                    // for whichever tool was last used (issue #75).
+                    lineWidth = savedWidth(for: currentTool)
                     // Pre-cache text regions for smart highlighter snapping
                     Task {
                         if let regions = try? await TextRecognizer.recognize(
@@ -192,25 +226,17 @@ struct AnnotationEditorView: View {
                     // overwrite the previously drawn object's style.
                     document.clearSelection()
 
-                    // Save outgoing tool's value
-                    switch oldTool {
-                    case .pixelate: savedBlockSize = lineWidth
-                    case .counter: savedCounterSize = lineWidth
-                    case .highlighter: savedHighlighterWidth = lineWidth
-                    case .text: savedTextFontSize = lineWidth
-                    default: savedLineWidth = lineWidth
-                    }
-                    // Restore incoming tool's value
-                    switch newTool {
-                    case .pixelate: lineWidth = savedBlockSize
-                    case .counter: lineWidth = savedCounterSize
-                    case .highlighter: lineWidth = savedHighlighterWidth
-                    case .text: lineWidth = savedTextFontSize
-                    default: lineWidth = savedLineWidth
-                    }
+                    // Save outgoing tool's value then restore incoming.
+                    persistWidth(lineWidth, for: oldTool)
+                    lineWidth = savedWidth(for: newTool)
                 }
                 .onChange(of: currentColor) { _, _ in updateSelectedStyle() }
-                .onChange(of: lineWidth) { _, _ in updateSelectedStyle() }
+                .onChange(of: lineWidth) { _, newValue in
+                    updateSelectedStyle()
+                    // Persist slider drags live so closing the editor
+                    // without switching tools still saves the change.
+                    persistWidth(newValue, for: currentTool)
+                }
                 .onChange(of: filled) { _, _ in updateSelectedStyle() }
                 .onChange(of: geo.size) { _, newSize in
                     // Re-fit if window is resized and we're at fit scale


### PR DESCRIPTION
## Summary

Addresses [#75](https://github.com/lzhgus/Capso/issues/75) — annotation editor UX feedback.

- **Sticky shape tools**: Arrow, Rectangle, Ellipse and Pixelate now stay active after each stroke (matching Counter / Freehand / Highlighter). Users drawing several arrows in a row no longer need to reach back to the toolbar. Text and Crop intentionally remain one-shot because of their inline-edit / one-per-image flows.
- **Persisted preferences**: Last tool, color, fill toggle, and per-tool sizes (shape width, pixelate block size, counter size, highlighter width, text font size) are saved to `UserDefaults` via `@AppStorage` and restored when the editor reopens. Size slider changes are persisted live, so closing the editor without switching tools still saves the value.

## Implementation notes

- `AnnotationCanvasView.stickyTools`: expanded the set and pulled it out as a private static constant so both `makeNSView` and `updateNSView` reference the same source of truth.
- `AnnotationEditorView`: `currentTool`, `currentColor`, `filled` and the five per-tool size stores moved from `@State` to `@AppStorage` under `annotation*` keys. The session-local `lineWidth` (CGFloat, bound to the toolbar slider) is synced on appear, tool switch, and every value change through `savedWidth(for:)` / `persistWidth(_:for:)` helpers.

## Test plan

- [x] `xcodebuild` Debug builds clean, no warnings
- [x] Draw several arrows in a row — tool stays on Arrow
- [x] Same check for Rectangle, Ellipse, Pixelate
- [x] Text tool still reverts to Select after commit (unchanged)
- [x] Crop still one-shot (unchanged)
- [x] Adjust arrow width → close editor → open editor → width matches
- [x] Switch to Pixelate, adjust block size, switch back to Arrow, close / reopen → both sizes preserved independently
- [x] Change color → reopen → color preserved
- [x] Toggle Fill on Rectangle → reopen → fill state preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)