### PR TITLE
[codex] Pin edited screenshots from annotation

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationEditorView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorView.swift
@@ -8,6 +8,7 @@ struct AnnotationEditorView: View {
     let document: AnnotationDocument
     let onSave: (CGImage) -> Void
     let onCopy: (CGImage) -> Void
+    let onPin: (CGImage) -> Void
     let onCancel: () -> Void
 
     /// The working image shown in the canvas. Starts equal to
@@ -20,12 +21,14 @@ struct AnnotationEditorView: View {
         document: AnnotationDocument,
         onSave: @escaping (CGImage) -> Void,
         onCopy: @escaping (CGImage) -> Void,
+        onPin: @escaping (CGImage) -> Void,
         onCancel: @escaping () -> Void
     ) {
         self.initialSourceImage = sourceImage
         self.document = document
         self.onSave = onSave
         self.onCopy = onCopy
+        self.onPin = onPin
         self.onCancel = onCancel
         self._sourceImage = State(initialValue: sourceImage)
     }
@@ -206,6 +209,7 @@ struct AnnotationEditorView: View {
                     onRedo: { document.redo(); refreshTrigger += 1 },
                     onSave: { save() },
                     onCopy: { copy() },
+                    onPin: { pin() },
                     onCancel: onCancel,
                     onCrop: { isCropMode = true }
                 )
@@ -419,6 +423,15 @@ struct AnnotationEditorView: View {
         DispatchQueue.main.async {
             if let rendered = renderedOutputImage() {
                 onCopy(rendered)
+            }
+        }
+    }
+
+    private func pin() {
+        commitEditingTrigger += 1
+        DispatchQueue.main.async {
+            if let rendered = renderedOutputImage() {
+                onPin(rendered)
             }
         }
     }

--- a/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
@@ -12,6 +12,7 @@ final class AnnotationEditorWindow: NSPanel {
         anchorScreen: NSScreen? = nil,
         onSave: @escaping (CGImage) -> Void,
         onCopy: @escaping (CGImage) -> Void,
+        onPin: @escaping (CGImage, CGRect?) -> Void,
         onClose: @escaping () -> Void
     ) {
         let imgW = CGFloat(image.width)
@@ -72,6 +73,10 @@ final class AnnotationEditorWindow: NSPanel {
             },
             onCopy: { [weak self] rendered in
                 onCopy(rendered)
+                self?.close()
+            },
+            onPin: { [weak self] rendered in
+                onPin(rendered, self?.frame)
                 self?.close()
             },
             onCancel: { [weak self] in

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -19,6 +19,7 @@ struct AnnotationToolbar: View {
     let onRedo: () -> Void
     let onSave: () -> Void
     let onCopy: () -> Void
+    let onPin: () -> Void
     let onCancel: () -> Void
     let onCrop: () -> Void
 
@@ -209,6 +210,14 @@ struct AnnotationToolbar: View {
             .buttonStyle(.bordered)
             .controlSize(.small)
             .keyboardShortcut("c", modifiers: .command)
+
+            Button(action: onPin) {
+                Label("Pin", systemImage: "pin")
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .keyboardShortcut("p", modifiers: .command)
 
             Button(action: onSave) {
                 Label("Save", systemImage: "square.and.arrow.down")

--- a/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
@@ -14,6 +14,7 @@ final class InlineAnnotationEditorWindow: NSPanel {
         screenLocalRect: CGRect,
         onSave: @escaping (CGImage) -> Void,
         onCopy: @escaping (CGImage) -> Void,
+        onPin: @escaping (CGImage, CGRect?) -> Void,
         onClose: @escaping () -> Void
     ) {
         self.document = AnnotationDocument(
@@ -39,6 +40,13 @@ final class InlineAnnotationEditorWindow: NSPanel {
         self.isRestorable = false
         self.setFrame(screen.frame, display: false)
 
+        let pinAnchor = CGRect(
+            x: screen.frame.minX + screenLocalRect.minX,
+            y: screen.frame.minY + screenLocalRect.minY,
+            width: screenLocalRect.width,
+            height: screenLocalRect.height
+        )
+
         let view = InlineAnnotationEditorView(
             sourceImage: image,
             document: document,
@@ -50,6 +58,10 @@ final class InlineAnnotationEditorWindow: NSPanel {
             },
             onCopy: { [weak self] rendered in
                 onCopy(rendered)
+                self?.close()
+            },
+            onPin: { [weak self] rendered in
+                onPin(rendered, pinAnchor)
                 self?.close()
             },
             onCancel: { [weak self] in
@@ -77,6 +89,7 @@ private struct InlineAnnotationEditorView: View {
     let screenLocalRect: CGRect
     let onSave: (CGImage) -> Void
     let onCopy: (CGImage) -> Void
+    let onPin: (CGImage) -> Void
     let onCancel: () -> Void
 
     @AppStorage("annotationLastTool") private var currentTool: AnnotationTool = .arrow
@@ -207,6 +220,7 @@ private struct InlineAnnotationEditorView: View {
                 },
                 onCancel: onCancel,
                 onCopy: copy,
+                onPin: pin,
                 onSave: save
             )
             .frame(width: toolbarRect.width, height: toolbarRect.height)
@@ -298,6 +312,15 @@ private struct InlineAnnotationEditorView: View {
             }
         }
     }
+
+    private func pin() {
+        commitEditingTrigger += 1
+        DispatchQueue.main.async {
+            if let rendered = renderedOutputImage() {
+                onPin(rendered)
+            }
+        }
+    }
 }
 
 private struct DimmingCutout: Shape {
@@ -324,6 +347,7 @@ private struct InlineAnnotationToolbar: View {
     let onRedo: () -> Void
     let onCancel: () -> Void
     let onCopy: () -> Void
+    let onPin: () -> Void
     let onSave: () -> Void
 
     private var isFontSizeMode: Bool {
@@ -407,6 +431,8 @@ private struct InlineAnnotationToolbar: View {
                     .keyboardShortcut(.escape, modifiers: [])
                 iconButton(systemName: "doc.on.doc", help: "Copy", action: onCopy)
                     .keyboardShortcut("c", modifiers: .command)
+                iconButton(systemName: "pin", help: "Pin to Screen", action: onPin)
+                    .keyboardShortcut("p", modifiers: .command)
                 iconButton(systemName: "square.and.arrow.down", help: "Save", isPrimary: true, action: onSave)
                     .keyboardShortcut("s", modifiers: .command)
             }

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -948,6 +948,10 @@ final class CaptureCoordinator {
                 self?.copyRenderedImage(rendered)
                 self?.annotationWindow = nil
             },
+            onPin: { [weak self] (rendered: CGImage, anchor: CGRect?) in
+                self?.pinRenderedImage(rendered, anchor: anchor)
+                self?.annotationWindow = nil
+            },
             onClose: { [weak self] in
                 self?.annotationWindow = nil
             }
@@ -982,6 +986,10 @@ final class CaptureCoordinator {
             },
             onCopy: { [weak self] rendered in
                 self?.copyRenderedImage(rendered)
+                self?.inlineAnnotationWindow = nil
+            },
+            onPin: { [weak self] rendered, anchor in
+                self?.pinRenderedImage(rendered, anchor: anchor)
                 self?.inlineAnnotationWindow = nil
             },
             onClose: { [weak self] in
@@ -1021,14 +1029,18 @@ final class CaptureCoordinator {
     }
 
     private func pinToScreen(_ result: CaptureResult, anchor: CGRect) {
+        pinRenderedImage(result.image, anchor: anchor)
+    }
+
+    private func pinRenderedImage(_ image: CGImage, anchor: CGRect?) {
         let controller = PinnedScreenshotController(
-            image: result.image,
+            image: image,
             anchorRect: anchor,
             onCopy: { [weak self] in
-                self?.copyImageToClipboard(result.image)
+                self?.copyImageToClipboard(image)
             },
             onSave: { [weak self] in
-                self?.saveImageToFile(result.image)
+                self?.saveImageToFile(image)
             },
             onDidClose: { [weak self] controllerID in
                 self?.pinnedControllers.removeAll { $0.id == controllerID }


### PR DESCRIPTION
## Summary

- Add a Pin action to the full Annotate editor.
- Add the same Pin action to the All-in-One inline annotation editor.
- Reuse the existing pinned screenshot window/controller so pinned edited screenshots keep copy/save/close behavior.

## Why

Issue #98 asks for a Snipaste-like workflow where a screenshot can be edited and then pinned directly to the desktop. This keeps the first improvement focused on the edited screenshot path instead of adding a separate clipboard text pinning surface in the same change.

## Validation

- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug -destination 'platform=macOS' build`

## Notes

- Pinning uses the rendered editor output, so annotations, crop, and full-editor beautify output are included.
- Clipboard text pinning is left as a separate follow-up.
