### PR TITLE
feat: add toggle to disable automatic update installation

### DIFF
--- a/App/Sources/Preferences/Components/CheckForUpdatesView.swift
+++ b/App/Sources/Preferences/Components/CheckForUpdatesView.swift
@@ -18,6 +18,11 @@ final class UpdateManager: NSObject, ObservableObject {
 
     @Published private(set) var canCheckForUpdates = false
     @Published private(set) var status: Status?
+    @Published var automaticallyDownloadsUpdates: Bool = false {
+        didSet {
+            updater.automaticallyDownloadsUpdates = automaticallyDownloadsUpdates
+        }
+    }
 
     private enum ManualCheckState {
         case none
@@ -26,7 +31,8 @@ final class UpdateManager: NSObject, ObservableObject {
 
     private var manualCheckState: ManualCheckState = .none
     private var probeFoundValidUpdate = false
-    private var observation: NSKeyValueObservation?
+    private var canCheckObservation: NSKeyValueObservation?
+    private var autoDownloadObservation: NSKeyValueObservation?
     private var clearStatusTask: Task<Void, Never>?
 
     lazy var updaterController = SPUStandardUpdaterController(
@@ -39,9 +45,15 @@ final class UpdateManager: NSObject, ObservableObject {
 
     override init() {
         super.init()
-        observation = updater.observe(\.canCheckForUpdates, options: [.initial, .new]) { [weak self] updater, _ in
+        automaticallyDownloadsUpdates = updater.automaticallyDownloadsUpdates
+        canCheckObservation = updater.observe(\.canCheckForUpdates, options: [.initial, .new]) { [weak self] updater, _ in
             Task { @MainActor in
                 self?.canCheckForUpdates = updater.canCheckForUpdates
+            }
+        }
+        autoDownloadObservation = updater.observe(\.automaticallyDownloadsUpdates, options: [.new]) { [weak self] updater, _ in
+            Task { @MainActor in
+                self?.automaticallyDownloadsUpdates = updater.automaticallyDownloadsUpdates
             }
         }
     }

--- a/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
@@ -55,7 +55,15 @@ struct GeneralSettingsView: View {
             if let updateManager {
                 SettingGroup(title: "Updates") {
                     SettingCard {
-                        SettingRow(label: "Check for Updates", sublabel: "Automatically checks daily") {
+                        SettingRow(label: "Automatically Install Updates", sublabel: "Install updates in the background when available") {
+                            Toggle("", isOn: Binding(
+                                get: { updateManager.automaticallyDownloadsUpdates },
+                                set: { updateManager.automaticallyDownloadsUpdates = $0 }
+                            ))
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                        }
+                        SettingRow(label: "Check for Updates", sublabel: "Automatically checks daily", showDivider: true) {
                             CheckForUpdatesView(updateManager: updateManager)
                         }
                     }


### PR DESCRIPTION
## What changed

Adds an "Automatically Install Updates" toggle in **Preferences → General → Updates**. Once a user opts into automatic installation via the Sparkle update prompt, there was previously no way to undo that choice from within the app. This exposes Sparkle's `automaticallyDownloadsUpdates` setting directly in the UI.

- `UpdateManager` now publishes `automaticallyDownloadsUpdates`, initialised from Sparkle on launch, with a KVO observation so the toggle stays in sync if Sparkle changes the value internally (e.g. from its own update prompt).
- `GeneralSettingsView` adds the new toggle row to the existing Updates card.

## Related issue

Closes #79

## Screenshots / recordings

<img width="681" height="510" alt="image" src="https://github.com/user-attachments/assets/700c8715-91fa-495f-b472-53f0c96e969b" />

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass (`swift test --package-path Packages/<Kit>`)
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)