### PR TITLE
[codex] Restore annotate and recording area memory

### DIFF
--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -46,13 +46,14 @@ final class CaptureCoordinator {
     enum PostCaptureAction {
         case `default`    // Use Settings (Show Preview / Copy / Auto Save)
         case clipboard    // Copy to clipboard only, no preview
-        case annotate     // Open annotation editor directly
+        case annotate     // Open the full annotation editor directly
+        case inlineAnnotate // Open the All-in-One inline annotation editor
         case ocr          // Open visual OCR directly
         case share        // Upload to cloud, skip Quick Access, save to history
 
         var playsShutterSound: Bool {
             switch self {
-            case .annotate:
+            case .annotate, .inlineAnnotate:
                 false
             case .default, .clipboard, .ocr, .share:
                 true
@@ -61,7 +62,7 @@ final class CaptureCoordinator {
 
         var savesOriginalCaptureToHistory: Bool {
             switch self {
-            case .annotate:
+            case .annotate, .inlineAnnotate:
                 false
             case .default, .clipboard, .ocr, .share:
                 true
@@ -324,7 +325,7 @@ final class CaptureCoordinator {
             guard let self else { return }
             self.dismissAllInOneToolbar()
             self.settings.lastCaptureSelection = .area(rect: rect, screenID: screen.displayID)
-            self.pendingAction = .annotate
+            self.pendingAction = .inlineAnnotate
             self.performAreaCapture(rect: rect, screen: screen)
         }
         toolbar.onCopy = { [weak self] rect in
@@ -782,6 +783,8 @@ final class CaptureCoordinator {
         case .annotate:
             // Open the editor on the same screen the capture came from.
             openAnnotationEditor(result, anchorScreen: screenFor(result: result))
+        case .inlineAnnotate:
+            openInlineAnnotationEditor(result, anchorScreen: screenFor(result: result))
         case .ocr:
             ocrCoordinator?.startVisualOCR(image: result.image, anchorScreen: screenFor(result: result))
         case .share:
@@ -925,15 +928,7 @@ final class CaptureCoordinator {
     }
 
     private func openAnnotationEditor(_ result: CaptureResult, anchorScreen: NSScreen? = nil) {
-        // If the caller didn't pass a screen explicitly, derive one from the
-        // capture's displayID so `captureAreaAndAnnotate()` (direct ⌘⇧…
-        // shortcut path) also opens on the right display.
         let screen = anchorScreen ?? screenFor(result: result)
-        if result.mode == .area,
-           let screen,
-           openInlineAnnotationEditor(result, screen: screen) {
-            return
-        }
 
         inlineAnnotationWindow?.close()
         inlineAnnotationWindow = nil
@@ -953,6 +948,16 @@ final class CaptureCoordinator {
             }
         )
         annotationWindow?.show()
+    }
+
+    private func openInlineAnnotationEditor(_ result: CaptureResult, anchorScreen: NSScreen? = nil) {
+        let screen = anchorScreen ?? screenFor(result: result)
+        guard result.mode == .area,
+              let screen,
+              openInlineAnnotationEditor(result, screen: screen) else {
+            openAnnotationEditor(result, anchorScreen: screen)
+            return
+        }
     }
 
     private func openInlineAnnotationEditor(_ result: CaptureResult, screen: NSScreen) -> Bool {

--- a/App/Sources/Preferences/Tabs/RecordingSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/RecordingSettingsView.swift
@@ -46,21 +46,20 @@ struct RecordingSettingsView: View {
                             .toggleStyle(.switch)
                             .controlSize(.small)
                     }
-                    // TODO: Re-enable the two rows below once their behaviors
-                    // are implemented. They are stored in AppSettings but
-                    // never consumed by RecordingCoordinator:
+                    // TODO: Re-enable the row below once its behavior is
+                    // implemented. It is stored in AppSettings but never
+                    // consumed by RecordingCoordinator:
                     //   - dimScreenWhileRecording: dim non-captured displays
-                    //   - rememberLastRecordingArea: persist last recording rect
                     // SettingRow(label: "Dim Screen While Recording", showDivider: true) {
                     //     Toggle("", isOn: $viewModel.dimScreenWhileRecording)
                     //         .toggleStyle(.switch)
                     //         .controlSize(.small)
                     // }
-                    // SettingRow(label: "Remember Last Recording Area", showDivider: true) {
-                    //     Toggle("", isOn: $viewModel.rememberLastRecordingArea)
-                    //         .toggleStyle(.switch)
-                    //         .controlSize(.small)
-                    // }
+                    SettingRow(label: "Remember Last Recording Area", showDivider: true) {
+                        Toggle("", isOn: $viewModel.rememberLastRecordingArea)
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                    }
                 }
             }
 

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -70,7 +70,11 @@ final class RecordingCoordinator {
     /// Start the recording flow: show overlay for area selection.
     func startRecordingFlow() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
-            self?.showAreaSelectionOverlay()
+            guard let self else { return }
+            if self.showRememberedRecordingArea() {
+                return
+            }
+            self.showAreaSelectionOverlay()
         }
     }
 
@@ -104,9 +108,37 @@ final class RecordingCoordinator {
         }
     }
 
+    private func showRememberedRecordingArea() -> Bool {
+        guard settings.rememberLastRecordingArea,
+              let selection = settings.lastRecordingArea else {
+            return false
+        }
+
+        guard case let .area(x, y, width, height, screenID) = selection,
+              width > 5,
+              height > 5,
+              let screen = NSScreen.screens.first(where: { $0.displayID == screenID }) else {
+            return false
+        }
+
+        let screenBounds = CGRect(origin: .zero, size: screen.frame.size)
+        let rect = CaptureSelectionGeometry.move(
+            CGRect(x: x, y: y, width: width, height: height),
+            by: .zero,
+            in: screenBounds
+        )
+        dismissOverlay()
+        dismissToolbarUI()
+        handleAreaSelected(rect: rect, screen: screen)
+        return true
+    }
+
     private func handleAreaSelected(rect: CGRect, screen: NSScreen) {
         selectedScreen = screen
         selectedDisplayID = screen.displayID
+        if settings.rememberLastRecordingArea {
+            settings.lastRecordingArea = .area(rect: rect, screenID: screen.displayID)
+        }
 
         // `rect` comes from the overlay view in view-local coordinates:
         // (0,0) at the screen's bottom-left, width/height = screen dimensions.
@@ -208,6 +240,11 @@ final class RecordingCoordinator {
                     self?.cameraPiPWindow = nil
                     self?.cameraManager.stop()
                 }
+            },
+            onChangeArea: { [weak self] in
+                guard let self else { return }
+                self.dismissToolbarUI()
+                self.showAreaSelectionOverlay()
             },
             onCancel: { [weak self] in
                 self?.cancelPendingRecordingFlow()

--- a/App/Sources/Recording/RecordingToolbar.swift
+++ b/App/Sources/Recording/RecordingToolbar.swift
@@ -19,6 +19,7 @@ struct RecordingToolbarView: View {
     let settings: SharedKit.AppSettings
     let onRecordVideo: () -> Void
     let onRecordGIF: () -> Void
+    let onChangeArea: () -> Void
     let onCancel: () -> Void
     let onCameraSettingsChanged: () -> Void
 
@@ -122,6 +123,27 @@ struct RecordingToolbarView: View {
                         Spacer()
 
                         shortcutKey("\u{21A9}")  // Return
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+
+                Divider()
+                    .background(.white.opacity(0.1))
+
+                Button(action: onChangeArea) {
+                    HStack(spacing: 10) {
+                        Image(systemName: "selection.pin.in.out")
+                            .font(.system(size: 14))
+                            .foregroundStyle(.white.opacity(0.8))
+
+                        Text("Change Area")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.white)
+
+                        Spacer()
                     }
                     .padding(.horizontal, 14)
                     .padding(.vertical, 8)

--- a/App/Sources/Recording/RecordingToolbarWindow.swift
+++ b/App/Sources/Recording/RecordingToolbarWindow.swift
@@ -15,13 +15,14 @@ final class RecordingToolbarWindow: NSPanel {
         settings: AppSettings,
         onRecord: @escaping (RecordingFormatChoice, Bool, String?, Bool, Bool) -> Void,
         onCameraToggled: @escaping (Bool, String?) -> Void,
+        onChangeArea: @escaping () -> Void,
         onCancel: @escaping () -> Void,
         onCameraSettingsChanged: @escaping () -> Void
     ) {
         self.settings = settings
         self.onCancelAction = onCancel
         let width: CGFloat = 240
-        let height: CGFloat = 180
+        let height: CGFloat = 220
 
         let screenFrame = screen.visibleFrame
         var x = selectionRect.midX - width / 2
@@ -50,6 +51,7 @@ final class RecordingToolbarWindow: NSPanel {
             settings: settings,
             onRecord: onRecord,
             onCameraToggled: onCameraToggled,
+            onChangeArea: onChangeArea,
             onCancel: onCancel,
             onCameraSettingsChanged: onCameraSettingsChanged
         )
@@ -80,6 +82,7 @@ private struct RecordingToolbarWrapper: View {
     let settings: AppSettings
     let onRecord: (RecordingFormatChoice, Bool, String?, Bool, Bool) -> Void
     let onCameraToggled: (Bool, String?) -> Void
+    let onChangeArea: () -> Void
     let onCancel: () -> Void
     let onCameraSettingsChanged: () -> Void
 
@@ -103,6 +106,7 @@ private struct RecordingToolbarWrapper: View {
             onRecordGIF: {
                 onRecord(.gif, cameraEnabled, selectedCameraID, micEnabled, systemAudioEnabled)
             },
+            onChangeArea: onChangeArea,
             onCancel: onCancel,
             onCameraSettingsChanged: onCameraSettingsChanged
         )

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -198,6 +198,23 @@ public final class AppSettings: @unchecked Sendable {
         set { defaults.set(newValue, forKey: "rememberLastRecordingArea") }
     }
 
+    public var lastRecordingArea: StoredCaptureSelection? {
+        get {
+            guard let data = defaults.data(forKey: "lastRecordingArea"),
+                  let value = try? JSONDecoder().decode(StoredCaptureSelection.self, from: data) else {
+                return nil
+            }
+            return value
+        }
+        set {
+            if let newValue, let data = try? JSONEncoder().encode(newValue) {
+                defaults.set(data, forKey: "lastRecordingArea")
+            } else {
+                defaults.removeObject(forKey: "lastRecordingArea")
+            }
+        }
+    }
+
     /// When `true`, the recording editor opens after every recording stops.
     /// When `false` (default), the quick-preview flow is used instead.
     /// Default is `false` to preserve existing behaviour for existing users.

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -211,6 +211,21 @@ struct AppSettingsTests {
         #expect(second.selfTimerPlayTickSound == false)
     }
 
+    @Test("Last recording area persists across instances")
+    func lastRecordingAreaPersists() {
+        let suite = "test.lastRecordingArea.persists"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let first = AppSettings(defaults: defaults)
+        let selection = StoredCaptureSelection.area(
+            rect: CGRect(x: 24, y: 48, width: 640, height: 360),
+            screenID: 42
+        )
+        first.lastRecordingArea = selection
+        let second = AppSettings(defaults: defaults)
+        #expect(second.lastRecordingArea == selection)
+    }
+
     @Test("Self-timer HUD position defaults to nil")
     func defaultSelfTimerHUDPosition() {
         let suite = "test.selfTimerHUDPosition.default"


### PR DESCRIPTION
## Summary

- Restore Quick Access and direct screenshot Annotate to the full annotation editor with beautification controls
- Keep the All-in-One inline editor on its own post-capture action
- Complete the recording "Remember Last Recording Area" setting with persisted area state
- Add a Change Area action so remembered recording regions can be replaced across screens or sizes

## Root Cause

The All-in-One inline annotation path reused the existing area annotate action, so every area annotation route started preferring the inline editor. Separately, recording already had a dormant remember-last-area setting, but RecordingCoordinator did not persist or consume a recording-specific area. The first implementation restored the area too aggressively by skipping selection without a way to change it, so this PR adds an explicit Change Area path.

## Validation

- `swift test --package-path Packages/SharedKit`
- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug -destination 'platform=macOS' build`
- `git diff --check`

## Notes

Manual multi-display recording UI still deserves a real pass before marking this ready, because the code safely falls back but physical-display behavior is easiest to validate interactively.

Closes #99
Related #100