### PR TITLE
fix: guard redundant writes in automatic-update toggle

### DIFF
--- a/App/Sources/Preferences/Components/CheckForUpdatesView.swift
+++ b/App/Sources/Preferences/Components/CheckForUpdatesView.swift
@@ -20,6 +20,7 @@ final class UpdateManager: NSObject, ObservableObject {
     @Published private(set) var status: Status?
     @Published var automaticallyDownloadsUpdates: Bool = false {
         didSet {
+            guard oldValue != automaticallyDownloadsUpdates else { return }
             updater.automaticallyDownloadsUpdates = automaticallyDownloadsUpdates
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to #80. Adds a one-line equality guard to the `automaticallyDownloadsUpdates` `didSet` so our setter and Sparkle's KVO observation can't ping-pong on same-value writes.

Before:
\`\`\`swift
@Published var automaticallyDownloadsUpdates: Bool = false {
    didSet {
        updater.automaticallyDownloadsUpdates = automaticallyDownloadsUpdates
    }
}
\`\`\`

After:
\`\`\`swift
@Published var automaticallyDownloadsUpdates: Bool = false {
    didSet {
        guard oldValue != automaticallyDownloadsUpdates else { return }
        updater.automaticallyDownloadsUpdates = automaticallyDownloadsUpdates
    }
}
\`\`\`

Swift's \`didSet\` doesn't short-circuit on equal values, and Sparkle's KVO may fire for same-value writes internally — so a chain like \`didSet → updater = X → KVO fires → self = X → didSet → …\` is theoretically possible. In practice it probably settles after one async hop, but the guard is free and makes the interaction airtight.

## Test plan

- [x] \`xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build\` passes
- [x] Toggle still flips Sparkle's setting on first write

🤖 Generated with [Claude Code](https://claude.com/claude-code)