### PR TITLE
[codex] Harden OCR capture edit flow and polish Quick Access

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -32,15 +32,15 @@ struct AnnotationToolbar: View {
     var body: some View {
         HStack(spacing: 12) {
             toolGroup
-            Divider().frame(height: 24)
+            toolbarDivider
             colorGroup
-            Divider().frame(height: 24)
+            toolbarDivider
             strokeGroup
-            Divider().frame(height: 24)
+            toolbarDivider
             cropGroup
-            Divider().frame(height: 24)
+            toolbarDivider
             beautifyGroup
-            Divider().frame(height: 24)
+            toolbarDivider
             undoGroup
             Spacer()
             actionGroup
@@ -66,10 +66,12 @@ struct AnnotationToolbar: View {
     private func toolButton(_ tool: AnnotationTool, icon: String, label: LocalizedStringKey) -> some View {
         Button(action: { currentTool = tool }) {
             Image(systemName: icon)
-                .font(.system(size: 14))
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(toolbarIconForeground(isActive: currentTool == tool))
                 .frame(width: 30, height: 26)
-                .background(currentTool == tool ? Color.accentColor.opacity(0.2) : Color.clear)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .background(toolbarButtonBackground(isActive: currentTool == tool))
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .overlay(toolbarButtonStroke)
         }
         .buttonStyle(.plain)
         .help(label)
@@ -87,9 +89,11 @@ struct AnnotationToolbar: View {
         Button(action: { currentTool = .text }) {
             Text(verbatim: "Aa")
                 .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(toolbarIconForeground(isActive: currentTool == .text))
                 .frame(width: 30, height: 26)
-                .background(currentTool == .text ? Color.accentColor.opacity(0.2) : Color.clear)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .background(toolbarButtonBackground(isActive: currentTool == .text))
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .overlay(toolbarButtonStroke)
         }
         .buttonStyle(.plain)
         .help("Text")
@@ -101,9 +105,14 @@ struct AnnotationToolbar: View {
                 Button(action: { currentColor = color }) {
                     Circle()
                         .fill(Color(cgColor: color.cgColor))
-                        .frame(width: 18, height: 18)
-                        .overlay(Circle().stroke(currentColor == color ? Color.white : Color.clear, lineWidth: 2))
-                        .overlay(Circle().stroke(Color.black.opacity(0.2), lineWidth: 0.5))
+                        .frame(width: 19, height: 19)
+                        .overlay(Circle().stroke(currentColor == color ? Color.accentColor : Color.clear, lineWidth: 2))
+                        .overlay(Circle().stroke(Color.black.opacity(0.24), lineWidth: 0.5))
+                        .padding(2)
+                        .background(
+                            Circle()
+                                .fill(currentColor == color ? Color.accentColor.opacity(0.12) : Color.clear)
+                        )
                 }
                 .buttonStyle(.plain)
                 .help(Text(color.rawValue.capitalized))
@@ -152,10 +161,12 @@ struct AnnotationToolbar: View {
     private var cropGroup: some View {
         Button(action: onCrop) {
             Image(systemName: "crop")
-                .font(.system(size: 14))
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(toolbarIconForeground(isActive: false))
                 .frame(width: 30, height: 26)
-                .background(Color.clear)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .background(toolbarButtonBackground(isActive: false))
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .overlay(toolbarButtonStroke)
         }
         .buttonStyle(.plain)
         .help("Crop")
@@ -165,10 +176,12 @@ struct AnnotationToolbar: View {
     private var beautifyGroup: some View {
         Button(action: { showBeautifyPanel.toggle() }) {
             Image(systemName: showBeautifyPanel ? "sparkles.rectangle.stack.fill" : "sparkles")
-                .font(.system(size: 14))
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(toolbarIconForeground(isActive: showBeautifyPanel))
                 .frame(width: 30, height: 26)
-                .background(showBeautifyPanel ? Color.accentColor.opacity(0.2) : Color.clear)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .background(toolbarButtonBackground(isActive: showBeautifyPanel))
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .overlay(toolbarButtonStroke)
         }
         .buttonStyle(.plain)
         .help("Beautify")
@@ -195,37 +208,81 @@ struct AnnotationToolbar: View {
 
     private var actionGroup: some View {
         HStack(spacing: 6) {
-            Button(action: onCancel) {
-                Label("Close", systemImage: "xmark")
-                    .font(.system(size: 12, weight: .medium))
-            }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-            .keyboardShortcut(.escape, modifiers: [])
+            actionButton(icon: "xmark", help: "Close", isDestructive: true, action: onCancel)
+                .keyboardShortcut(.escape, modifiers: [])
 
-            Button(action: onCopy) {
-                Label("Copy", systemImage: "doc.on.doc")
-                    .font(.system(size: 12, weight: .medium))
-            }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-            .keyboardShortcut("c", modifiers: .command)
+            actionButton(icon: "doc.on.doc", help: "Copy", action: onCopy)
+                .keyboardShortcut("c", modifiers: .command)
 
-            Button(action: onPin) {
-                Label("Pin", systemImage: "pin")
-                    .font(.system(size: 12, weight: .medium))
-            }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-            .keyboardShortcut("p", modifiers: .command)
+            actionButton(icon: "pin", help: "Pin", action: onPin)
+                .keyboardShortcut("p", modifiers: .command)
 
-            Button(action: onSave) {
-                Label("Save", systemImage: "square.and.arrow.down")
-                    .font(.system(size: 12, weight: .medium))
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.small)
-            .keyboardShortcut("s", modifiers: .command)
+            actionButton(icon: "square.and.arrow.down", help: "Save", isPrimary: true, action: onSave)
+                .keyboardShortcut("s", modifiers: .command)
         }
+    }
+
+    private func actionButton(
+        icon: String,
+        help: LocalizedStringKey,
+        isPrimary: Bool = false,
+        isDestructive: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(actionIconForeground(isPrimary: isPrimary, isDestructive: isDestructive))
+                .frame(width: 34, height: 26)
+                .background(actionButtonBackground(isPrimary: isPrimary, isDestructive: isDestructive))
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .overlay(actionButtonStroke(isPrimary: isPrimary))
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+
+    private var toolbarDivider: some View {
+        Rectangle()
+            .fill(Color.primary.opacity(0.12))
+            .frame(width: 1, height: 24)
+    }
+
+    private func toolbarButtonBackground(isActive: Bool) -> Color {
+        isActive ? Color.accentColor.opacity(0.18) : Color.primary.opacity(0.04)
+    }
+
+    private func toolbarIconForeground(isActive: Bool) -> Color {
+        isActive ? Color.accentColor : Color.primary.opacity(0.82)
+    }
+
+    private var toolbarButtonStroke: some View {
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .stroke(Color.primary.opacity(0.06), lineWidth: 0.5)
+    }
+
+    private func actionButtonBackground(isPrimary: Bool, isDestructive: Bool) -> Color {
+        if isPrimary {
+            return Color.accentColor
+        }
+        if isDestructive {
+            return Color.primary.opacity(0.045)
+        }
+        return Color.primary.opacity(0.055)
+    }
+
+    private func actionIconForeground(isPrimary: Bool, isDestructive: Bool) -> Color {
+        if isPrimary {
+            return .white
+        }
+        if isDestructive {
+            return Color.primary.opacity(0.72)
+        }
+        return Color.primary.opacity(0.84)
+    }
+
+    private func actionButtonStroke(isPrimary: Bool) -> some View {
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .stroke(isPrimary ? Color.white.opacity(0.18) : Color.primary.opacity(0.08), lineWidth: 0.5)
     }
 }

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -7,6 +7,7 @@ import SwiftUI
 @MainActor
 final class CaptureAllInOneToolbarWindow {
     private static let minimumSelectionSize = CGSize(width: 24, height: 24)
+    private static let toolbarCornerRadius: CGFloat = 14
 
     private var selectionOverlayWindow: NSPanel?
     private weak var selectionOverlayView: AllInOneSelectionOverlayView?
@@ -138,7 +139,8 @@ final class CaptureAllInOneToolbarWindow {
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
 
         panel.acceptsMouseMovedEvents = true
-        panel.contentView = AllInOneToolbarHostingView(rootView: CaptureAllInOneToolbarView(
+
+        let hostingView = AllInOneToolbarHostingView(rootView: CaptureAllInOneToolbarView(
             state: toolbarState,
             onArea: { [weak self] in
                 guard let self else { return }
@@ -175,6 +177,12 @@ final class CaptureAllInOneToolbarWindow {
             },
             onCancel: { [weak self] in self?.onCancel?() }
         ))
+        hostingView.wantsLayer = true
+        hostingView.layer?.backgroundColor = NSColor.clear.cgColor
+        hostingView.layer?.cornerRadius = Self.toolbarCornerRadius
+        hostingView.layer?.cornerCurve = .continuous
+        hostingView.layer?.masksToBounds = true
+        panel.contentView = hostingView
 
         toolbarWindow = panel
         panel.orderFrontRegardless()
@@ -331,6 +339,14 @@ private final class CaptureAllInOneToolbarState {
 }
 
 private struct CaptureAllInOneToolbarView: View {
+    private enum ModeAction: Hashable {
+        case area, fullscreen, window, scrolling, timer, ocr, recording
+    }
+
+    private enum UtilityAction: Hashable {
+        case annotate, copy, cancel
+    }
+
     let state: CaptureAllInOneToolbarState
     let onArea: () -> Void
     let onFullscreen: () -> Void
@@ -344,16 +360,19 @@ private struct CaptureAllInOneToolbarView: View {
     let onPresetSelected: (CapturePreset) -> Void
     let onCancel: () -> Void
 
+    @State private var hoveredMode: ModeAction?
+    @State private var hoveredUtility: UtilityAction?
+
     var body: some View {
-        HStack(spacing: 14) {
-            HStack(spacing: 4) {
-                modeButton(icon: "viewfinder", title: "Area", action: onArea)
-                modeButton(icon: "display", title: "Fullscreen", action: onFullscreen)
-                modeButton(icon: "macwindow", title: "Window", action: onWindow)
-                modeButton(icon: "arrow.down.to.line.compact", title: "Scrolling", action: onScrolling)
-                modeButton(icon: "timer", title: "Timer", action: onTimer)
-                modeButton(textIcon: "Aa", title: "OCR", action: onOCR)
-                modeButton(icon: "video", title: "Recording", action: onRecording)
+        HStack(spacing: 12) {
+            HStack(spacing: 3) {
+                modeButton(.area, icon: "viewfinder", title: "Area", action: onArea)
+                modeButton(.fullscreen, icon: "display", title: "Fullscreen", action: onFullscreen)
+                modeButton(.window, icon: "macwindow", title: "Window", action: onWindow)
+                modeButton(.scrolling, icon: "arrow.down.to.line.compact", title: "Scrolling", action: onScrolling)
+                modeButton(.timer, icon: "timer", title: "Timer", action: onTimer)
+                modeButton(.ocr, textIcon: "Aa", title: "OCR", action: onOCR)
+                modeButton(.recording, icon: "video", title: "Recording", action: onRecording)
             }
 
             divider
@@ -361,21 +380,22 @@ private struct CaptureAllInOneToolbarView: View {
             HStack(spacing: 8) {
                 dimensionPill
                 presetMenu
-                iconButton("pencil", help: "Annotate in place", action: onAnnotate)
-                iconButton("doc.on.doc", help: "Copy selected area", action: onCopy)
-                iconButton("xmark", help: "Cancel", action: onCancel)
+                iconButton("pencil", kind: .annotate, help: "Annotate in place", action: onAnnotate)
+                iconButton("doc.on.doc", kind: .copy, help: "Copy selected area", action: onCopy)
+                iconButton("xmark", kind: .cancel, help: "Cancel", action: onCancel)
             }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.regularMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: 16)
-                .stroke(Color.white.opacity(0.16), lineWidth: 0.5)
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Color.white.opacity(0.20), lineWidth: 0.5)
         )
-        .shadow(color: .black.opacity(0.36), radius: 20, y: 8)
+        .shadow(color: .black.opacity(0.30), radius: 18, y: 8)
+        .shadow(color: .black.opacity(0.14), radius: 3, y: 1)
         .environment(\.colorScheme, .dark)
         .onHover { hovering in
             if hovering {
@@ -386,7 +406,7 @@ private struct CaptureAllInOneToolbarView: View {
 
     private var divider: some View {
         Rectangle()
-            .fill(Color.white.opacity(0.16))
+            .fill(Color.white.opacity(0.13))
             .frame(width: 1, height: 44)
     }
 
@@ -419,8 +439,11 @@ private struct CaptureAllInOneToolbarView: View {
             }
             .foregroundStyle(.white)
             .frame(width: 74, height: 36)
-            .background(Color.white.opacity(0.10))
-            .clipShape(RoundedRectangle(cornerRadius: 9))
+            .background(Color.white.opacity(0.11), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+            )
         }
         .menuStyle(.borderlessButton)
         .help("Capture preset")
@@ -474,12 +497,16 @@ private struct CaptureAllInOneToolbarView: View {
         .fixedSize(horizontal: true, vertical: false)
         .padding(.horizontal, 12)
         .frame(minWidth: 116, minHeight: 36)
-        .background(Color.white.opacity(0.10))
-        .clipShape(RoundedRectangle(cornerRadius: 9))
+        .background(Color.white.opacity(0.11), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+        )
         .help("Selected area size")
     }
 
     private func modeButton(
+        _ kind: ModeAction,
         icon: String? = nil,
         textIcon: String? = nil,
         title: LocalizedStringKey,
@@ -505,14 +532,21 @@ private struct CaptureAllInOneToolbarView: View {
             }
             .foregroundStyle(.white)
             .frame(width: 78, height: 54)
-            .contentShape(Rectangle())
+            .background(modeBackground(kind), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
         .buttonStyle(.plain)
+        .onHover { hoveredMode = $0 ? kind : nil }
         .help(title)
+    }
+
+    private func modeBackground(_ kind: ModeAction) -> Color {
+        hoveredMode == kind ? Color.white.opacity(0.12) : Color.white.opacity(0.001)
     }
 
     private func iconButton(
         _ systemName: String,
+        kind: UtilityAction,
         help: LocalizedStringKey,
         action: @escaping () -> Void
     ) -> some View {
@@ -521,11 +555,19 @@ private struct CaptureAllInOneToolbarView: View {
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(.white)
                 .frame(width: 36, height: 36)
-                .background(Color.white.opacity(0.10))
-                .clipShape(RoundedRectangle(cornerRadius: 9))
+                .background(utilityBackground(kind), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+                )
         }
         .buttonStyle(.plain)
+        .onHover { hoveredUtility = $0 ? kind : nil }
         .help(help)
+    }
+
+    private func utilityBackground(_ kind: UtilityAction) -> Color {
+        hoveredUtility == kind ? Color.white.opacity(0.18) : Color.white.opacity(0.11)
     }
 }
 

--- a/App/Sources/QuickAccess/QuickAccessView.swift
+++ b/App/Sources/QuickAccess/QuickAccessView.swift
@@ -40,16 +40,19 @@ struct QuickAccessView: View {
     }
 
     private var isRevealed: Bool { isHovering || isFocused }
+    private static let panelCornerRadius: CGFloat = 14
+    private static let thumbnailSize = CGSize(width: 268, height: 116)
 
     private var reduceMotion: Bool {
         NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
     }
 
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 9) {
             thumbnailFrame
 
-            // Caption at rest / Chrome on hover — crossfade in the same slot
+            // Caption at rest / chrome on hover share the same slot so the
+            // panel does not resize while the user's pointer moves across it.
             ZStack {
                 captionRow
                     .opacity(isRevealed ? 0 : 1)
@@ -60,13 +63,17 @@ struct QuickAccessView: View {
         }
         .padding(8)
         .background(hiddenEscapeButton)
-        .background(.ultraThinMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 14))
-        .overlay(
-            RoundedRectangle(cornerRadius: 14)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 0.5)
+        .background(
+            .ultraThinMaterial,
+            in: RoundedRectangle(cornerRadius: Self.panelCornerRadius, style: .continuous)
         )
-        .shadow(color: .black.opacity(0.3), radius: 10, y: 4)
+        .clipShape(RoundedRectangle(cornerRadius: Self.panelCornerRadius, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Self.panelCornerRadius, style: .continuous)
+                .stroke(panelStroke, lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.24), radius: 18, y: 8)
+        .shadow(color: .black.opacity(0.12), radius: 3, y: 1)
         .offset(y: isRevealed ? -2 : 0)
         .animation(reduceMotion ? nil : .easeOut(duration: 0.26), value: isRevealed)
         .onHover { isHovering = $0 }
@@ -84,6 +91,10 @@ struct QuickAccessView: View {
         }
     }
 
+    private var panelStroke: Color {
+        isRevealed ? Color.primary.opacity(0.14) : Color.primary.opacity(0.08)
+    }
+
     // MARK: - Thumbnail
 
     private var thumbnailFrame: some View {
@@ -91,23 +102,25 @@ struct QuickAccessView: View {
             Image(nsImage: thumbnail)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
-                .frame(maxWidth: 268, maxHeight: 116)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .frame(width: Self.thumbnailSize.width, height: Self.thumbnailSize.height)
+                .background(Color.black.opacity(0.12))
+                .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
                 .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .stroke(Color.black.opacity(0.25), lineWidth: 0.5)
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .stroke(Color.primary.opacity(0.12), lineWidth: 0.5)
                 )
 
             if isRevealed {
                 Button(action: onClose) {
                     Image(systemName: "xmark")
-                        .font(.system(size: 9, weight: .bold))
-                        .foregroundStyle(.secondary)
-                        .frame(width: 18, height: 18)
-                        .background(Circle().fill(.regularMaterial))
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.primary.opacity(0.78))
+                        .frame(width: 24, height: 24)
+                        .background(.regularMaterial, in: Circle())
+                        .overlay(Circle().stroke(Color.primary.opacity(0.10), lineWidth: 0.5))
                 }
                 .buttonStyle(.plain)
-                .padding(6)
+                .padding(7)
                 .transition(.opacity)
                 .help("Close")
             }
@@ -118,14 +131,18 @@ struct QuickAccessView: View {
 
     private var captionRow: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
-            Text("Capture,")
-                .font(.system(size: 14, design: .serif).italic())
-                .foregroundStyle(.primary)
+            Label {
+                Text("Captured")
+                    .font(.system(size: 13, weight: .semibold))
+            } icon: {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.green)
+            }
             Spacer()
             Text(metaLine)
-                .font(.system(size: 9, design: .monospaced))
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
                 .foregroundStyle(.secondary)
-                .tracking(0.6)
                 .textCase(.uppercase)
         }
         .padding(.horizontal, 6)
@@ -153,7 +170,7 @@ struct QuickAccessView: View {
     private var contextLine: some View {
         HStack(alignment: .center, spacing: 8) {
             Text(contextTitle)
-                .font(.system(size: 13, design: .serif).italic())
+                .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(.primary)
             Spacer()
             contextHintView
@@ -206,7 +223,7 @@ struct QuickAccessView: View {
     private var toolbar: some View {
         HStack(spacing: 2) {
             toolButton(.copy, icon: "doc.on.doc", action: onCopy)
-            toolButton(.save, icon: "square.and.arrow.down", action: onSave)
+            toolButton(.save, icon: "square.and.arrow.down", isPrimary: true, action: onSave)
             if shareCoordinator != nil {
                 toolDivider
                 uploadButton
@@ -221,6 +238,9 @@ struct QuickAccessView: View {
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel(Text("Quick Access actions"))
+        .padding(.horizontal, 4)
+        .padding(.vertical, 3)
+        .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
 
     @ViewBuilder
@@ -287,15 +307,21 @@ struct QuickAccessView: View {
     }
 
     @ViewBuilder
-    private func toolButton(_ kind: HoverAction, icon: String, action: @escaping () -> Void) -> some View {
+    private func toolButton(
+        _ kind: HoverAction,
+        icon: String,
+        isPrimary: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
         let button = Button(action: action) {
             Image(systemName: icon)
-                .font(.system(size: 14, weight: .regular))
+                .font(.system(size: 14, weight: .medium))
                 .symbolRenderingMode(.monochrome)
-                .frame(width: 28, height: 26)
+                .foregroundStyle(toolForeground(kind, isPrimary: isPrimary))
+                .frame(width: 29, height: 28)
                 .background(
-                    RoundedRectangle(cornerRadius: 5)
-                        .fill(hoveredAction == kind ? Color.primary.opacity(0.10) : Color.clear)
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(toolBackground(kind, isPrimary: isPrimary))
                 )
         }
         .buttonStyle(.plain)
@@ -313,6 +339,19 @@ struct QuickAccessView: View {
         } else {
             button
         }
+    }
+
+    private func toolForeground(_ kind: HoverAction, isPrimary: Bool) -> Color {
+        if isPrimary { return .white }
+        if kind == .linkCopied { return .green }
+        return Color.primary.opacity(hoveredAction == kind ? 0.96 : 0.78)
+    }
+
+    private func toolBackground(_ kind: HoverAction, isPrimary: Bool) -> Color {
+        if isPrimary {
+            return Color.accentColor.opacity(hoveredAction == kind ? 0.92 : 0.78)
+        }
+        return hoveredAction == kind ? Color.primary.opacity(0.12) : Color.clear
     }
 
     private func shortcut(for kind: HoverAction) -> (key: KeyEquivalent, modifiers: EventModifiers)? {
@@ -337,7 +376,7 @@ struct QuickAccessView: View {
 
     private var toolDivider: some View {
         Rectangle()
-            .fill(Color.primary.opacity(0.08))
+            .fill(Color.primary.opacity(0.10))
             .frame(width: 1, height: 14)
     }
 
@@ -426,7 +465,6 @@ private struct ShortcutKeyPill: View {
     var body: some View {
         Text(text)
             .font(.system(size: 10, weight: .medium, design: .monospaced))
-            .tracking(1.5)  // breathing room between modifier + key glyphs
             .foregroundStyle(.primary.opacity(0.85))
             .padding(.horizontal, 6)
             .padding(.vertical, 1.5)

--- a/App/Sources/QuickAccess/QuickAccessWindow.swift
+++ b/App/Sources/QuickAccess/QuickAccessWindow.swift
@@ -7,6 +7,8 @@ import ShareKit
 
 @MainActor
 final class QuickAccessWindow: NSPanel {
+    private static let cornerRadius: CGFloat = 14
+
     override var canBecomeKey: Bool { true }
 
     var onCopy: (() -> Void)?
@@ -80,7 +82,16 @@ final class QuickAccessWindow: NSPanel {
             onClose:     { [weak self] in self?.onClose?() }
         )
 
-        self.contentView = NSHostingView(rootView: view)
+        let hostingView = NSHostingView(rootView: view)
+        hostingView.wantsLayer = true
+        hostingView.layer?.backgroundColor = NSColor.clear.cgColor
+        hostingView.layer?.cornerRadius = Self.cornerRadius
+        hostingView.layer?.cornerCurve = .continuous
+        hostingView.layer?.masksToBounds = true
+
+        self.contentView = hostingView
+        self.contentView?.wantsLayer = true
+        self.contentView?.layer?.backgroundColor = NSColor.clear.cgColor
     }
 
     private static func targetLanguageDisplay(settings: AppSettings) -> String? {

--- a/Packages/OCRKit/Sources/OCRKit/TextRecognizer.swift
+++ b/Packages/OCRKit/Sources/OCRKit/TextRecognizer.swift
@@ -25,14 +25,15 @@ public enum TextRecognizer {
         let imageHeight = CGFloat(image.height)
 
         return try await withCheckedThrowingContinuation { continuation in
+            let oneShot = OneShotContinuation(continuation)
             let request = VNRecognizeTextRequest { request, error in
                 if let error {
-                    continuation.resume(throwing: error)
+                    oneShot.resume(throwing: error)
                     return
                 }
 
                 guard let observations = request.results as? [VNRecognizedTextObservation] else {
-                    continuation.resume(returning: [])
+                    oneShot.resume(returning: [])
                     return
                 }
 
@@ -77,7 +78,7 @@ public enum TextRecognizer {
                     return a.boundingBox.minY < b.boundingBox.minY
                 }
 
-                continuation.resume(returning: regions)
+                oneShot.resume(returning: regions)
             }
 
             request.recognitionLevel = level == .fast
@@ -92,7 +93,7 @@ public enum TextRecognizer {
             do {
                 try handler.perform([request])
             } catch {
-                continuation.resume(throwing: error)
+                oneShot.resume(throwing: error)
             }
         }
     }
@@ -111,5 +112,37 @@ public enum TextRecognizer {
         )
         let separator = keepLineBreaks ? "\n" : " "
         return regions.map(\.text).joined(separator: separator)
+    }
+}
+
+final class OneShotContinuation<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Value, Error>?
+
+    init(_ continuation: CheckedContinuation<Value, Error>) {
+        self.continuation = continuation
+    }
+
+    @discardableResult
+    func resume(returning value: Value) -> Bool {
+        guard let continuation = takeContinuation() else { return false }
+        continuation.resume(returning: value)
+        return true
+    }
+
+    @discardableResult
+    func resume(throwing error: Error) -> Bool {
+        guard let continuation = takeContinuation() else { return false }
+        continuation.resume(throwing: error)
+        return true
+    }
+
+    private func takeContinuation() -> CheckedContinuation<Value, Error>? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        let continuation = continuation
+        self.continuation = nil
+        return continuation
     }
 }

--- a/Packages/OCRKit/Tests/OCRKitTests/OCRKitTests.swift
+++ b/Packages/OCRKit/Tests/OCRKitTests/OCRKitTests.swift
@@ -1,8 +1,15 @@
 import XCTest
+@testable import OCRKit
 
 final class OCRKitTests: XCTestCase {
-    func testPlaceholder() {
-        // Placeholder — add real tests here
-        XCTAssertTrue(true)
+    func testOneShotContinuationIgnoresSecondResume() async throws {
+        let value: String = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<String, Error>) in
+            let oneShot = OneShotContinuation(continuation)
+
+            XCTAssertTrue(oneShot.resume(returning: "first"))
+            XCTAssertFalse(oneShot.resume(returning: "second"))
+        }
+
+        XCTAssertEqual(value, "first")
     }
 }


### PR DESCRIPTION
## Summary

- Fixes the OCR async bridge behind the capture -> edit path so Vision completion and `perform()` errors cannot resume the same checked continuation twice.
- Polishes Quick Access panel rendering, including the outer rounded-corner mask that previously showed square edges around the material panel.
- Tightens the capture/edit toolbar chrome, including icon-only editor actions to avoid truncated labels in screenshots.

## Root Cause

GitHub issue #100 points to `SWIFT TASK CONTINUATION MISUSE` in `TextRecognizer.recognize(...)`. The OCR request could resume its continuation from the Vision completion handler while `VNImageRequestHandler.perform` also threw and attempted to resume the same continuation from the catch path.

## Validation

- `swift test --package-path Packages/OCRKit`
- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build`
- Manual debug-app smoke: `Capture Fullscreen -> Quick Access -> Edit`, with window screenshots verifying the Quick Access rounded corners and editor toolbar state.

Fixes #100
