### PR TITLE
feat: Self-Timer — delayed area capture with countdown HUD

### DIFF
--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -114,6 +114,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         KeyboardShortcuts.onKeyDown(for: .captureScrolling) { [weak self] in
             self?.captureCoordinator?.captureScrolling()
         }
+        KeyboardShortcuts.onKeyDown(for: .selfTimerCapture) { [weak self] in
+            self?.captureCoordinator?.captureAreaWithSelfTimer()
+        }
         KeyboardShortcuts.onKeyDown(for: .captureAreaToClipboard) { [weak self] in
             self?.captureCoordinator?.captureAreaToClipboard()
         }

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -29,6 +29,7 @@ final class CaptureCoordinator {
     private var freezeWindows: [NSWindow] = []
     private var scrollCaptureController: ScrollCaptureController?
     private var scrollCaptureOverlay: ScrollCaptureOverlay?
+    private var selfTimerHUD: SelfTimerHUD?
 
     var lastCaptureResult: CaptureResult?
     var ocrCoordinator: OCRCoordinator?
@@ -129,6 +130,16 @@ final class CaptureCoordinator {
         }
     }
 
+    /// Self-timer area capture: pick area, show countdown HUD, then capture.
+    /// Uses `settings.selfTimerDurationSeconds` as the delay.
+    func captureAreaWithSelfTimer() {
+        pendingAction = .default
+        let seconds = settings.selfTimerDurationSeconds
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+            self?.showOverlay(mode: .area, selfTimerSeconds: seconds)
+        }
+    }
+
     func captureWindow() {
         // Enumerate windows first, then show overlay in window selection mode
         Task {
@@ -151,7 +162,11 @@ final class CaptureCoordinator {
         }
     }
 
-    private func showOverlay(mode: CaptureOverlayMode = .area, isScrollingCapture: Bool = false) {
+    private func showOverlay(
+        mode: CaptureOverlayMode = .area,
+        isScrollingCapture: Bool = false,
+        selfTimerSeconds: Int? = nil
+    ) {
         dismissOverlay()
         for screen in NSScreen.screens {
             let overlay = CaptureOverlayWindow(screen: screen, settings: settings)
@@ -159,6 +174,8 @@ final class CaptureCoordinator {
                 self?.dismissOverlay()
                 if isScrollingCapture {
                     self?.startScrollingCapture(rect: rect, screen: screen)
+                } else if let seconds = selfTimerSeconds {
+                    self?.runSelfTimerThenCapture(rect: rect, screen: screen, seconds: seconds)
                 } else {
                     self?.performAreaCapture(rect: rect, screen: screen)
                 }
@@ -173,6 +190,36 @@ final class CaptureCoordinator {
             overlay.activate(mode: mode)
             overlayWindows.append(overlay)
         }
+    }
+
+    /// Show the Self-Timer HUD on the screen the user just selected an area
+    /// on, then fire the capture once the countdown finishes. Esc / click on
+    /// the HUD cancels the capture entirely (no fallback capture).
+    private func runSelfTimerThenCapture(rect: CGRect, screen: NSScreen, seconds: Int) {
+        // Tear down any stale HUD first (defensive — there shouldn't be one).
+        selfTimerHUD?.dismiss()
+
+        let hud = SelfTimerHUD()
+        selfTimerHUD = hud
+        hud.show(
+            on: screen,
+            selectionRect: rect,
+            duration: seconds,
+            playTickSound: settings.selfTimerPlayTickSound,
+            savedPosition: settings.selfTimerHUDPosition,
+            persistPosition: { [weak self] origin in
+                self?.settings.selfTimerHUDPosition = origin
+            },
+            onComplete: { [weak self] in
+                self?.selfTimerHUD = nil
+                self?.performAreaCapture(rect: rect, screen: screen)
+            },
+            onCancel: { [weak self] in
+                self?.selfTimerHUD = nil
+                // Reset pendingAction; the user explicitly bailed.
+                self?.pendingAction = .default
+            }
+        )
     }
 
     /// Two-window freeze architecture for preserving popups/dropdowns:

--- a/App/Sources/Capture/SelfTimerHUD.swift
+++ b/App/Sources/Capture/SelfTimerHUD.swift
@@ -1,0 +1,405 @@
+// App/Sources/Capture/SelfTimerHUD.swift
+import AppKit
+import SwiftUI
+import SharedKit
+
+/// Floating countdown overlay shown during a Self-Timer capture.
+///
+/// Visual design (see docs / design spec): rounded-square HUD using
+/// `.regularMaterial` vibrancy, monochrome progress ring draining clockwise,
+/// SF Rounded numeric digit driven by `.contentTransition(.numericText)`.
+/// Adapts to light / dark with the system; never branded with accent color.
+@MainActor
+final class SelfTimerHUD {
+    private var panel: SelfTimerPanel?
+    private var borderPanel: NSPanel?
+    private let viewModel = SelfTimerViewModel()
+    private var keyMonitor: Any?
+    private var positionPersist: ((CGPoint) -> Void)?
+    private var onCancel: (() -> Void)?
+    private var playTickSound: Bool = false
+
+    /// Reusable system "Tink" sound for per-second countdown ticks. Loaded
+    /// once and stopped/restarted on each tick so consecutive ticks don't
+    /// drop. The shutter sound at t=0 is fired by `CaptureCoordinator`, not
+    /// here — we never tick on the final beat.
+    private static let tickSound: NSSound? = NSSound(named: "Tink")
+
+    /// Show the HUD on `screen` for `duration` seconds. Draws a thin
+    /// monochrome border around `selectionRect` for the lifetime of the
+    /// countdown so the user can see what's about to be captured. Calls
+    /// `onComplete` once the countdown finishes — the caller is expected
+    /// to immediately fire the capture. Calls `onCancel` on Esc / click.
+    /// Both the HUD and the border are guaranteed to be off-screen
+    /// *before* `onComplete` returns.
+    func show(
+        on screen: NSScreen,
+        selectionRect: CGRect,
+        duration: Int,
+        playTickSound: Bool,
+        savedPosition: CGPoint?,
+        persistPosition: @escaping (CGPoint) -> Void,
+        onComplete: @escaping () -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        dismiss()  // guard against re-entrant show
+
+        self.positionPersist = persistPosition
+        self.onCancel = onCancel
+        self.playTickSound = playTickSound
+        viewModel.totalDuration = TimeInterval(duration)
+        viewModel.startDate = Date()
+        viewModel.remaining = duration
+
+        showSelectionBorder(rect: selectionRect, screen: screen)
+
+        let size = NSSize(width: 108, height: 108)
+        let origin = Self.resolveOrigin(savedPosition: savedPosition, screen: screen, hudSize: size)
+
+        let panel = SelfTimerPanel(
+            contentRect: NSRect(origin: origin, size: size),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .floating
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false  // SwiftUI draws its own
+        panel.isMovableByWindowBackground = false  // we handle drag in SwiftUI
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+        panel.hidesOnDeactivate = false
+        panel.acceptsMouseMovedEvents = true
+
+        let host = NSHostingView(rootView: SelfTimerHUDView(
+            viewModel: viewModel,
+            hudSize: size,
+            window: { [weak panel] in panel },
+            onCancel: { [weak self] in self?.cancelByUser() },
+            onDragEnded: { [weak self] newOrigin in
+                self?.positionPersist?(newOrigin)
+            }
+        ))
+        host.frame = NSRect(origin: .zero, size: size)
+        panel.contentView = host
+        self.panel = panel
+
+        installKeyMonitor()
+
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.18
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().alphaValue = 1.0
+        }
+
+        // Drive the visible digit on a 1Hz tick. The progress ring is driven
+        // by TimelineView in SwiftUI for sub-second smoothness.
+        Task { [weak self] in
+            guard let self else { return }
+            for tick in 1...duration {
+                try? await Task.sleep(for: .seconds(1))
+                if Task.isCancelled || self.panel == nil { return }
+                let next = duration - tick
+                withAnimation(.snappy(duration: 0.28)) {
+                    self.viewModel.remaining = next
+                }
+                // Tick on every beat *except* the final one — at t=0 the
+                // shutter sound from CaptureCoordinator takes over.
+                if next > 0 && self.playTickSound {
+                    Self.tickSound?.stop()
+                    Self.tickSound?.play()
+                }
+            }
+            // Tear down both panels synchronously, give the window server
+            // two frames to ensure they're fully off-screen, then fire.
+            self.dismissImmediate()
+            try? await Task.sleep(for: .milliseconds(33))
+            onComplete()
+        }
+    }
+
+    /// Draw a 2pt white border around `rect` on `screen`, with a soft black
+    /// outer shadow so the border stays visible on any wallpaper. Sits at
+    /// `.floating` level just below the HUD; ignores mouse events so the
+    /// user can keep interacting with whatever they're capturing.
+    private func showSelectionBorder(rect: CGRect, screen: NSScreen) {
+        let inset: CGFloat = 4  // padding around the rect for the stroke + shadow
+        let screenOrigin = screen.frame.origin
+        let panelRect = NSRect(
+            x: screenOrigin.x + rect.origin.x - inset,
+            y: screenOrigin.y + rect.origin.y - inset,
+            width: rect.width + inset * 2,
+            height: rect.height + inset * 2
+        )
+        let panel = NSPanel(
+            contentRect: panelRect,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .floating
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.ignoresMouseEvents = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+        panel.hidesOnDeactivate = false
+
+        let view = SelfTimerBorderView(
+            frame: NSRect(origin: .zero, size: panelRect.size),
+            inset: inset
+        )
+        panel.contentView = view
+        self.borderPanel = panel
+        panel.orderFrontRegardless()
+    }
+
+    /// User-driven cancel (Esc / click). Animates out then calls onCancel.
+    private func cancelByUser() {
+        let cb = onCancel
+        animatedDismiss { cb?() }
+    }
+
+    /// Pull both panels down with no animation. Used when the timer fires —
+    /// the screenshot must not see either panel, so this is synchronous.
+    private func dismissImmediate() {
+        if let mon = keyMonitor {
+            NSEvent.removeMonitor(mon)
+            keyMonitor = nil
+        }
+        panel?.orderOut(nil)
+        panel = nil
+        borderPanel?.orderOut(nil)
+        borderPanel = nil
+    }
+
+    /// Animate then tear down. Used for cancel paths. Uses a delayed
+    /// `asyncAfter` for clean-up rather than `runAnimationGroup`'s
+    /// completion handler — that closure is `@Sendable`, which doesn't play
+    /// nicely with main-actor-isolated state. The pattern matches
+    /// `CaptureCoordinator.dismissOverlay`.
+    private func animatedDismiss(then completion: (() -> Void)? = nil) {
+        guard let panel else { completion?(); return }
+        if let mon = keyMonitor {
+            NSEvent.removeMonitor(mon)
+            keyMonitor = nil
+        }
+        let border = borderPanel
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = 0.14
+            ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            panel.animator().alphaValue = 0
+            border?.animator().alphaValue = 0
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) { [weak self] in
+            panel.orderOut(nil)
+            border?.orderOut(nil)
+            self?.panel = nil
+            self?.borderPanel = nil
+            completion?()
+        }
+    }
+
+    /// External cancel (e.g., another capture flow starts). No callback fires.
+    func dismiss() {
+        if let mon = keyMonitor {
+            NSEvent.removeMonitor(mon)
+            keyMonitor = nil
+        }
+        panel?.orderOut(nil)
+        panel = nil
+        borderPanel?.orderOut(nil)
+        borderPanel = nil
+        onCancel = nil
+        positionPersist = nil
+    }
+
+    private func installKeyMonitor() {
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            if event.keyCode == 53 { // Esc
+                self?.cancelByUser()
+                return nil
+            }
+            return event
+        }
+    }
+
+    /// Default placement: top-center of `screen`, 80pt below the menu bar /
+    /// top edge. If the user has dragged before, restore that position
+    /// clamped into the visible frame so a disconnected display can't trap
+    /// the HUD off-screen.
+    private static func resolveOrigin(savedPosition: CGPoint?, screen: NSScreen, hudSize: NSSize) -> NSPoint {
+        if let saved = savedPosition {
+            let visible = screensVisibleBounds()
+            let x = max(visible.minX, min(saved.x, visible.maxX - hudSize.width))
+            let y = max(visible.minY, min(saved.y, visible.maxY - hudSize.height))
+            return NSPoint(x: x, y: y)
+        }
+        let frame = screen.visibleFrame
+        let x = frame.midX - hudSize.width / 2
+        let y = frame.maxY - hudSize.height - 80
+        return NSPoint(x: x, y: y)
+    }
+
+    private static func screensVisibleBounds() -> NSRect {
+        var union = NSRect.zero
+        for s in NSScreen.screens {
+            union = union.isEmpty ? s.visibleFrame : union.union(s.visibleFrame)
+        }
+        return union
+    }
+}
+
+// MARK: - Panel (allows borderless windows to become key for Esc handling)
+
+private final class SelfTimerPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}
+
+// MARK: - Selection border view
+
+/// Draws a 2pt white border with a soft black outer shadow so the rect is
+/// visible on bright, dark, and busy backgrounds alike. Static — no marching
+/// ants — to keep the visual language quiet and consistent with the HUD.
+private final class SelfTimerBorderView: NSView {
+    private let inset: CGFloat
+
+    init(frame: NSRect, inset: CGFloat) {
+        self.inset = inset
+        super.init(frame: frame)
+        wantsLayer = true
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    override func draw(_ dirtyRect: NSRect) {
+        guard let ctx = NSGraphicsContext.current?.cgContext else { return }
+        let rect = bounds.insetBy(dx: inset, dy: inset)
+
+        ctx.saveGState()
+        ctx.setShadow(
+            offset: .zero,
+            blur: 4,
+            color: NSColor.black.withAlphaComponent(0.5).cgColor
+        )
+        ctx.setStrokeColor(NSColor.white.cgColor)
+        ctx.setLineWidth(2)
+        ctx.stroke(rect)
+        ctx.restoreGState()
+    }
+}
+
+// MARK: - View model
+
+@MainActor
+@Observable
+final class SelfTimerViewModel {
+    var totalDuration: TimeInterval = 5
+    var startDate: Date = Date()
+    var remaining: Int = 5
+}
+
+// MARK: - SwiftUI view
+
+private struct SelfTimerHUDView: View {
+    let viewModel: SelfTimerViewModel
+    let hudSize: NSSize
+    /// Returns the hosting NSPanel weakly so dragging can move it directly
+    /// without searching `NSApp.windows`.
+    let window: () -> NSWindow?
+    let onCancel: () -> Void
+    /// Called when a drag finishes, with the new bottom-left origin in screen
+    /// coordinates (matching NSWindow.frame.origin convention).
+    let onDragEnded: (CGPoint) -> Void
+
+    @State private var isHovering = false
+    @State private var dragStartOrigin: CGPoint?
+    @State private var didDrag = false
+
+    var body: some View {
+        ZStack {
+            // Backdrop: rounded square with vibrancy + thin inner edge.
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .fill(.regularMaterial)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 22, style: .continuous)
+                        .stroke(Color.primary.opacity(0.08), lineWidth: 0.5)
+                )
+                .shadow(color: Color.black.opacity(0.18), radius: 20, x: 0, y: 8)
+
+            // Progress ring + digit.
+            TimelineView(.animation) { context in
+                let elapsed = context.date.timeIntervalSince(viewModel.startDate)
+                let progress = max(0, min(1, 1 - elapsed / viewModel.totalDuration))
+
+                ZStack {
+                    Circle()
+                        .stroke(Color.primary.opacity(0.12), lineWidth: 3)
+                        .frame(width: 80, height: 80)
+
+                    Circle()
+                        .trim(from: 0, to: progress)
+                        .stroke(
+                            Color.primary.opacity(0.85),
+                            style: StrokeStyle(lineWidth: 3, lineCap: .round)
+                        )
+                        .frame(width: 80, height: 80)
+                        .rotationEffect(.degrees(-90))
+
+                    Group {
+                        if isHovering {
+                            Image(systemName: "xmark")
+                                .font(.system(size: 28, weight: .semibold))
+                                .foregroundStyle(.primary.opacity(0.6))
+                        } else {
+                            Text("\(viewModel.remaining)")
+                                .font(.system(size: 44, weight: .semibold, design: .rounded))
+                                .monospacedDigit()
+                                .foregroundStyle(.primary)
+                                .contentTransition(.numericText(countsDown: true))
+                        }
+                    }
+                    .transition(.opacity)
+                }
+            }
+        }
+        .frame(width: hudSize.width, height: hudSize.height)
+        .onHover { hovering in
+            withAnimation(.easeOut(duration: 0.12)) { isHovering = hovering }
+        }
+        .gesture(
+            DragGesture(minimumDistance: 4, coordinateSpace: .global)
+                .onChanged { value in
+                    guard let win = window() else { return }
+                    if dragStartOrigin == nil {
+                        dragStartOrigin = win.frame.origin
+                    }
+                    didDrag = true
+                    let dx = value.translation.width
+                    let dy = -value.translation.height  // SwiftUI y grows down; NSWindow y grows up
+                    if let start = dragStartOrigin {
+                        win.setFrameOrigin(NSPoint(x: start.x + dx, y: start.y + dy))
+                    }
+                }
+                .onEnded { _ in
+                    if didDrag, let win = window() {
+                        onDragEnded(win.frame.origin)
+                    }
+                    dragStartOrigin = nil
+                    didDrag = false
+                }
+        )
+        .simultaneousGesture(
+            // Tap (no drag) cancels.
+            TapGesture().onEnded {
+                if !didDrag { onCancel() }
+            }
+        )
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text("Self-timer countdown"))
+        .accessibilityValue(Text("\(viewModel.remaining) seconds remaining"))
+    }
+}

--- a/App/Sources/MenuBar/MenuBarController.swift
+++ b/App/Sources/MenuBar/MenuBarController.swift
@@ -97,6 +97,9 @@ final class MenuBarController: NSObject {
         captureScrolling.setShortcut(for: .captureScrolling)
         menu.addItem(captureScrolling)
 
+        let selfTimer = selfTimerMenuItem()
+        menu.addItem(selfTimer)
+
         menu.addItem(.separator())
 
         let recordScreen = menuItem(String(localized: "Record Screen"), action: #selector(recordScreen))
@@ -125,6 +128,34 @@ final class MenuBarController: NSObject {
         return item
     }
 
+    /// Self-Timer menu row. Title is "Self-Timer" with the saved duration
+    /// rendered in tertiary color as a trailing tag (e.g. "Self-Timer  5s").
+    /// Refreshed in `menuWillOpen` so the tag stays in sync with Preferences.
+    private func selfTimerMenuItem() -> NSMenuItem {
+        let item = NSMenuItem(title: "", action: #selector(captureSelfTimer), keyEquivalent: "")
+        item.target = self
+        refreshSelfTimerTitle(item)
+        item.setShortcut(for: .selfTimerCapture)
+        return item
+    }
+
+    private func refreshSelfTimerTitle(_ item: NSMenuItem) {
+        let label = String(localized: "Self-Timer")
+        let duration = "\(settings.selfTimerDurationSeconds)s"
+        let attributed = NSMutableAttributedString(
+            string: label,
+            attributes: [.font: NSFont.menuFont(ofSize: 0)]
+        )
+        attributed.append(NSAttributedString(
+            string: "   \(duration)",
+            attributes: [
+                .font: NSFont.menuFont(ofSize: 0),
+                .foregroundColor: NSColor.tertiaryLabelColor,
+            ]
+        ))
+        item.attributedTitle = attributed
+    }
+
     @objc private func captureArea() {
         captureCoordinator.captureArea()
     }
@@ -147,6 +178,10 @@ final class MenuBarController: NSObject {
 
     @objc private func captureScrolling() {
         captureCoordinator.captureScrolling()
+    }
+
+    @objc private func captureSelfTimer() {
+        captureCoordinator.captureAreaWithSelfTimer()
     }
 
     @objc private func recordScreen() {
@@ -185,6 +220,9 @@ extension MenuBarController: NSMenuDelegate {
             case #selector(captureAndTranslate): item.setShortcut(for: .captureAndTranslate)
             case #selector(recordScreen): item.setShortcut(for: .recordScreen)
             case #selector(captureScrolling): item.setShortcut(for: .captureScrolling)
+            case #selector(captureSelfTimer):
+                item.setShortcut(for: .selfTimerCapture)
+                refreshSelfTimerTitle(item)
             case #selector(openHistory): item.setShortcut(for: .screenshotHistory)
             default: break
             }

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -127,6 +127,30 @@ final class PreferencesViewModel {
         }
     }
 
+    // MARK: Self-Timer
+    var selfTimerDurationSeconds: Int {
+        get {
+            access(keyPath: \.selfTimerDurationSeconds)
+            return settings.selfTimerDurationSeconds
+        }
+        set {
+            withMutation(keyPath: \.selfTimerDurationSeconds) {
+                settings.selfTimerDurationSeconds = newValue
+            }
+        }
+    }
+    var selfTimerPlayTickSound: Bool {
+        get {
+            access(keyPath: \.selfTimerPlayTickSound)
+            return settings.selfTimerPlayTickSound
+        }
+        set {
+            withMutation(keyPath: \.selfTimerPlayTickSound) {
+                settings.selfTimerPlayTickSound = newValue
+            }
+        }
+    }
+
     // MARK: Capture Presets
     var capturePresetsEnabled: Bool {
         get {

--- a/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
@@ -49,6 +49,41 @@ struct ScreenshotSettingsView: View {
                 }
             }
 
+            SettingGroup(title: "Self-Timer") {
+                SettingCard {
+                    SettingRow(
+                        label: "Default Duration",
+                        sublabel: "Delay before the screenshot fires"
+                    ) {
+                        HStack(spacing: 8) {
+                            Text("\(viewModel.selfTimerDurationSeconds)s")
+                                .font(.system(size: 13, weight: .medium).monospacedDigit())
+                                .frame(minWidth: 32, alignment: .trailing)
+                            Stepper(
+                                "",
+                                value: $viewModel.selfTimerDurationSeconds,
+                                in: AppSettings.selfTimerDurationRange
+                            )
+                            .labelsHidden()
+                        }
+                    }
+                    SettingRow(
+                        label: "Tick Sound",
+                        sublabel: "Play a sound on each second of the countdown",
+                        showDivider: true
+                    ) {
+                        Toggle("", isOn: $viewModel.selfTimerPlayTickSound)
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                    }
+                }
+
+                Text("Useful for capturing menus, hover states, and other UI that disappears the moment you move the mouse.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 4)
+            }
+
             SettingGroup(title: "Capture Presets") {
                 SettingCard {
                     SettingRow(

--- a/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
@@ -14,6 +14,10 @@ extension KeyboardShortcuts.Name {
     static let captureAreaAndAnnotate = Self("captureAreaAndAnnotate", default: .init(.eight, modifiers: [.option, .shift]))
     static let screenshotHistory = Self("screenshotHistory", default: .init(.nine, modifiers: [.option, .shift]))
     static let captureAndTranslate = Self("captureAndTranslate", default: .init(.t, modifiers: [.command, .shift]))
+    /// No default binding — opt-in. Self-Timer is discoverable from the
+    /// menu bar; shipping a default risks colliding with whatever the user
+    /// has already bound in macOS or third-party apps.
+    static let selfTimerCapture = Self("selfTimerCapture")
 }
 
 struct ShortcutSettingsView: View {
@@ -46,6 +50,7 @@ struct ShortcutSettingsView: View {
                     shortcutRow("Capture Window", name: .captureWindow, showDivider: true)
                     shortcutRow("Capture Text (OCR)", name: .captureText, showDivider: true)
                     shortcutRow("Scrolling Capture", name: .captureScrolling, showDivider: true)
+                    shortcutRow("Self-Timer", name: .selfTimerCapture, showDivider: true)
                     shortcutRow("Capture Area to Clipboard", name: .captureAreaToClipboard, showDivider: true)
                     shortcutRow("Capture and Share to Cloud", name: .captureAreaAndShare, showDivider: true)
                     shortcutRow("Capture Area & Annotate", name: .captureAreaAndAnnotate, showDivider: true)

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -246,6 +246,54 @@ public final class AppSettings: @unchecked Sendable {
         set { defaults.set(newValue, forKey: "rememberLastCaptureArea") }
     }
 
+    // MARK: Self-Timer
+
+    /// Allowed range for the self-timer duration in seconds. Anything stored
+    /// outside this range is clamped on read so the UI / countdown loop
+    /// never has to defend against zero or absurd values.
+    public static let selfTimerDurationRange: ClosedRange<Int> = 1...60
+
+    /// Default countdown duration in seconds. The setter clamps into
+    /// `selfTimerDurationRange`. Stored as `Int` (raw seconds) so users can
+    /// pick any value in range — the previous 3/5/10 enum values still
+    /// round-trip cleanly because they're plain ints.
+    public var selfTimerDurationSeconds: Int {
+        get {
+            let raw = defaults.object(forKey: "selfTimerDuration") as? Int ?? 5
+            return min(max(raw, Self.selfTimerDurationRange.lowerBound), Self.selfTimerDurationRange.upperBound)
+        }
+        set {
+            let clamped = min(max(newValue, Self.selfTimerDurationRange.lowerBound), Self.selfTimerDurationRange.upperBound)
+            defaults.set(clamped, forKey: "selfTimerDuration")
+        }
+    }
+
+    /// Play a per-second tick sound during the self-timer countdown.
+    /// Independent of `playShutterSound`: some users want the shutter
+    /// sound but find the ticking distracting (or vice versa).
+    public var selfTimerPlayTickSound: Bool {
+        get { defaults.object(forKey: "selfTimerPlayTickSound") as? Bool ?? true }
+        set { defaults.set(newValue, forKey: "selfTimerPlayTickSound") }
+    }
+
+    /// Last screen position of the Self-Timer HUD. `nil` means "use the
+    /// default top-center placement of the active screen". Persisted as
+    /// `[Double]` (x, y) — only written when the user drags the HUD.
+    public var selfTimerHUDPosition: CGPoint? {
+        get {
+            guard let arr = defaults.array(forKey: "selfTimerHUDPosition") as? [Double],
+                  arr.count == 2 else { return nil }
+            return CGPoint(x: arr[0], y: arr[1])
+        }
+        set {
+            if let p = newValue {
+                defaults.set([Double(p.x), Double(p.y)], forKey: "selfTimerHUDPosition")
+            } else {
+                defaults.removeObject(forKey: "selfTimerHUDPosition")
+            }
+        }
+    }
+
     // MARK: Capture Presets
 
     public var capturePresetsEnabled: Bool {

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -146,4 +146,89 @@ struct AppSettingsTests {
         let settings = AppSettings(defaults: defaults)
         #expect(settings.translationAutoDismissDelay == 10)
     }
+
+    // MARK: Self-Timer
+
+    @Test("Default self-timer duration is 5 seconds")
+    func defaultSelfTimerDuration() {
+        let suite = "test.selfTimerDuration.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.selfTimerDurationSeconds == 5)
+    }
+
+    @Test("Self-timer duration persists across instances")
+    func selfTimerDurationPersists() {
+        let suite = "test.selfTimerDuration.persists"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let first = AppSettings(defaults: defaults)
+        first.selfTimerDurationSeconds = 7
+        let second = AppSettings(defaults: defaults)
+        #expect(second.selfTimerDurationSeconds == 7)
+    }
+
+    @Test("Self-timer duration clamps below the lower bound")
+    func selfTimerDurationClampsLow() {
+        let suite = "test.selfTimerDuration.clampLow"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        settings.selfTimerDurationSeconds = 0
+        #expect(settings.selfTimerDurationSeconds == AppSettings.selfTimerDurationRange.lowerBound)
+        settings.selfTimerDurationSeconds = -10
+        #expect(settings.selfTimerDurationSeconds == AppSettings.selfTimerDurationRange.lowerBound)
+    }
+
+    @Test("Self-timer duration clamps above the upper bound")
+    func selfTimerDurationClampsHigh() {
+        let suite = "test.selfTimerDuration.clampHigh"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        settings.selfTimerDurationSeconds = 1000
+        #expect(settings.selfTimerDurationSeconds == AppSettings.selfTimerDurationRange.upperBound)
+    }
+
+    @Test("Tick sound defaults to enabled")
+    func defaultSelfTimerTickSound() {
+        let suite = "test.selfTimerPlayTickSound.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.selfTimerPlayTickSound == true)
+    }
+
+    @Test("Tick sound persists when disabled")
+    func selfTimerTickSoundPersists() {
+        let suite = "test.selfTimerPlayTickSound.persists"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let first = AppSettings(defaults: defaults)
+        first.selfTimerPlayTickSound = false
+        let second = AppSettings(defaults: defaults)
+        #expect(second.selfTimerPlayTickSound == false)
+    }
+
+    @Test("Self-timer HUD position defaults to nil")
+    func defaultSelfTimerHUDPosition() {
+        let suite = "test.selfTimerHUDPosition.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.selfTimerHUDPosition == nil)
+    }
+
+    @Test("Self-timer HUD position round-trips and clears")
+    func selfTimerHUDPositionRoundTrip() {
+        let suite = "test.selfTimerHUDPosition.roundtrip"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        settings.selfTimerHUDPosition = CGPoint(x: 412.5, y: 88.0)
+        #expect(settings.selfTimerHUDPosition == CGPoint(x: 412.5, y: 88.0))
+        settings.selfTimerHUDPosition = nil
+        #expect(settings.selfTimerHUDPosition == nil)
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a Self-Timer area capture: pick an area, see a floating countdown HUD + thin border around the selection, screenshot fires when the timer hits zero. Closes [#89](https://github.com/lzhgus/Capso/issues/89).
- New menu bar entry "Self-Timer  Ns" between Scrolling Capture and Record Screen, with the saved duration shown in tertiary color.
- New "Self-Timer" section in Preferences → Screenshots: Stepper for duration (1–60s, default 5) and a toggle for the per-second tick sound (default on, independent of the existing shutter-sound preference). Optional configurable shortcut with no default binding.

## Design notes
- HUD is 108pt rounded-square on `.regularMaterial`, monochrome (no system-accent splash), draining ring driven by `TimelineView(.animation)`, SF Rounded digit with `.contentTransition(.numericText(countsDown: true))`. Drag to reposition (last position persisted), Esc / click to cancel.
- Selection border is a 2pt white stroke with a soft black outer shadow for visibility on any wallpaper.
- Both panels are torn down synchronously, then a 33ms (~2 frames) buffer runs before `ScreenCaptureManager.captureArea` fires — neither lands in the screenshot.
- Tick sound uses the system "Tink" only on beats where the digit changes to a non-zero value (5→4→3→2→1); the existing shutter sound takes over at 0.

## Test plan
- [x] **Unit**: `swift test --package-path Packages/SharedKit` — 6 new self-timer tests pass (default duration, persistence, low-clamp at 1, high-clamp at 60, tick-sound default on, tick-sound persistence).
- [x] **Build**: `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` succeeds with no new warnings.
- [x] **Menu bar**: open the status menu — "Self-Timer  5s" appears between "Scrolling Capture" and "Record Screen", flush-left with the rest of the items.
- [x] **Settings**: Preferences → Screenshots → Self-Timer card — Stepper updates the menu's trailing tag live; Tick Sound toggle on/off persists.
- [x] **Shortcut**: Preferences → Shortcuts → Capture — "Self-Timer" row exists with no default; recording a custom binding works and triggers the flow.
- [x] **Capture flow**: trigger Self-Timer → pick an area → border + HUD appear → countdown ticks audibly (when enabled) → at t=0 both vanish, screenshot fires, and the captured image contains neither the HUD nor the border.
- [x] **Cancel**: Esc and click both dismiss without firing a capture.
- [x] **Drag**: drag the HUD to a new position, run Self-Timer again — HUD reappears at the saved position.
- [x] **Multi-display**: pick an area on a non-primary screen — HUD + border appear on that screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)