### PR TITLE
Refine All-in-One annotation controls

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -16,6 +16,7 @@ final class AnnotationCanvasNSView: NSView {
     var currentStyle: StrokeStyle = StrokeStyle() {
         didSet { syncEditorStyle() }
     }
+    var redactionMode: RedactionMode = .pixelate
     /// Font size used for newly created TextObjects and propagated live to
     /// the inline editor. Pushed from SwiftUI by AnnotationCanvasView.
     var currentTextFontSize: CGFloat = 48 {
@@ -531,7 +532,13 @@ final class AnnotationCanvasNSView: NSView {
                 let rect = CGRect(x: min(start.x, end.x), y: min(start.y, end.y),
                                   width: abs(end.x - start.x), height: abs(end.y - start.y))
                 if rect.width > 5 / zoomScale && rect.height > 5 / zoomScale {
-                    doc.addObject(PixelateObject(rect: rect, blockSize: currentStyle.lineWidth))
+                    let redaction = PixelateObject(
+                        rect: rect,
+                        blockSize: currentStyle.lineWidth,
+                        mode: redactionMode
+                    )
+                    redaction.style = currentStyle
+                    doc.addObject(redaction)
                 }
             case .counter:
                 let number = nextCounterNumber()

--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -3,9 +3,10 @@ import AppKit
 import CoreGraphics
 import AnnotationKit
 
-/// Which corner handle is being dragged for resize
+/// Which visible handle is being dragged for resize or path adjustment.
 private enum ResizeHandle {
     case topLeft, topRight, bottomLeft, bottomRight
+    case lineStart, lineEnd, lineControl
 }
 
 @MainActor
@@ -52,6 +53,7 @@ final class AnnotationCanvasNSView: NSView {
     private var resizeOriginalBounds: CGRect?
     private var resizeOriginalFreehandPoints: [CGPoint]?
     private var resizeOriginalEndpoints: (start: CGPoint, end: CGPoint)?
+    private var resizeOriginalLineControlPoint: CGPoint?
     /// Original fontSize captured when a TextObject resize drag begins.
     /// Text uses intrinsic sizing (bounds derived from fontSize), so we scale
     /// fontSize from this original value — not the live one, which drifts each tick.
@@ -99,10 +101,24 @@ final class AnnotationCanvasNSView: NSView {
 
     // MARK: - Handle Hit Testing
 
-    private func handleHitTest(point: CGPoint, bounds: CGRect) -> ResizeHandle? {
+    private func handleHitTest(point: CGPoint, object: any AnnotationObject) -> ResizeHandle? {
+        if let line = object as? LineObject {
+            return lineHandleHitTest(point: point, line: line)
+        }
+
         let r = max(10 / max(zoomScale, 0.1), handleRadius + 4)
-        for (handle, corner) in selectionHandleCenters(for: bounds) {
+        for (handle, corner) in selectionHandleCenters(for: object.bounds) {
             if hypot(point.x - corner.x, point.y - corner.y) <= r {
+                return handle
+            }
+        }
+        return nil
+    }
+
+    private func lineHandleHitTest(point: CGPoint, line: LineObject) -> ResizeHandle? {
+        let r = max(10 / max(zoomScale, 0.1), handleRadius + 4)
+        for (handle, center) in lineHandleCenters(for: line) {
+            if hypot(point.x - center.x, point.y - center.y) <= r {
                 return handle
             }
         }
@@ -122,7 +138,7 @@ final class AnnotationCanvasNSView: NSView {
         guard let doc = document else { return }
 
         if let selected = doc.selectedObject {
-            if let handle = handleHitTest(point: point, bounds: selected.bounds) {
+            if let handle = handleHitTest(point: point, object: selected) {
                 cursorForHandle(handle).set()
                 return
             }
@@ -150,6 +166,8 @@ final class AnnotationCanvasNSView: NSView {
     private func cursorForHandle(_ handle: ResizeHandle) -> NSCursor {
         let symbolName: String
         switch handle {
+        case .lineStart, .lineEnd, .lineControl:
+            return NSCursor.openHand
         case .topLeft, .bottomRight:
             // ↖↘ diagonal
             symbolName = "arrow.up.left.and.arrow.down.right"
@@ -205,7 +223,11 @@ final class AnnotationCanvasNSView: NSView {
             }
 
             if let selected = doc.selectedObject {
-                drawSelectionHandles(ctx: ctx, bounds: selected.bounds)
+                if let line = selected as? LineObject {
+                    drawLineSelectionHandles(ctx: ctx, line: line)
+                } else {
+                    drawSelectionHandles(ctx: ctx, bounds: selected.bounds)
+                }
             }
 
             if let start = dragStart, let current = dragCurrent,
@@ -216,6 +238,69 @@ final class AnnotationCanvasNSView: NSView {
         }
 
         ctx.restoreGState()
+    }
+
+    private func drawLineSelectionHandles(ctx: CGContext, line: LineObject) {
+        ctx.saveGState()
+
+        let scale = max(zoomScale, 0.1)
+        let endpointSize: CGFloat = 8 / scale
+        let controlSize: CGFloat = 7 / scale
+        let lw: CGFloat = 1.5 / scale
+        let accent = NSColor.controlAccentColor.withAlphaComponent(0.9).cgColor
+        let controlFill = NSColor.white.withAlphaComponent(0.92).cgColor
+
+        if let controlPoint = line.controlPoint {
+            ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.36).cgColor)
+            ctx.setLineWidth(1 / scale)
+            ctx.setLineDash(phase: 0, lengths: [3 / scale, 4 / scale])
+            ctx.move(to: line.start)
+            ctx.addLine(to: controlPoint)
+            ctx.addLine(to: line.end)
+            ctx.strokePath()
+            ctx.setLineDash(phase: 0, lengths: [])
+        }
+
+        for (_, center) in [(ResizeHandle.lineStart, line.start), (.lineEnd, line.end)] {
+            let rect = CGRect(
+                x: center.x - endpointSize / 2,
+                y: center.y - endpointSize / 2,
+                width: endpointSize,
+                height: endpointSize
+            )
+            ctx.setFillColor(accent)
+            ctx.fillEllipse(in: rect)
+            ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.92).cgColor)
+            ctx.setLineWidth(lw)
+            ctx.strokeEllipse(in: rect.insetBy(dx: lw / 2, dy: lw / 2))
+        }
+
+        let controlPoint = line.controlPoint ?? lineMidpoint(line)
+        let controlRect = CGRect(
+            x: controlPoint.x - controlSize / 2,
+            y: controlPoint.y - controlSize / 2,
+            width: controlSize,
+            height: controlSize
+        )
+        ctx.setFillColor(controlFill)
+        ctx.fillEllipse(in: controlRect)
+        ctx.setStrokeColor(accent)
+        ctx.setLineWidth(lw)
+        ctx.strokeEllipse(in: controlRect.insetBy(dx: lw / 2, dy: lw / 2))
+
+        ctx.restoreGState()
+    }
+
+    private func lineHandleCenters(for line: LineObject) -> [(ResizeHandle, CGPoint)] {
+        [
+            (.lineStart, line.start),
+            (.lineEnd, line.end),
+            (.lineControl, line.controlPoint ?? lineMidpoint(line)),
+        ]
+    }
+
+    private func lineMidpoint(_ line: LineObject) -> CGPoint {
+        CGPoint(x: (line.start.x + line.end.x) / 2, y: (line.start.y + line.end.y) / 2)
     }
 
     private func drawSelectionHandles(ctx: CGContext, bounds: CGRect) {
@@ -312,9 +397,10 @@ final class AnnotationCanvasNSView: NSView {
         resizeOriginalTextFontSize = nil
         resizeOriginalFreehandPoints = nil
         resizeOriginalEndpoints = nil
+        resizeOriginalLineControlPoint = nil
 
         if let selected = doc.selectedObject,
-           let handle = handleHitTest(point: point, bounds: selected.bounds) {
+           let handle = handleHitTest(point: point, object: selected) {
             activeResizeHandle = handle
             resizeOriginalBounds = selected.bounds
             resizeOriginalFreehandPoints = (selected as? FreehandObject)?.points
@@ -322,6 +408,7 @@ final class AnnotationCanvasNSView: NSView {
                 resizeOriginalEndpoints = (arrow.start, arrow.end)
             } else if let line = selected as? LineObject {
                 resizeOriginalEndpoints = (line.start, line.end)
+                resizeOriginalLineControlPoint = line.controlPoint ?? lineMidpoint(line)
             }
             if let text = selected as? TextObject {
                 resizeOriginalTextFontSize = text.fontSize
@@ -411,6 +498,26 @@ final class AnnotationCanvasNSView: NSView {
         let dx = dragCurrent.x - dragStart.x
         let dy = dragCurrent.y - dragStart.y
 
+        guard let obj = document?.objects.first(where: { $0.id == id }) else { return }
+        if let line = obj as? LineObject {
+            guard let endpoints = resizeOriginalEndpoints else { return }
+            switch handle {
+            case .lineStart:
+                line.start = CGPoint(x: endpoints.start.x + dx, y: endpoints.start.y + dy)
+            case .lineEnd:
+                line.end = CGPoint(x: endpoints.end.x + dx, y: endpoints.end.y + dy)
+            case .lineControl:
+                let original = resizeOriginalLineControlPoint ?? CGPoint(
+                    x: (endpoints.start.x + endpoints.end.x) / 2,
+                    y: (endpoints.start.y + endpoints.end.y) / 2
+                )
+                line.controlPoint = CGPoint(x: original.x + dx, y: original.y + dy)
+            default:
+                break
+            }
+            return
+        }
+
         var newRect = originalBounds
         switch handle {
         case .topLeft:
@@ -429,6 +536,8 @@ final class AnnotationCanvasNSView: NSView {
         case .bottomRight:
             newRect.size.width = originalBounds.width + dx
             newRect.size.height = originalBounds.height + dy
+        case .lineStart, .lineEnd, .lineControl:
+            return
         }
 
         // Enforce minimum size
@@ -436,7 +545,6 @@ final class AnnotationCanvasNSView: NSView {
         if newRect.height < 10 { newRect.size.height = 10 }
 
         // Apply to the object
-        guard let obj = document?.objects.first(where: { $0.id == id }) else { return }
         if let rect = obj as? RectangleObject { rect.rect = newRect }
         else if let ellipse = obj as? EllipseObject { ellipse.rect = newRect }
         else if let pixelate = obj as? PixelateObject { pixelate.rect = newRect }
@@ -477,6 +585,8 @@ final class AnnotationCanvasNSView: NSView {
             case .bottomRight:
                 // Anchor: topLeft of original bounds
                 text.origin = originalBounds.origin
+            case .lineStart, .lineEnd, .lineControl:
+                break
             }
         }
         else if let arrow = obj as? ArrowObject {
@@ -522,6 +632,7 @@ final class AnnotationCanvasNSView: NSView {
             resizeOriginalTextFontSize = nil
             resizeOriginalFreehandPoints = nil
             resizeOriginalEndpoints = nil
+            resizeOriginalLineControlPoint = nil
             isDragging = false
             dragStart = nil
             dragCurrent = nil
@@ -537,6 +648,7 @@ final class AnnotationCanvasNSView: NSView {
             resizeOriginalTextFontSize = nil
             resizeOriginalFreehandPoints = nil
             resizeOriginalEndpoints = nil
+            resizeOriginalLineControlPoint = nil
         } else {
             switch currentTool {
             case .arrow:

--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -50,6 +50,8 @@ final class AnnotationCanvasNSView: NSView {
     private var dragObjectID: ObjectID?
     private var activeResizeHandle: ResizeHandle?
     private var resizeOriginalBounds: CGRect?
+    private var resizeOriginalFreehandPoints: [CGPoint]?
+    private var resizeOriginalEndpoints: (start: CGPoint, end: CGPoint)?
     /// Original fontSize captured when a TextObject resize drag begins.
     /// Text uses intrinsic sizing (bounds derived from fontSize), so we scale
     /// fontSize from this original value — not the live one, which drifts each tick.
@@ -116,13 +118,9 @@ final class AnnotationCanvasNSView: NSView {
     }
 
     override func mouseMoved(with event: NSEvent) {
-        // For drawing tools the cursor rect handles the crosshair; nothing to do.
-        guard currentTool == .select else { return }
-
         let point = toImagePoint(convert(event.locationInWindow, from: nil))
         guard let doc = document else { return }
 
-        // Check if over a handle of the selected object
         if let selected = doc.selectedObject {
             if let handle = handleHitTest(point: point, bounds: selected.bounds) {
                 cursorForHandle(handle).set()
@@ -130,11 +128,12 @@ final class AnnotationCanvasNSView: NSView {
             }
         }
 
-        // Check if over any object body
-        if doc.objectAt(point: point) != nil {
+        if currentTool == .select, doc.objectAt(point: point) != nil {
             NSCursor.openHand.set()
-        } else {
+        } else if currentTool == .select {
             NSCursor.arrow.set()
+        } else {
+            NSCursor.crosshair.set()
         }
     }
 
@@ -273,7 +272,7 @@ final class AnnotationCanvasNSView: NSView {
                           width: abs(end.x - start.x), height: abs(end.y - start.y))
 
         switch currentTool {
-        case .arrow: ctx.move(to: start); ctx.addLine(to: end); ctx.strokePath()
+        case .arrow, .line: ctx.move(to: start); ctx.addLine(to: end); ctx.strokePath()
         case .rectangle: ctx.stroke(rect)
         case .ellipse: ctx.strokeEllipse(in: rect)
         case .pixelate: ctx.setFillColor(CGColor(gray: 0.5, alpha: 0.3)); ctx.fill(rect)
@@ -311,6 +310,28 @@ final class AnnotationCanvasNSView: NSView {
         isDragging = true
         activeResizeHandle = nil
         resizeOriginalTextFontSize = nil
+        resizeOriginalFreehandPoints = nil
+        resizeOriginalEndpoints = nil
+
+        if let selected = doc.selectedObject,
+           let handle = handleHitTest(point: point, bounds: selected.bounds) {
+            activeResizeHandle = handle
+            resizeOriginalBounds = selected.bounds
+            resizeOriginalFreehandPoints = (selected as? FreehandObject)?.points
+            if let arrow = selected as? ArrowObject {
+                resizeOriginalEndpoints = (arrow.start, arrow.end)
+            } else if let line = selected as? LineObject {
+                resizeOriginalEndpoints = (line.start, line.end)
+            }
+            if let text = selected as? TextObject {
+                resizeOriginalTextFontSize = text.fontSize
+            }
+            dragObjectID = selected.id
+            doc.beginDrag()
+            cursorForHandle(handle).set()
+            needsDisplay = true
+            return
+        }
 
         if currentTool == .select {
             // Double-click a TextObject → enter inline edit mode.
@@ -319,22 +340,6 @@ final class AnnotationCanvasNSView: NSView {
                 isDragging = false
                 beginTextEditing(at: text.origin, existing: text)
                 return
-            }
-
-            // Check resize handles on selected object FIRST
-            if let selected = doc.selectedObject {
-                if let handle = handleHitTest(point: point, bounds: selected.bounds) {
-                    activeResizeHandle = handle
-                    resizeOriginalBounds = selected.bounds
-                    if let text = selected as? TextObject {
-                        resizeOriginalTextFontSize = text.fontSize
-                    }
-                    dragObjectID = selected.id
-                    doc.beginDrag()
-                    NSCursor.closedHand.set()
-                    needsDisplay = true
-                    return
-                }
             }
 
             // Then check object body for move
@@ -376,13 +381,13 @@ final class AnnotationCanvasNSView: NSView {
         let point = toImagePoint(convert(event.locationInWindow, from: nil))
         dragCurrent = point
 
-        if currentTool == .select {
-            if let handle = activeResizeHandle, let objID = dragObjectID,
-               let origBounds = resizeOriginalBounds, let start = dragStart {
-                // Resize: compute new bounds based on which handle is dragged
-                resizeObject(id: objID, handle: handle, originalBounds: origBounds,
-                             dragStart: start, dragCurrent: point)
-            } else if let objID = dragObjectID, let start = dragStart {
+        if let handle = activeResizeHandle, let objID = dragObjectID,
+           let origBounds = resizeOriginalBounds, let start = dragStart {
+            // Resize handles remain active even while a drawing tool is selected.
+            resizeObject(id: objID, handle: handle, originalBounds: origBounds,
+                         dragStart: start, dragCurrent: point)
+        } else if currentTool == .select {
+            if let objID = dragObjectID, let start = dragStart {
                 // Move
                 let delta = CGSize(width: point.x - start.x, height: point.y - start.y)
                 document?.moveObject(id: objID, by: delta)
@@ -475,21 +480,33 @@ final class AnnotationCanvasNSView: NSView {
             }
         }
         else if let arrow = obj as? ArrowObject {
-            switch handle {
-            case .topLeft, .bottomLeft: arrow.start = CGPoint(x: newRect.minX, y: newRect.midY)
-            case .topRight, .bottomRight: arrow.end = CGPoint(x: newRect.maxX, y: newRect.midY)
-            }
+            guard let endpoints = resizeOriginalEndpoints else { return }
+            arrow.start = scaledPoint(endpoints.start, from: originalBounds, to: newRect)
+            arrow.end = scaledPoint(endpoints.end, from: originalBounds, to: newRect)
+        } else if let line = obj as? LineObject {
+            guard let endpoints = resizeOriginalEndpoints else { return }
+            line.start = scaledPoint(endpoints.start, from: originalBounds, to: newRect)
+            line.end = scaledPoint(endpoints.end, from: originalBounds, to: newRect)
         } else if let freehand = obj as? FreehandObject {
             // Scale all points from original bounds to new bounds
-            guard originalBounds.width > 0, originalBounds.height > 0 else { return }
+            guard originalBounds.width > 0, originalBounds.height > 0,
+                  let originalPoints = resizeOriginalFreehandPoints else { return }
             let scaleX = newRect.width / originalBounds.width
             let scaleY = newRect.height / originalBounds.height
-            for i in 0..<freehand.points.count {
-                freehand.points[i].x = newRect.origin.x + (freehand.points[i].x - originalBounds.origin.x) * scaleX
-                freehand.points[i].y = newRect.origin.y + (freehand.points[i].y - originalBounds.origin.y) * scaleY
+            for i in 0..<min(freehand.points.count, originalPoints.count) {
+                freehand.points[i].x = newRect.origin.x + (originalPoints[i].x - originalBounds.origin.x) * scaleX
+                freehand.points[i].y = newRect.origin.y + (originalPoints[i].y - originalBounds.origin.y) * scaleY
             }
             freehand.invalidateCache()
         }
+    }
+
+    private func scaledPoint(_ point: CGPoint, from originalBounds: CGRect, to newRect: CGRect) -> CGPoint {
+        guard originalBounds.width > 0, originalBounds.height > 0 else { return point }
+        return CGPoint(
+            x: newRect.origin.x + (point.x - originalBounds.origin.x) * (newRect.width / originalBounds.width),
+            y: newRect.origin.y + (point.y - originalBounds.origin.y) * (newRect.height / originalBounds.height)
+        )
     }
 
     override func mouseUp(with event: NSEvent) {
@@ -498,16 +515,37 @@ final class AnnotationCanvasNSView: NSView {
         }
         let end = toImagePoint(convert(event.locationInWindow, from: nil))
 
+        if activeResizeHandle != nil {
+            dragObjectID = nil
+            activeResizeHandle = nil
+            resizeOriginalBounds = nil
+            resizeOriginalTextFontSize = nil
+            resizeOriginalFreehandPoints = nil
+            resizeOriginalEndpoints = nil
+            isDragging = false
+            dragStart = nil
+            dragCurrent = nil
+            needsDisplay = true
+            onDocumentChanged?()
+            return
+        }
+
         if currentTool == .select {
             dragObjectID = nil
             activeResizeHandle = nil
             resizeOriginalBounds = nil
             resizeOriginalTextFontSize = nil
+            resizeOriginalFreehandPoints = nil
+            resizeOriginalEndpoints = nil
         } else {
             switch currentTool {
             case .arrow:
                 if hypot(end.x - start.x, end.y - start.y) > 5 / zoomScale {
                     doc.addObject(ArrowObject(start: start, end: end, style: currentStyle))
+                }
+            case .line:
+                if hypot(end.x - start.x, end.y - start.y) > 5 / zoomScale {
+                    doc.addObject(LineObject(start: start, end: end, style: currentStyle))
                 }
             case .rectangle:
                 let rect = CGRect(x: min(start.x, end.x), y: min(start.y, end.y),

--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -98,14 +98,8 @@ final class AnnotationCanvasNSView: NSView {
     // MARK: - Handle Hit Testing
 
     private func handleHitTest(point: CGPoint, bounds: CGRect) -> ResizeHandle? {
-        let r = handleRadius + 3  // generous hit area
-        let corners: [(ResizeHandle, CGPoint)] = [
-            (.topLeft, CGPoint(x: bounds.minX, y: bounds.minY)),
-            (.topRight, CGPoint(x: bounds.maxX, y: bounds.minY)),
-            (.bottomLeft, CGPoint(x: bounds.minX, y: bounds.maxY)),
-            (.bottomRight, CGPoint(x: bounds.maxX, y: bounds.maxY)),
-        ]
-        for (handle, corner) in corners {
+        let r = max(10 / max(zoomScale, 0.1), handleRadius + 4)
+        for (handle, corner) in selectionHandleCenters(for: bounds) {
             if hypot(point.x - corner.x, point.y - corner.y) <= r {
                 return handle
             }
@@ -226,30 +220,47 @@ final class AnnotationCanvasNSView: NSView {
     }
 
     private func drawSelectionHandles(ctx: CGContext, bounds: CGRect) {
-        let hs: CGFloat = 5
-        let lw: CGFloat = 1.5
-        let selColor = CGColor(red: 0, green: 0.48, blue: 1, alpha: 1)
+        ctx.saveGState()
+
+        let scale = max(zoomScale, 0.1)
+        let hs: CGFloat = 4 / scale
+        let lw: CGFloat = 1 / scale
+        let selColor = NSColor.controlAccentColor.withAlphaComponent(0.78).cgColor
+        let frame = selectionFrame(for: bounds)
 
         // Selection border
         ctx.setStrokeColor(selColor)
         ctx.setLineWidth(lw)
-        ctx.stroke(bounds.insetBy(dx: -2, dy: -2))
+        ctx.setLineDash(phase: 0, lengths: [4 / scale, 3 / scale])
+        ctx.stroke(frame)
+        ctx.setLineDash(phase: 0, lengths: [])
 
         // Corner handles
-        let corners = [
-            CGPoint(x: bounds.minX, y: bounds.minY),
-            CGPoint(x: bounds.maxX, y: bounds.minY),
-            CGPoint(x: bounds.minX, y: bounds.maxY),
-            CGPoint(x: bounds.maxX, y: bounds.maxY),
-        ]
-        for corner in corners {
+        for (_, corner) in selectionHandleCenters(for: bounds) {
             let r = CGRect(x: corner.x - hs, y: corner.y - hs, width: hs * 2, height: hs * 2)
-            ctx.setFillColor(.white)
+            ctx.setFillColor(NSColor.controlAccentColor.withAlphaComponent(0.18).cgColor)
             ctx.fillEllipse(in: r)
             ctx.setStrokeColor(selColor)
             ctx.setLineWidth(lw)
             ctx.strokeEllipse(in: r)
         }
+
+        ctx.restoreGState()
+    }
+
+    private func selectionFrame(for bounds: CGRect) -> CGRect {
+        let outset = 6 / max(zoomScale, 0.1)
+        return bounds.insetBy(dx: -outset, dy: -outset)
+    }
+
+    private func selectionHandleCenters(for bounds: CGRect) -> [(ResizeHandle, CGPoint)] {
+        let frame = selectionFrame(for: bounds)
+        return [
+            (.topLeft, CGPoint(x: frame.minX, y: frame.minY)),
+            (.topRight, CGPoint(x: frame.maxX, y: frame.minY)),
+            (.bottomLeft, CGPoint(x: frame.minX, y: frame.maxY)),
+            (.bottomRight, CGPoint(x: frame.maxX, y: frame.maxY)),
+        ]
     }
 
     private func drawPreview(ctx: CGContext, from start: CGPoint, to end: CGPoint) {

--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -6,8 +6,17 @@ import AnnotationKit
 /// Which visible handle is being dragged for resize or path adjustment.
 private enum ResizeHandle {
     case topLeft, topRight, bottomLeft, bottomRight
-    case lineStart, lineEnd, lineControl
+    case pathStart, pathEnd, pathControl
 }
+
+private protocol PathEditableAnnotation: AnnotationObject {
+    var start: CGPoint { get set }
+    var end: CGPoint { get set }
+    var controlPoint: CGPoint? { get set }
+}
+
+extension LineObject: PathEditableAnnotation {}
+extension ArrowObject: PathEditableAnnotation {}
 
 @MainActor
 final class AnnotationCanvasNSView: NSView {
@@ -102,8 +111,8 @@ final class AnnotationCanvasNSView: NSView {
     // MARK: - Handle Hit Testing
 
     private func handleHitTest(point: CGPoint, object: any AnnotationObject) -> ResizeHandle? {
-        if let line = object as? LineObject {
-            return lineHandleHitTest(point: point, line: line)
+        if let pathObject = object as? any PathEditableAnnotation {
+            return pathHandleHitTest(point: point, object: pathObject)
         }
 
         let r = max(10 / max(zoomScale, 0.1), handleRadius + 4)
@@ -115,9 +124,9 @@ final class AnnotationCanvasNSView: NSView {
         return nil
     }
 
-    private func lineHandleHitTest(point: CGPoint, line: LineObject) -> ResizeHandle? {
+    private func pathHandleHitTest(point: CGPoint, object: any PathEditableAnnotation) -> ResizeHandle? {
         let r = max(10 / max(zoomScale, 0.1), handleRadius + 4)
-        for (handle, center) in lineHandleCenters(for: line) {
+        for (handle, center) in pathHandleCenters(for: object) {
             if hypot(point.x - center.x, point.y - center.y) <= r {
                 return handle
             }
@@ -166,7 +175,7 @@ final class AnnotationCanvasNSView: NSView {
     private func cursorForHandle(_ handle: ResizeHandle) -> NSCursor {
         let symbolName: String
         switch handle {
-        case .lineStart, .lineEnd, .lineControl:
+        case .pathStart, .pathEnd, .pathControl:
             return NSCursor.openHand
         case .topLeft, .bottomRight:
             // ↖↘ diagonal
@@ -223,8 +232,8 @@ final class AnnotationCanvasNSView: NSView {
             }
 
             if let selected = doc.selectedObject {
-                if let line = selected as? LineObject {
-                    drawLineSelectionHandles(ctx: ctx, line: line)
+                if let pathObject = selected as? any PathEditableAnnotation {
+                    drawPathSelectionHandles(ctx: ctx, object: pathObject)
                 } else {
                     drawSelectionHandles(ctx: ctx, bounds: selected.bounds)
                 }
@@ -240,7 +249,7 @@ final class AnnotationCanvasNSView: NSView {
         ctx.restoreGState()
     }
 
-    private func drawLineSelectionHandles(ctx: CGContext, line: LineObject) {
+    private func drawPathSelectionHandles(ctx: CGContext, object: any PathEditableAnnotation) {
         ctx.saveGState()
 
         let scale = max(zoomScale, 0.1)
@@ -250,18 +259,18 @@ final class AnnotationCanvasNSView: NSView {
         let accent = NSColor.controlAccentColor.withAlphaComponent(0.9).cgColor
         let controlFill = NSColor.white.withAlphaComponent(0.92).cgColor
 
-        if let controlPoint = line.controlPoint {
+        if let controlPoint = object.controlPoint {
             ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.36).cgColor)
             ctx.setLineWidth(1 / scale)
             ctx.setLineDash(phase: 0, lengths: [3 / scale, 4 / scale])
-            ctx.move(to: line.start)
+            ctx.move(to: object.start)
             ctx.addLine(to: controlPoint)
-            ctx.addLine(to: line.end)
+            ctx.addLine(to: object.end)
             ctx.strokePath()
             ctx.setLineDash(phase: 0, lengths: [])
         }
 
-        for (_, center) in [(ResizeHandle.lineStart, line.start), (.lineEnd, line.end)] {
+        for (_, center) in [(ResizeHandle.pathStart, object.start), (.pathEnd, object.end)] {
             let rect = CGRect(
                 x: center.x - endpointSize / 2,
                 y: center.y - endpointSize / 2,
@@ -275,7 +284,7 @@ final class AnnotationCanvasNSView: NSView {
             ctx.strokeEllipse(in: rect.insetBy(dx: lw / 2, dy: lw / 2))
         }
 
-        let controlPoint = line.controlPoint ?? lineMidpoint(line)
+        let controlPoint = object.controlPoint ?? pathMidpoint(object)
         let controlRect = CGRect(
             x: controlPoint.x - controlSize / 2,
             y: controlPoint.y - controlSize / 2,
@@ -291,16 +300,16 @@ final class AnnotationCanvasNSView: NSView {
         ctx.restoreGState()
     }
 
-    private func lineHandleCenters(for line: LineObject) -> [(ResizeHandle, CGPoint)] {
+    private func pathHandleCenters(for object: any PathEditableAnnotation) -> [(ResizeHandle, CGPoint)] {
         [
-            (.lineStart, line.start),
-            (.lineEnd, line.end),
-            (.lineControl, line.controlPoint ?? lineMidpoint(line)),
+            (.pathStart, object.start),
+            (.pathEnd, object.end),
+            (.pathControl, object.controlPoint ?? pathMidpoint(object)),
         ]
     }
 
-    private func lineMidpoint(_ line: LineObject) -> CGPoint {
-        CGPoint(x: (line.start.x + line.end.x) / 2, y: (line.start.y + line.end.y) / 2)
+    private func pathMidpoint(_ object: any PathEditableAnnotation) -> CGPoint {
+        CGPoint(x: (object.start.x + object.end.x) / 2, y: (object.start.y + object.end.y) / 2)
     }
 
     private func drawSelectionHandles(ctx: CGContext, bounds: CGRect) {
@@ -406,9 +415,10 @@ final class AnnotationCanvasNSView: NSView {
             resizeOriginalFreehandPoints = (selected as? FreehandObject)?.points
             if let arrow = selected as? ArrowObject {
                 resizeOriginalEndpoints = (arrow.start, arrow.end)
+                resizeOriginalLineControlPoint = arrow.controlPoint ?? pathMidpoint(arrow)
             } else if let line = selected as? LineObject {
                 resizeOriginalEndpoints = (line.start, line.end)
-                resizeOriginalLineControlPoint = line.controlPoint ?? lineMidpoint(line)
+                resizeOriginalLineControlPoint = line.controlPoint ?? pathMidpoint(line)
             }
             if let text = selected as? TextObject {
                 resizeOriginalTextFontSize = text.fontSize
@@ -499,19 +509,19 @@ final class AnnotationCanvasNSView: NSView {
         let dy = dragCurrent.y - dragStart.y
 
         guard let obj = document?.objects.first(where: { $0.id == id }) else { return }
-        if let line = obj as? LineObject {
+        if let pathObject = obj as? any PathEditableAnnotation {
             guard let endpoints = resizeOriginalEndpoints else { return }
             switch handle {
-            case .lineStart:
-                line.start = CGPoint(x: endpoints.start.x + dx, y: endpoints.start.y + dy)
-            case .lineEnd:
-                line.end = CGPoint(x: endpoints.end.x + dx, y: endpoints.end.y + dy)
-            case .lineControl:
+            case .pathStart:
+                pathObject.start = CGPoint(x: endpoints.start.x + dx, y: endpoints.start.y + dy)
+            case .pathEnd:
+                pathObject.end = CGPoint(x: endpoints.end.x + dx, y: endpoints.end.y + dy)
+            case .pathControl:
                 let original = resizeOriginalLineControlPoint ?? CGPoint(
                     x: (endpoints.start.x + endpoints.end.x) / 2,
                     y: (endpoints.start.y + endpoints.end.y) / 2
                 )
-                line.controlPoint = CGPoint(x: original.x + dx, y: original.y + dy)
+                pathObject.controlPoint = CGPoint(x: original.x + dx, y: original.y + dy)
             default:
                 break
             }
@@ -536,7 +546,7 @@ final class AnnotationCanvasNSView: NSView {
         case .bottomRight:
             newRect.size.width = originalBounds.width + dx
             newRect.size.height = originalBounds.height + dy
-        case .lineStart, .lineEnd, .lineControl:
+        case .pathStart, .pathEnd, .pathControl:
             return
         }
 
@@ -585,7 +595,7 @@ final class AnnotationCanvasNSView: NSView {
             case .bottomRight:
                 // Anchor: topLeft of original bounds
                 text.origin = originalBounds.origin
-            case .lineStart, .lineEnd, .lineControl:
+            case .pathStart, .pathEnd, .pathControl:
                 break
             }
         }

--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -86,6 +86,7 @@ final class AnnotationCanvasNSView: NSView {
 
     override var isFlipped: Bool { true }
     override var acceptsFirstResponder: Bool { true }
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
     // Ensure we become first responder when added to a window so that
     // keyDown events (e.g. Delete to remove selected annotation) are delivered.
@@ -395,6 +396,7 @@ final class AnnotationCanvasNSView: NSView {
 
         // Make sure we own keyboard focus so subsequent keyDown events
         // (Delete, etc.) actually reach us. Safe to call even if we already are.
+        window?.makeKey()
         window?.makeFirstResponder(self)
 
         guard let doc = document else { return }

--- a/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
@@ -8,6 +8,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
     let sourceImage: CGImage
     let currentTool: AnnotationTool
     let currentStyle: AnnotationKit.StrokeStyle
+    let redactionMode: RedactionMode
     /// Font size for the text tool / active inline edit. Bound to the
     /// font-size slider in SwiftUI.
     let textFontSize: CGFloat
@@ -40,6 +41,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
         view.sourceImage = sourceImage
         view.currentTool = currentTool
         view.currentStyle = currentStyle
+        view.redactionMode = redactionMode
         view.currentTextFontSize = textFontSize
         view.zoomScale = zoomScale
         view.textRegions = textRegions
@@ -61,6 +63,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
         let toolChanged = nsView.currentTool != currentTool
         nsView.currentTool = currentTool
         nsView.currentStyle = currentStyle
+        nsView.redactionMode = redactionMode
         nsView.currentTextFontSize = textFontSize
         nsView.zoomScale = zoomScale
         nsView.textRegions = textRegions

--- a/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
@@ -31,7 +31,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
     /// several in a row. Text and crop intentionally stay one-shot: text has
     /// its own inline-edit flow and crop is naturally one-per-image.
     private static let stickyTools: Set<AnnotationTool> = [
-        .arrow, .rectangle, .ellipse, .pixelate,
+        .arrow, .line, .rectangle, .ellipse, .pixelate,
         .counter, .freehand, .highlighter
     ]
 

--- a/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
@@ -63,6 +63,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
 
     func updateNSView(_ nsView: AnnotationCanvasNSView, context: Context) {
         let toolChanged = nsView.currentTool != currentTool
+        nsView.sourceImage = sourceImage
         nsView.currentTool = currentTool
         nsView.currentStyle = currentStyle
         nsView.redactionMode = redactionMode

--- a/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
@@ -16,6 +16,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
     let refreshTrigger: Int
     var textRegions: [CGRect] = []
     var commitEditingTrigger: Int = 0
+    var onDocumentChanged: (() -> Void)?
     var onSwitchToSelect: (() -> Void)?
     /// Called when the inline text editor appears. Passes the effective
     /// fontSize (existing object's size when re-editing, current slider
@@ -45,6 +46,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
         view.currentTextFontSize = textFontSize
         view.zoomScale = zoomScale
         view.textRegions = textRegions
+        view.onDocumentChanged = { onDocumentChanged?() }
         view.onObjectCreated = {
             if !Self.stickyTools.contains(currentTool) {
                 onSwitchToSelect?()
@@ -67,6 +69,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
         nsView.currentTextFontSize = textFontSize
         nsView.zoomScale = zoomScale
         nsView.textRegions = textRegions
+        nsView.onDocumentChanged = { onDocumentChanged?() }
         nsView.onObjectCreated = {
             if !Self.stickyTools.contains(currentTool) {
                 onSwitchToSelect?()

--- a/App/Sources/AnnotationEditor/AnnotationColorControls.swift
+++ b/App/Sources/AnnotationEditor/AnnotationColorControls.swift
@@ -10,13 +10,7 @@ struct AnnotationColorControls: View {
     var selectedRingColor: Color = .accentColor
 
     @State private var sampler: NSColorSampler?
-
-    private var customColor: Binding<Color> {
-        Binding(
-            get: { Color(nsColor: currentColor.nsColor) },
-            set: { currentColor = AnnotationColor(nsColor: NSColor($0)) }
-        )
-    }
+    @StateObject private var colorPanel = AnnotationColorPanelController()
 
     var body: some View {
         HStack(spacing: spacing) {
@@ -37,10 +31,22 @@ struct AnnotationColorControls: View {
                 .help(Text(color.displayName))
             }
 
-            ColorPicker("", selection: customColor, supportsOpacity: false)
-                .labelsHidden()
+            Button(action: showCustomColorPanel) {
+                ZStack {
+                    Circle()
+                        .fill(Color(nsColor: currentColor.nsColor))
+                        .overlay(Circle().stroke(Color.black.opacity(0.28), lineWidth: 0.5))
+                        .overlay(Circle().stroke(selectedRingColor.opacity(0.55), lineWidth: 1.5))
+
+                    Image(systemName: "paintpalette.fill")
+                        .font(.system(size: max(10, swatchSize - 8), weight: .semibold))
+                        .foregroundStyle(readableGlyphColor(for: currentColor.nsColor))
+                }
                 .frame(width: swatchSize + 8, height: swatchSize + 8)
-                .help("Custom Color")
+                .contentShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .help("Custom Color")
 
             Button(action: pickScreenColor) {
                 Image(systemName: "eyedropper")
@@ -54,6 +60,12 @@ struct AnnotationColorControls: View {
         }
     }
 
+    private func showCustomColorPanel() {
+        colorPanel.show(initialColor: currentColor.nsColor) { color in
+            currentColor = AnnotationColor(nsColor: color)
+        }
+    }
+
     private func pickScreenColor() {
         let sampler = NSColorSampler()
         self.sampler = sampler
@@ -63,5 +75,32 @@ struct AnnotationColorControls: View {
             }
             self.sampler = nil
         }
+    }
+
+    private func readableGlyphColor(for color: NSColor) -> Color {
+        let rgb = color.usingColorSpace(.deviceRGB) ?? color
+        let luminance = (0.299 * rgb.redComponent) + (0.587 * rgb.greenComponent) + (0.114 * rgb.blueComponent)
+        return luminance > 0.62 ? Color.black.opacity(0.72) : Color.white.opacity(0.92)
+    }
+}
+
+@MainActor
+private final class AnnotationColorPanelController: NSObject, ObservableObject {
+    private var onChange: ((NSColor) -> Void)?
+
+    func show(initialColor: NSColor, onChange: @escaping (NSColor) -> Void) {
+        self.onChange = onChange
+
+        let panel = NSColorPanel.shared
+        panel.showsAlpha = false
+        panel.color = initialColor
+        panel.setTarget(self)
+        panel.setAction(#selector(colorChanged(_:)))
+        panel.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    @objc private func colorChanged(_ sender: NSColorPanel) {
+        onChange?(sender.color)
     }
 }

--- a/App/Sources/AnnotationEditor/AnnotationColorControls.swift
+++ b/App/Sources/AnnotationEditor/AnnotationColorControls.swift
@@ -1,0 +1,67 @@
+import AppKit
+import SwiftUI
+import AnnotationKit
+
+struct AnnotationColorControls: View {
+    @Binding var currentColor: AnnotationColor
+
+    var swatchSize: CGFloat = 19
+    var spacing: CGFloat = 3
+    var selectedRingColor: Color = .accentColor
+
+    @State private var sampler: NSColorSampler?
+
+    private var customColor: Binding<Color> {
+        Binding(
+            get: { Color(nsColor: currentColor.nsColor) },
+            set: { currentColor = AnnotationColor(nsColor: NSColor($0)) }
+        )
+    }
+
+    var body: some View {
+        HStack(spacing: spacing) {
+            ForEach(AnnotationColor.allCases, id: \.self) { color in
+                Button(action: { currentColor = color }) {
+                    Circle()
+                        .fill(Color(cgColor: color.cgColor))
+                        .frame(width: swatchSize, height: swatchSize)
+                        .overlay(Circle().stroke(currentColor == color ? selectedRingColor : Color.clear, lineWidth: 2))
+                        .overlay(Circle().stroke(Color.black.opacity(0.24), lineWidth: 0.5))
+                        .padding(2)
+                        .background(
+                            Circle()
+                                .fill(currentColor == color ? selectedRingColor.opacity(0.12) : Color.clear)
+                        )
+                }
+                .buttonStyle(.plain)
+                .help(Text(color.displayName))
+            }
+
+            ColorPicker("", selection: customColor, supportsOpacity: false)
+                .labelsHidden()
+                .frame(width: swatchSize + 8, height: swatchSize + 8)
+                .help("Custom Color")
+
+            Button(action: pickScreenColor) {
+                Image(systemName: "eyedropper")
+                    .font(.system(size: max(12, swatchSize - 6), weight: .medium))
+                    .foregroundStyle(Color.primary.opacity(0.88))
+                    .frame(width: swatchSize + 8, height: swatchSize + 8)
+                    .background(Circle().fill(Color.primary.opacity(0.08)))
+            }
+            .buttonStyle(.plain)
+            .help("Pick Color From Screen")
+        }
+    }
+
+    private func pickScreenColor() {
+        let sampler = NSColorSampler()
+        self.sampler = sampler
+        sampler.show { color in
+            if let color {
+                currentColor = AnnotationColor(nsColor: color)
+            }
+            self.sampler = nil
+        }
+    }
+}

--- a/App/Sources/AnnotationEditor/AnnotationEditorView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorView.swift
@@ -45,6 +45,7 @@ struct AnnotationEditorView: View {
     @AppStorage("annotationBlockSize") private var savedBlockSize: Double = 12
     @AppStorage("annotationCounterSize") private var savedCounterSize: Double = 20
     @AppStorage("annotationHighlighterWidth") private var savedHighlighterWidth: Double = 20
+    @AppStorage("annotationRedactionMode") private var redactionMode: RedactionMode = .pixelate
     /// Preserved font size for the Text tool. Swapped in/out of `lineWidth`
     /// as the user toggles tools — same pattern as savedBlockSize etc.
     @AppStorage("annotationTextFontSize") private var savedTextFontSize: Double = 48
@@ -201,6 +202,7 @@ struct AnnotationEditorView: View {
                     currentColor: $currentColor,
                     lineWidth: $lineWidth,
                     filled: $filled,
+                    redactionMode: $redactionMode,
                     showBeautifyPanel: $showBeautifyPanel,
                     isEditingText: isEditingText,
                     canUndo: document.canUndo,
@@ -234,6 +236,7 @@ struct AnnotationEditorView: View {
                                 sourceImage: sourceImage,
                                 currentTool: currentTool,
                                 currentStyle: currentStyle,
+                                redactionMode: redactionMode,
                                 textFontSize: effectiveTextFontSize,
                                 zoomScale: zoomScale,
                                 refreshTrigger: refreshTrigger,
@@ -315,6 +318,7 @@ struct AnnotationEditorView: View {
                         persistWidth(newValue, for: currentTool)
                     }
                     .onChange(of: filled) { _, _ in updateSelectedStyle() }
+                    .onChange(of: redactionMode) { _, _ in updateSelectedStyle() }
                     .onChange(of: geo.size) { _, newSize in
                         // Re-fit if window is resized and we're at fit scale
                         if zoomScale == fitScale(for: newSize) { return }
@@ -388,6 +392,8 @@ struct AnnotationEditorView: View {
         if let obj = document.selectedObject {
             if let pixelate = obj as? PixelateObject {
                 pixelate.blockSize = lineWidth
+                pixelate.mode = redactionMode
+                pixelate.style = currentStyle
             } else if let counter = obj as? CounterObject {
                 counter.radius = lineWidth
                 counter.style = AnnotationKit.StrokeStyle(color: currentColor, lineWidth: lineWidth, filled: filled)

--- a/App/Sources/AnnotationEditor/AnnotationEditorView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorView.swift
@@ -46,11 +46,13 @@ struct AnnotationEditorView: View {
     @AppStorage("annotationCounterSize") private var savedCounterSize: Double = 20
     @AppStorage("annotationHighlighterWidth") private var savedHighlighterWidth: Double = 20
     @AppStorage("annotationRedactionMode") private var redactionMode: RedactionMode = .pixelate
+    @AppStorage("annotationStrokePattern") private var savedStrokePattern: StrokePattern = .solid
     /// Preserved font size for the Text tool. Swapped in/out of `lineWidth`
     /// as the user toggles tools — same pattern as savedBlockSize etc.
     @AppStorage("annotationTextFontSize") private var savedTextFontSize: Double = 48
 
     @State private var lineWidth: CGFloat = 3
+    @State private var strokePattern: StrokePattern = .solid
     /// True while an inline text editor is active. Lets the toolbar show
     /// the font-size slider even when the tool is `.select` (happens when
     /// re-editing via double-click).
@@ -112,7 +114,8 @@ struct AnnotationEditorView: View {
             color: currentColor,
             lineWidth: lineWidth,
             opacity: currentTool == .highlighter ? 0.35 : 1.0,
-            filled: filled
+            filled: filled,
+            pattern: strokePattern
         )
     }
 
@@ -201,6 +204,7 @@ struct AnnotationEditorView: View {
                     currentTool: $currentTool,
                     currentColor: $currentColor,
                     lineWidth: $lineWidth,
+                    strokePattern: $strokePattern,
                     filled: $filled,
                     redactionMode: $redactionMode,
                     showBeautifyPanel: $showBeautifyPanel,
@@ -292,6 +296,7 @@ struct AnnotationEditorView: View {
                         // Sync the session-local slider to the persisted width
                         // for whichever tool was last used (issue #75).
                         lineWidth = savedWidth(for: currentTool)
+                        strokePattern = savedStrokePattern
                         // Pre-cache text regions for smart highlighter snapping
                         Task {
                             if let regions = try? await TextRecognizer.recognize(
@@ -316,6 +321,10 @@ struct AnnotationEditorView: View {
                         // Persist slider drags live so closing the editor
                         // without switching tools still saves the change.
                         persistWidth(newValue, for: currentTool)
+                    }
+                    .onChange(of: strokePattern) { _, newValue in
+                        savedStrokePattern = newValue
+                        updateSelectedStyle()
                     }
                     .onChange(of: filled) { _, _ in updateSelectedStyle() }
                     .onChange(of: redactionMode) { _, _ in updateSelectedStyle() }

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -54,6 +54,7 @@ struct AnnotationToolbar: View {
         HStack(spacing: 4) {
             toolButton(.select, icon: "cursorarrow", label: "Select")
             toolButton(.arrow, icon: "arrow.up.right", label: "Arrow")
+            toolButton(.line, icon: "line.diagonal", label: "Line")
             toolButton(.rectangle, icon: "rectangle", label: "Rectangle")
             toolButton(.ellipse, icon: "circle", label: "Ellipse")
             textToolButton

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -7,6 +7,7 @@ struct AnnotationToolbar: View {
     @Binding var currentColor: AnnotationColor
     @Binding var lineWidth: CGFloat
     @Binding var filled: Bool
+    @Binding var redactionMode: RedactionMode
     @Binding var showBeautifyPanel: Bool
     /// True when an inline text edit is active (either via the text tool or
     /// by double-clicking an existing TextObject in select mode). When set,
@@ -128,9 +129,21 @@ struct AnnotationToolbar: View {
                     .frame(width: 80)
                     .help("Font Size: \(Int(lineWidth))")
             } else if currentTool == .pixelate {
-                Slider(value: $lineWidth, in: 4...48, step: 2)
-                    .frame(width: 80)
-                    .help("Block Size: \(Int(lineWidth))")
+                Picker("", selection: $redactionMode) {
+                    ForEach(RedactionMode.allCases, id: \.self) { mode in
+                        Text(mode.label).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 184)
+                .help("Redaction Mode")
+
+                if redactionMode != .solid {
+                    Slider(value: $lineWidth, in: 4...48, step: 2)
+                        .frame(width: 80)
+                        .help("Block Size: \(Int(lineWidth))")
+                }
             } else if currentTool == .counter {
                 Slider(value: $lineWidth, in: 12...40, step: 1)
                     .frame(width: 80)

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -101,24 +101,7 @@ struct AnnotationToolbar: View {
     }
 
     private var colorGroup: some View {
-        HStack(spacing: 3) {
-            ForEach(AnnotationColor.allCases, id: \.self) { color in
-                Button(action: { currentColor = color }) {
-                    Circle()
-                        .fill(Color(cgColor: color.cgColor))
-                        .frame(width: 19, height: 19)
-                        .overlay(Circle().stroke(currentColor == color ? Color.accentColor : Color.clear, lineWidth: 2))
-                        .overlay(Circle().stroke(Color.black.opacity(0.24), lineWidth: 0.5))
-                        .padding(2)
-                        .background(
-                            Circle()
-                                .fill(currentColor == color ? Color.accentColor.opacity(0.12) : Color.clear)
-                        )
-                }
-                .buttonStyle(.plain)
-                .help(Text(color.rawValue.capitalized))
-            }
-        }
+        AnnotationColorControls(currentColor: $currentColor)
     }
 
     private var strokeGroup: some View {

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -6,6 +6,7 @@ struct AnnotationToolbar: View {
     @Binding var currentTool: AnnotationTool
     @Binding var currentColor: AnnotationColor
     @Binding var lineWidth: CGFloat
+    @Binding var strokePattern: StrokePattern
     @Binding var filled: Bool
     @Binding var redactionMode: RedactionMode
     @Binding var showBeautifyPanel: Bool
@@ -141,8 +142,22 @@ struct AnnotationToolbar: View {
                     .frame(width: 80)
                     .help("Line Width: \(Int(lineWidth))")
             }
+            if currentTool == .arrow || currentTool == .line {
+                Picker("", selection: $strokePattern) {
+                    ForEach(StrokePattern.allCases, id: \.self) { pattern in
+                        StrokePatternGlyph(pattern: pattern)
+                            .tag(pattern)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 104)
+                .help("Stroke Pattern")
+            }
             // Fill toggle is meaningless for counter / highlighter / text.
             if currentTool != .counter
+                && currentTool != .arrow
+                && currentTool != .line
                 && currentTool != .highlighter
                 && !isFontSizeMode {
                 Toggle(isOn: $filled) {
@@ -281,5 +296,29 @@ struct AnnotationToolbar: View {
     private func actionButtonStroke(isPrimary: Bool) -> some View {
         RoundedRectangle(cornerRadius: 6, style: .continuous)
             .stroke(isPrimary ? Color.white.opacity(0.18) : Color.primary.opacity(0.08), lineWidth: 0.5)
+    }
+}
+
+struct StrokePatternGlyph: View {
+    let pattern: StrokePattern
+
+    var body: some View {
+        Canvas { context, size in
+            var path = Path()
+            path.move(to: CGPoint(x: 3, y: size.height / 2))
+            path.addLine(to: CGPoint(x: size.width - 3, y: size.height / 2))
+
+            let style: SwiftUI.StrokeStyle
+            switch pattern {
+            case .solid:
+                style = SwiftUI.StrokeStyle(lineWidth: 2, lineCap: .round)
+            case .dashed:
+                style = SwiftUI.StrokeStyle(lineWidth: 2, lineCap: .round, dash: [7, 5])
+            case .dotted:
+                style = SwiftUI.StrokeStyle(lineWidth: 2.4, lineCap: .round, dash: [0, 5])
+            }
+            context.stroke(path, with: .color(.primary), style: style)
+        }
+        .frame(width: 22, height: 14)
     }
 }

--- a/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
@@ -99,6 +99,7 @@ private struct InlineAnnotationEditorView: View {
     @AppStorage("annotationBlockSize") private var savedBlockSize: Double = 12
     @AppStorage("annotationCounterSize") private var savedCounterSize: Double = 20
     @AppStorage("annotationHighlighterWidth") private var savedHighlighterWidth: Double = 20
+    @AppStorage("annotationRedactionMode") private var redactionMode: RedactionMode = .pixelate
     @AppStorage("annotationTextFontSize") private var savedTextFontSize: Double = 48
 
     @State private var lineWidth: CGFloat = 3
@@ -173,6 +174,7 @@ private struct InlineAnnotationEditorView: View {
                 sourceImage: sourceImage,
                 currentTool: currentTool,
                 currentStyle: currentStyle,
+                redactionMode: redactionMode,
                 textFontSize: effectiveTextFontSize,
                 zoomScale: displayScale,
                 refreshTrigger: refreshTrigger,
@@ -207,6 +209,7 @@ private struct InlineAnnotationEditorView: View {
                 currentColor: $currentColor,
                 lineWidth: $lineWidth,
                 filled: $filled,
+                redactionMode: $redactionMode,
                 isEditingText: isEditingText,
                 canUndo: document.canUndo,
                 canRedo: document.canRedo,
@@ -251,6 +254,7 @@ private struct InlineAnnotationEditorView: View {
             persistWidth(newValue, for: currentTool)
         }
         .onChange(of: filled) { _, _ in updateSelectedStyle() }
+        .onChange(of: redactionMode) { _, _ in updateSelectedStyle() }
     }
 
     private func savedWidth(for tool: AnnotationTool) -> CGFloat {
@@ -277,6 +281,8 @@ private struct InlineAnnotationEditorView: View {
         if let obj = document.selectedObject {
             if let pixelate = obj as? PixelateObject {
                 pixelate.blockSize = lineWidth
+                pixelate.mode = redactionMode
+                pixelate.style = currentStyle
             } else if let counter = obj as? CounterObject {
                 counter.radius = lineWidth
                 counter.style = AnnotationKit.StrokeStyle(
@@ -339,6 +345,7 @@ private struct InlineAnnotationToolbar: View {
     @Binding var currentColor: AnnotationColor
     @Binding var lineWidth: CGFloat
     @Binding var filled: Bool
+    @Binding var redactionMode: RedactionMode
 
     let isEditingText: Bool
     let canUndo: Bool
@@ -390,11 +397,25 @@ private struct InlineAnnotationToolbar: View {
             divider
 
             HStack(spacing: 7) {
-                Slider(value: $lineWidth, in: sliderRange, step: sliderStep)
-                    .frame(width: 82)
-                    .help(sliderHelp)
+                if !(currentTool == .pixelate && redactionMode == .solid) {
+                    Slider(value: $lineWidth, in: sliderRange, step: sliderStep)
+                        .frame(width: 82)
+                        .help(sliderHelp)
+                }
 
-                if currentTool != .counter && currentTool != .highlighter && !isFontSizeMode {
+                if currentTool == .pixelate {
+                    Picker("", selection: $redactionMode) {
+                        ForEach(RedactionMode.allCases, id: \.self) { mode in
+                            Text(mode.label).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .frame(width: 168)
+                    .help("Redaction Mode")
+                }
+
+                if currentTool != .counter && currentTool != .highlighter && currentTool != .pixelate && !isFontSizeMode {
                     iconButton(
                         systemName: filled ? "square.fill" : "square",
                         help: "Fill Shape",

--- a/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
@@ -366,6 +366,7 @@ private struct InlineAnnotationToolbar: View {
             HStack(spacing: 4) {
                 toolButton(.select)
                 toolButton(.arrow)
+                toolButton(.line)
                 toolButton(.rectangle)
                 toolButton(.ellipse)
                 toolButton(.text)
@@ -546,6 +547,7 @@ private struct InlineAnnotationToolbar: View {
         switch tool {
         case .select: return "cursorarrow"
         case .arrow: return "arrow.up.right"
+        case .line: return "line.diagonal"
         case .rectangle: return "rectangle"
         case .ellipse: return "circle"
         case .text: return "textformat"
@@ -560,6 +562,7 @@ private struct InlineAnnotationToolbar: View {
         switch tool {
         case .select: return "Select"
         case .arrow: return "Arrow"
+        case .line: return "Line"
         case .rectangle: return "Rectangle"
         case .ellipse: return "Ellipse"
         case .text: return "Text"

--- a/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
@@ -377,22 +377,11 @@ private struct InlineAnnotationToolbar: View {
 
             divider
 
-            HStack(spacing: 3) {
-                ForEach(AnnotationColor.allCases, id: \.self) { color in
-                    Button(action: { currentColor = color }) {
-                        Circle()
-                            .fill(Color(cgColor: color.cgColor))
-                            .frame(width: 17, height: 17)
-                            .overlay(
-                                Circle()
-                                    .stroke(currentColor == color ? Color.white : Color.clear, lineWidth: 2)
-                            )
-                            .overlay(Circle().stroke(Color.black.opacity(0.35), lineWidth: 0.5))
-                    }
-                    .buttonStyle(.plain)
-                    .help(localizedColorName(for: color))
-                }
-            }
+            AnnotationColorControls(
+                currentColor: $currentColor,
+                swatchSize: 17,
+                selectedRingColor: .white
+            )
 
             divider
 
@@ -581,16 +570,4 @@ private struct InlineAnnotationToolbar: View {
         }
     }
 
-    private func localizedColorName(for color: AnnotationColor) -> String {
-        switch color {
-        case .red: return String(localized: "Red")
-        case .orange: return String(localized: "Orange")
-        case .yellow: return String(localized: "Yellow")
-        case .green: return String(localized: "Green")
-        case .blue: return String(localized: "Blue")
-        case .purple: return String(localized: "Purple")
-        case .white: return String(localized: "White")
-        case .black: return String(localized: "Black")
-        }
-    }
 }

--- a/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
@@ -101,8 +101,10 @@ private struct InlineAnnotationEditorView: View {
     @AppStorage("annotationHighlighterWidth") private var savedHighlighterWidth: Double = 20
     @AppStorage("annotationRedactionMode") private var redactionMode: RedactionMode = .pixelate
     @AppStorage("annotationTextFontSize") private var savedTextFontSize: Double = 48
+    @AppStorage("annotationStrokePattern") private var savedStrokePattern: StrokePattern = .solid
 
     @State private var lineWidth: CGFloat = 3
+    @State private var strokePattern: StrokePattern = .solid
     @State private var isEditingText = false
     @State private var refreshTrigger = 0
     @State private var commitEditingTrigger = 0
@@ -124,7 +126,8 @@ private struct InlineAnnotationEditorView: View {
             color: currentColor,
             lineWidth: lineWidth,
             opacity: currentTool == .highlighter ? 0.35 : 1.0,
-            filled: filled
+            filled: filled,
+            pattern: strokePattern
         )
     }
 
@@ -208,6 +211,7 @@ private struct InlineAnnotationEditorView: View {
                 currentTool: $currentTool,
                 currentColor: $currentColor,
                 lineWidth: $lineWidth,
+                strokePattern: $strokePattern,
                 filled: $filled,
                 redactionMode: $redactionMode,
                 isEditingText: isEditingText,
@@ -233,6 +237,7 @@ private struct InlineAnnotationEditorView: View {
         .background(Color.clear)
         .onAppear {
             lineWidth = savedWidth(for: currentTool)
+            strokePattern = savedStrokePattern
             Task {
                 if let regions = try? await TextRecognizer.recognize(
                     image: sourceImage,
@@ -252,6 +257,10 @@ private struct InlineAnnotationEditorView: View {
         .onChange(of: lineWidth) { _, newValue in
             updateSelectedStyle()
             persistWidth(newValue, for: currentTool)
+        }
+        .onChange(of: strokePattern) { _, newValue in
+            savedStrokePattern = newValue
+            updateSelectedStyle()
         }
         .onChange(of: filled) { _, _ in updateSelectedStyle() }
         .onChange(of: redactionMode) { _, _ in updateSelectedStyle() }
@@ -344,6 +353,7 @@ private struct InlineAnnotationToolbar: View {
     @Binding var currentTool: AnnotationTool
     @Binding var currentColor: AnnotationColor
     @Binding var lineWidth: CGFloat
+    @Binding var strokePattern: StrokePattern
     @Binding var filled: Bool
     @Binding var redactionMode: RedactionMode
 
@@ -405,7 +415,25 @@ private struct InlineAnnotationToolbar: View {
                     .help("Redaction Mode")
                 }
 
-                if currentTool != .counter && currentTool != .highlighter && currentTool != .pixelate && !isFontSizeMode {
+                if currentTool == .arrow || currentTool == .line {
+                    Picker("", selection: $strokePattern) {
+                        ForEach(StrokePattern.allCases, id: \.self) { pattern in
+                            StrokePatternGlyph(pattern: pattern)
+                                .tag(pattern)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .frame(width: 104)
+                    .help("Stroke Pattern")
+                }
+
+                if currentTool != .counter
+                    && currentTool != .arrow
+                    && currentTool != .line
+                    && currentTool != .highlighter
+                    && currentTool != .pixelate
+                    && !isFontSizeMode {
                     iconButton(
                         systemName: filled ? "square.fill" : "square",
                         help: "Fill Shape",

--- a/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
+++ b/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
@@ -10,6 +10,7 @@ final class CaptureAllInOneAnnotationOverlay {
     private var canvasWindow: NSPanel?
     private var toolbarWindow: NSPanel?
     private var session: AllInOneAnnotationSession?
+    private var currentSelectionRect: CGRect?
 
     init(screen: NSScreen) {
         self.screen = screen
@@ -25,15 +26,15 @@ final class CaptureAllInOneAnnotationOverlay {
         }
         session.availableWidth = selectionRect.width
         self.session = session
+        currentSelectionRect = selectionRect
 
         showCanvas(session: session, selectionRect: selectionRect)
         showToolbar(session: session, selectionRect: selectionRect, avoidingFrame: avoidingFrame)
     }
 
     func update(sourceImage: CGImage, selectionRect: CGRect, avoidingFrame: CGRect?) {
-        if let session, session.document.objects.isEmpty {
-            session.replaceSourceImage(sourceImage)
-        } else if session == nil {
+        let previousSelectionRect = currentSelectionRect
+        if session == nil {
             let newSession = AllInOneAnnotationSession(sourceImage: sourceImage)
             newSession.onRequestCanvasFocus = { [weak self] in
                 self?.focusCanvas()
@@ -45,6 +46,12 @@ final class CaptureAllInOneAnnotationOverlay {
         }
 
         guard let session else { return }
+        let objectOffset = objectOffset(
+            from: previousSelectionRect,
+            to: selectionRect,
+            sourceImage: session.sourceImage
+        )
+        session.replaceSourceImage(sourceImage, objectOffset: objectOffset)
         let wasCompact = session.usesCompactToolbar
         session.availableWidth = selectionRect.width
         if wasCompact != session.usesCompactToolbar {
@@ -59,6 +66,7 @@ final class CaptureAllInOneAnnotationOverlay {
             session: session,
             displayScale: displayScale(for: sourceImage, selectionRect: selectionRect)
         ))
+        currentSelectionRect = selectionRect
     }
 
     func close() {
@@ -67,6 +75,7 @@ final class CaptureAllInOneAnnotationOverlay {
         canvasWindow?.close()
         canvasWindow = nil
         session = nil
+        currentSelectionRect = nil
     }
 
     func renderImage(afterCommit completion: @escaping (CGImage?) -> Void) {
@@ -108,7 +117,7 @@ final class CaptureAllInOneAnnotationOverlay {
             backing: .buffered,
             defer: false
         )
-        panel.level = .screenSaver + 2
+        panel.level = .screenSaver + 3
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = false
@@ -251,6 +260,15 @@ final class CaptureAllInOneAnnotationOverlay {
             screenRect: selectionRect
         ) ?? 1
     }
+
+    private func objectOffset(from oldRect: CGRect?, to newRect: CGRect, sourceImage: CGImage) -> CGSize {
+        guard let oldRect else { return .zero }
+        let scale = displayScale(for: sourceImage, selectionRect: oldRect)
+        return CGSize(
+            width: (oldRect.minX - newRect.minX) * scale,
+            height: (newRect.maxY - oldRect.maxY) * scale
+        )
+    }
 }
 
 private final class AllInOneAnnotationPanel: NSPanel {
@@ -360,9 +378,12 @@ final class AllInOneAnnotationSession: ObservableObject {
         availableWidth < 420
     }
 
-    func replaceSourceImage(_ image: CGImage) {
+    func replaceSourceImage(_ image: CGImage, objectOffset: CGSize = .zero) {
         sourceImage = image
-        document.replaceImage(size: CGSize(width: image.width, height: image.height))
+        document.updateImageSizePreservingObjects(
+            size: CGSize(width: image.width, height: image.height),
+            objectOffset: objectOffset
+        )
         refreshTrigger += 1
     }
 

--- a/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
+++ b/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
@@ -70,7 +70,7 @@ final class CaptureAllInOneAnnotationOverlay {
         session.onRequestToolbarLayout = { [weak self] in
             self?.repositionToolbar(selectionRect: selectionRect, avoidingFrame: avoidingFrame, animated: true)
         }
-        canvasWindow?.setFrame(canvasFrame(for: selectionRect), display: !isLive)
+        canvasWindow?.setFrame(canvasFrame(for: selectionRect), display: true)
         toolbarWindow?.setFrame(toolbarFrame(for: selectionRect, avoidingFrame: avoidingFrame), display: !isLive)
         currentSelectionRect = selectionRect
     }

--- a/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
+++ b/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
@@ -1,0 +1,619 @@
+import AppKit
+import AnnotationKit
+import CaptureKit
+import OCRKit
+import SwiftUI
+
+@MainActor
+final class CaptureAllInOneAnnotationOverlay {
+    private let screen: NSScreen
+    private var canvasWindow: NSPanel?
+    private var toolbarWindow: NSPanel?
+    private var session: AllInOneAnnotationSession?
+
+    init(screen: NSScreen) {
+        self.screen = screen
+    }
+
+    func show(sourceImage: CGImage, selectionRect: CGRect) {
+        let session = AllInOneAnnotationSession(sourceImage: sourceImage)
+        self.session = session
+
+        showCanvas(session: session, selectionRect: selectionRect)
+        showToolbar(session: session, selectionRect: selectionRect)
+    }
+
+    func update(sourceImage: CGImage, selectionRect: CGRect) {
+        if let session, session.document.objects.isEmpty {
+            session.replaceSourceImage(sourceImage)
+        } else if session == nil {
+            session = AllInOneAnnotationSession(sourceImage: sourceImage)
+        }
+
+        guard let session else { return }
+        canvasWindow?.setFrame(canvasFrame(for: selectionRect), display: true)
+        toolbarWindow?.setFrame(toolbarFrame(for: selectionRect), display: true)
+        canvasWindow?.contentView = NSHostingView(rootView: AllInOneAnnotationCanvasView(
+            session: session,
+            displayScale: displayScale(for: sourceImage, selectionRect: selectionRect)
+        ))
+    }
+
+    func close() {
+        toolbarWindow?.close()
+        toolbarWindow = nil
+        canvasWindow?.close()
+        canvasWindow = nil
+        session = nil
+    }
+
+    func renderImage(afterCommit completion: @escaping (CGImage?) -> Void) {
+        guard let session else {
+            completion(nil)
+            return
+        }
+        session.renderImage(afterCommit: completion)
+    }
+
+    private func showCanvas(session: AllInOneAnnotationSession, selectionRect: CGRect) {
+        let panel = AllInOneAnnotationPanel(
+            contentRect: canvasFrame(for: selectionRect),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .screenSaver + 1
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.hidesOnDeactivate = false
+        panel.acceptsMouseMovedEvents = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+
+        panel.contentView = NSHostingView(rootView: AllInOneAnnotationCanvasView(
+            session: session,
+            displayScale: displayScale(for: session.sourceImage, selectionRect: selectionRect)
+        ))
+        canvasWindow = panel
+        panel.orderFrontRegardless()
+        panel.makeKey()
+    }
+
+    private func showToolbar(session: AllInOneAnnotationSession, selectionRect: CGRect) {
+        let panel = AllInOneAnnotationPanel(
+            contentRect: toolbarFrame(for: selectionRect),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.level = .screenSaver + 2
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.hidesOnDeactivate = false
+        panel.acceptsMouseMovedEvents = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+
+        panel.contentView = NSHostingView(rootView: AllInOneAnnotationToolbarView(session: session))
+        toolbarWindow = panel
+        panel.orderFrontRegardless()
+    }
+
+    private func canvasFrame(for selectionRect: CGRect) -> CGRect {
+        let inset: CGFloat = 2
+        let rect = selectionRect.insetBy(dx: inset, dy: inset)
+        return CGRect(
+            x: screen.frame.minX + rect.minX,
+            y: screen.frame.minY + rect.minY,
+            width: max(1, rect.width),
+            height: max(1, rect.height)
+        )
+    }
+
+    private func toolbarFrame(for selectionRect: CGRect) -> CGRect {
+        let margin: CGFloat = 12
+        let gap: CGFloat = 10
+        let width = min(max(760, selectionRect.width), screen.visibleFrame.width - margin * 2)
+        let height: CGFloat = 58
+        let globalRect = CGRect(
+            x: screen.frame.minX + selectionRect.minX,
+            y: screen.frame.minY + selectionRect.minY,
+            width: selectionRect.width,
+            height: selectionRect.height
+        )
+
+        let minX = screen.visibleFrame.minX + margin
+        let maxX = screen.visibleFrame.maxX - width - margin
+        let x = min(max(globalRect.midX - width / 2, minX), maxX)
+
+        let belowY = globalRect.minY - height - gap
+        let aboveY = globalRect.maxY + gap
+        let y: CGFloat
+        if belowY >= screen.visibleFrame.minY + margin {
+            y = belowY
+        } else if aboveY + height <= screen.visibleFrame.maxY - margin {
+            y = aboveY
+        } else {
+            y = max(screen.visibleFrame.minY + margin, min(globalRect.minY + margin, screen.visibleFrame.maxY - height - margin))
+        }
+
+        return CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    private func displayScale(for image: CGImage, selectionRect: CGRect) -> CGFloat {
+        CaptureDisplayGeometry.displayScale(
+            imageSize: CGSize(width: image.width, height: image.height),
+            screenRect: selectionRect
+        ) ?? 1
+    }
+}
+
+private final class AllInOneAnnotationPanel: NSPanel {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}
+
+@MainActor
+final class AllInOneAnnotationSession: ObservableObject {
+    @Published var sourceImage: CGImage
+    @Published var currentTool: AnnotationTool
+    @Published var currentColor: AnnotationColor
+    @Published var filled: Bool
+    @Published var lineWidth: CGFloat
+    @Published var strokePattern: StrokePattern
+    @Published var redactionMode: RedactionMode
+    @Published var isEditingText = false
+    @Published var refreshTrigger = 0
+    @Published var commitEditingTrigger = 0
+    @Published var textRegions: [CGRect] = []
+
+    let document: AnnotationDocument
+
+    private var savedLineWidth: Double {
+        get { UserDefaults.standard.object(forKey: "annotationShapeWidth") as? Double ?? 3 }
+        set { UserDefaults.standard.set(newValue, forKey: "annotationShapeWidth") }
+    }
+
+    init(sourceImage: CGImage) {
+        self.sourceImage = sourceImage
+        self.document = AnnotationDocument(imageSize: CGSize(width: sourceImage.width, height: sourceImage.height))
+        self.currentTool = Self.storedTool()
+        self.currentColor = Self.storedColor()
+        self.filled = UserDefaults.standard.bool(forKey: "annotationFilled")
+        self.lineWidth = Self.storedWidth(for: Self.storedTool())
+        self.strokePattern = Self.storedStrokePattern()
+        self.redactionMode = Self.storedRedactionMode()
+
+        Task { [weak self] in
+            guard let self else { return }
+            if let regions = try? await TextRecognizer.recognize(
+                image: sourceImage,
+                level: .fast,
+                detectURLs: false
+            ) {
+                self.textRegions = regions.map(\.boundingBox)
+            }
+        }
+    }
+
+    var currentStyle: AnnotationKit.StrokeStyle {
+        AnnotationKit.StrokeStyle(
+            color: currentColor,
+            lineWidth: lineWidth,
+            opacity: currentTool == .highlighter ? 0.35 : 1.0,
+            filled: filled,
+            pattern: strokePattern
+        )
+    }
+
+    var effectiveTextFontSize: CGFloat {
+        (currentTool == .text || isEditingText) ? lineWidth : Self.storedTextFontSize()
+    }
+
+    func replaceSourceImage(_ image: CGImage) {
+        sourceImage = image
+        document.replaceImage(size: CGSize(width: image.width, height: image.height))
+        refreshTrigger += 1
+    }
+
+    func switchTool(_ newTool: AnnotationTool) {
+        document.clearSelection()
+        persistWidth(lineWidth, for: currentTool)
+        currentTool = newTool
+        lineWidth = Self.storedWidth(for: newTool)
+        UserDefaults.standard.set(newTool.rawValue, forKey: "annotationLastTool")
+    }
+
+    func updateSelectedStyle() {
+        if let obj = document.selectedObject {
+            if let pixelate = obj as? PixelateObject {
+                pixelate.blockSize = lineWidth
+                pixelate.mode = redactionMode
+                pixelate.style = currentStyle
+            } else if let counter = obj as? CounterObject {
+                counter.radius = lineWidth
+                counter.style = AnnotationKit.StrokeStyle(
+                    color: currentColor,
+                    lineWidth: lineWidth,
+                    filled: filled
+                )
+            } else {
+                obj.style = currentStyle
+            }
+            refreshTrigger += 1
+        }
+    }
+
+    private func renderedOutputImage() -> CGImage? {
+        return AnnotationRenderer.render(sourceImage: sourceImage, objects: document.objects)
+    }
+
+    func renderImage(afterCommit completion: @escaping (CGImage?) -> Void) {
+        commitEditingTrigger += 1
+        DispatchQueue.main.async { [weak self] in
+            completion(self?.renderedOutputImage())
+        }
+    }
+
+    func markChanged() {
+        refreshTrigger += 1
+    }
+
+    func persistWidth(_ width: CGFloat, for tool: AnnotationTool) {
+        switch tool {
+        case .pixelate:
+            UserDefaults.standard.set(Double(width), forKey: "annotationBlockSize")
+        case .counter:
+            UserDefaults.standard.set(Double(width), forKey: "annotationCounterSize")
+        case .highlighter:
+            UserDefaults.standard.set(Double(width), forKey: "annotationHighlighterWidth")
+        case .text:
+            UserDefaults.standard.set(Double(width), forKey: "annotationTextFontSize")
+        default:
+            savedLineWidth = Double(width)
+        }
+    }
+
+    private static func storedTool() -> AnnotationTool {
+        if let raw = UserDefaults.standard.string(forKey: "annotationLastTool"),
+           let tool = AnnotationTool(rawValue: raw) {
+            return tool
+        }
+        return .arrow
+    }
+
+    private static func storedColor() -> AnnotationColor {
+        if let raw = UserDefaults.standard.string(forKey: "annotationLastColor"),
+           let color = AnnotationColor(rawValue: raw) {
+            return color
+        }
+        return .red
+    }
+
+    private static func storedStrokePattern() -> StrokePattern {
+        if let raw = UserDefaults.standard.string(forKey: "annotationStrokePattern"),
+           let pattern = StrokePattern(rawValue: raw) {
+            return pattern
+        }
+        return .solid
+    }
+
+    private static func storedRedactionMode() -> RedactionMode {
+        let value = UserDefaults.standard.integer(forKey: "annotationRedactionMode")
+        return RedactionMode(rawValue: value) ?? .pixelate
+    }
+
+    private static func storedTextFontSize() -> CGFloat {
+        CGFloat(UserDefaults.standard.object(forKey: "annotationTextFontSize") as? Double ?? 48)
+    }
+
+    private static func storedWidth(for tool: AnnotationTool) -> CGFloat {
+        switch tool {
+        case .pixelate:
+            return CGFloat(UserDefaults.standard.object(forKey: "annotationBlockSize") as? Double ?? 12)
+        case .counter:
+            return CGFloat(UserDefaults.standard.object(forKey: "annotationCounterSize") as? Double ?? 20)
+        case .highlighter:
+            return CGFloat(UserDefaults.standard.object(forKey: "annotationHighlighterWidth") as? Double ?? 20)
+        case .text:
+            return storedTextFontSize()
+        default:
+            return CGFloat(UserDefaults.standard.object(forKey: "annotationShapeWidth") as? Double ?? 3)
+        }
+    }
+}
+
+private struct AllInOneAnnotationCanvasView: View {
+    @ObservedObject var session: AllInOneAnnotationSession
+    let displayScale: CGFloat
+
+    var body: some View {
+        AnnotationCanvasView(
+            document: session.document,
+            sourceImage: session.sourceImage,
+            currentTool: session.currentTool,
+            currentStyle: session.currentStyle,
+            redactionMode: session.redactionMode,
+            textFontSize: session.effectiveTextFontSize,
+            zoomScale: displayScale,
+            refreshTrigger: session.refreshTrigger,
+            textRegions: session.textRegions,
+            commitEditingTrigger: session.commitEditingTrigger,
+            onDocumentChanged: { session.markChanged() },
+            onSwitchToSelect: {
+                session.document.clearSelection()
+                session.switchTool(.select)
+            },
+            onTextEditingStarted: { fontSize in
+                session.isEditingText = true
+                if session.lineWidth != fontSize {
+                    session.lineWidth = fontSize
+                }
+            },
+            onTextEditingEnded: {
+                session.isEditingText = false
+                session.persistWidth(session.lineWidth, for: .text)
+            }
+        )
+        .background(Color.clear)
+    }
+}
+
+private struct AllInOneAnnotationToolbarView: View {
+    @ObservedObject var session: AllInOneAnnotationSession
+
+    private var isFontSizeMode: Bool {
+        session.currentTool == .text || session.isEditingText
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            HStack(spacing: 4) {
+                toolButton(.select)
+                toolButton(.arrow)
+                toolButton(.line)
+                toolButton(.rectangle)
+                toolButton(.ellipse)
+                toolButton(.text)
+                toolButton(.freehand)
+                toolButton(.pixelate)
+                toolButton(.counter)
+                toolButton(.highlighter)
+            }
+
+            divider
+
+            AnnotationColorControls(
+                currentColor: Binding(
+                    get: { session.currentColor },
+                    set: {
+                        session.currentColor = $0
+                        UserDefaults.standard.set($0.rawValue, forKey: "annotationLastColor")
+                        session.updateSelectedStyle()
+                    }
+                ),
+                swatchSize: 17,
+                selectedRingColor: .white
+            )
+
+            divider
+
+            HStack(spacing: 7) {
+                if !(session.currentTool == .pixelate && session.redactionMode == .solid) {
+                    Slider(value: Binding(
+                        get: { session.lineWidth },
+                        set: {
+                            session.lineWidth = $0
+                            session.persistWidth($0, for: session.currentTool)
+                            session.updateSelectedStyle()
+                        }
+                    ), in: sliderRange, step: sliderStep)
+                    .frame(width: 92)
+                    .help(sliderHelp)
+                }
+
+                if session.currentTool == .pixelate {
+                    Picker("", selection: Binding(
+                        get: { session.redactionMode },
+                        set: {
+                            session.redactionMode = $0
+                            UserDefaults.standard.set($0.rawValue, forKey: "annotationRedactionMode")
+                            session.updateSelectedStyle()
+                        }
+                    )) {
+                        ForEach(RedactionMode.allCases, id: \.self) { mode in
+                            Text(mode.label).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .frame(width: 168)
+                    .help("Redaction Mode")
+                }
+
+                if session.currentTool == .arrow || session.currentTool == .line {
+                    Picker("", selection: Binding(
+                        get: { session.strokePattern },
+                        set: {
+                            session.strokePattern = $0
+                            UserDefaults.standard.set($0.rawValue, forKey: "annotationStrokePattern")
+                            session.updateSelectedStyle()
+                        }
+                    )) {
+                        ForEach(StrokePattern.allCases, id: \.self) { pattern in
+                            StrokePatternGlyph(pattern: pattern)
+                                .tag(pattern)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .frame(width: 104)
+                    .help("Stroke Pattern")
+                }
+
+                if session.currentTool != .counter
+                    && session.currentTool != .arrow
+                    && session.currentTool != .line
+                    && session.currentTool != .highlighter
+                    && session.currentTool != .pixelate
+                    && !isFontSizeMode {
+                    iconButton(
+                        systemName: session.filled ? "square.fill" : "square",
+                        help: "Fill Shape",
+                        isActive: session.filled,
+                        action: {
+                            session.filled.toggle()
+                            UserDefaults.standard.set(session.filled, forKey: "annotationFilled")
+                            session.updateSelectedStyle()
+                        }
+                    )
+                }
+            }
+
+            divider
+
+            HStack(spacing: 4) {
+                iconButton(
+                    systemName: "arrow.uturn.backward",
+                    help: "Undo",
+                    isEnabled: session.document.canUndo,
+                    action: {
+                        session.document.undo()
+                        session.markChanged()
+                    }
+                )
+
+                iconButton(
+                    systemName: "arrow.uturn.forward",
+                    help: "Redo",
+                    isEnabled: session.document.canRedo,
+                    action: {
+                        session.document.redo()
+                        session.markChanged()
+                    }
+                )
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Color.white.opacity(0.18), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.32), radius: 18, y: 8)
+        .environment(\.colorScheme, .dark)
+    }
+
+    private var divider: some View {
+        Rectangle()
+            .fill(Color.white.opacity(0.16))
+            .frame(width: 1, height: 30)
+    }
+
+    private var sliderRange: ClosedRange<CGFloat> {
+        if isFontSizeMode { return 12...120 }
+        switch session.currentTool {
+        case .pixelate: return 4...48
+        case .counter: return 12...40
+        case .highlighter: return 10...100
+        default: return 1...40
+        }
+    }
+
+    private var sliderStep: CGFloat {
+        switch session.currentTool {
+        case .pixelate, .highlighter: return 2
+        default: return 1
+        }
+    }
+
+    private var sliderHelp: String {
+        if isFontSizeMode { return "\(String(localized: "Font Size")): \(Int(session.lineWidth))" }
+        switch session.currentTool {
+        case .pixelate: return "\(String(localized: "Block Size")): \(Int(session.lineWidth))"
+        case .counter: return "\(String(localized: "Counter Size")): \(Int(session.lineWidth))"
+        case .highlighter: return "\(String(localized: "Highlighter Width")): \(Int(session.lineWidth))"
+        default: return "\(String(localized: "Line Width")): \(Int(session.lineWidth))"
+        }
+    }
+
+    @ViewBuilder
+    private func toolButton(_ tool: AnnotationTool) -> some View {
+        Button(action: { session.switchTool(tool) }) {
+            Group {
+                if tool == .text {
+                    Text(verbatim: "Aa")
+                        .font(.system(size: 13, weight: .semibold))
+                } else {
+                    Image(systemName: iconName(for: tool))
+                        .font(.system(size: 14, weight: .medium))
+                }
+            }
+            .foregroundStyle(.white)
+            .frame(width: 29, height: 28)
+            .background(session.currentTool == tool ? Color.accentColor.opacity(0.45) : Color.white.opacity(0.001))
+            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .help(helpText(for: tool))
+    }
+
+    private func iconButton(
+        systemName: String,
+        help: LocalizedStringKey,
+        isActive: Bool = false,
+        isEnabled: Bool = true,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 30, height: 28)
+                .background(buttonBackground(isActive: isActive, isEnabled: isEnabled))
+                .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .opacity(isEnabled ? 1 : 0.35)
+        .help(help)
+    }
+
+    private func buttonBackground(isActive: Bool, isEnabled: Bool) -> Color {
+        if !isEnabled { return Color.white.opacity(0.06) }
+        if isActive { return Color.accentColor.opacity(0.45) }
+        return Color.white.opacity(0.10)
+    }
+
+    private func iconName(for tool: AnnotationTool) -> String {
+        switch tool {
+        case .select: return "cursorarrow"
+        case .arrow: return "arrow.up.right"
+        case .line: return "line.diagonal"
+        case .rectangle: return "rectangle"
+        case .ellipse: return "circle"
+        case .text: return "textformat"
+        case .freehand: return "pencil.tip"
+        case .pixelate: return "eye.slash.fill"
+        case .counter: return "number.circle.fill"
+        case .highlighter: return "highlighter"
+        }
+    }
+
+    private func helpText(for tool: AnnotationTool) -> LocalizedStringKey {
+        switch tool {
+        case .select: return "Select"
+        case .arrow: return "Arrow"
+        case .line: return "Line"
+        case .rectangle: return "Rectangle"
+        case .ellipse: return "Ellipse"
+        case .text: return "Text"
+        case .freehand: return "Draw"
+        case .pixelate: return "Pixelate / Blur"
+        case .counter: return "Counter"
+        case .highlighter: return "Highlighter"
+        }
+    }
+}

--- a/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
+++ b/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
@@ -15,25 +15,47 @@ final class CaptureAllInOneAnnotationOverlay {
         self.screen = screen
     }
 
-    func show(sourceImage: CGImage, selectionRect: CGRect) {
+    func show(sourceImage: CGImage, selectionRect: CGRect, avoidingFrame: CGRect?) {
         let session = AllInOneAnnotationSession(sourceImage: sourceImage)
+        session.onRequestCanvasFocus = { [weak self] in
+            self?.focusCanvas()
+        }
+        session.onRequestToolbarLayout = { [weak self] in
+            self?.repositionToolbar(selectionRect: selectionRect, avoidingFrame: avoidingFrame, animated: true)
+        }
+        session.availableWidth = selectionRect.width
         self.session = session
 
         showCanvas(session: session, selectionRect: selectionRect)
-        showToolbar(session: session, selectionRect: selectionRect)
+        showToolbar(session: session, selectionRect: selectionRect, avoidingFrame: avoidingFrame)
     }
 
-    func update(sourceImage: CGImage, selectionRect: CGRect) {
+    func update(sourceImage: CGImage, selectionRect: CGRect, avoidingFrame: CGRect?) {
         if let session, session.document.objects.isEmpty {
             session.replaceSourceImage(sourceImage)
         } else if session == nil {
-            session = AllInOneAnnotationSession(sourceImage: sourceImage)
+            let newSession = AllInOneAnnotationSession(sourceImage: sourceImage)
+            newSession.onRequestCanvasFocus = { [weak self] in
+                self?.focusCanvas()
+            }
+            newSession.onRequestToolbarLayout = { [weak self] in
+                self?.repositionToolbar(selectionRect: selectionRect, avoidingFrame: avoidingFrame, animated: true)
+            }
+            session = newSession
         }
 
         guard let session else { return }
+        let wasCompact = session.usesCompactToolbar
+        session.availableWidth = selectionRect.width
+        if wasCompact != session.usesCompactToolbar {
+            session.showsOverflow = false
+        }
+        session.onRequestToolbarLayout = { [weak self] in
+            self?.repositionToolbar(selectionRect: selectionRect, avoidingFrame: avoidingFrame, animated: true)
+        }
         canvasWindow?.setFrame(canvasFrame(for: selectionRect), display: true)
-        toolbarWindow?.setFrame(toolbarFrame(for: selectionRect), display: true)
-        canvasWindow?.contentView = NSHostingView(rootView: AllInOneAnnotationCanvasView(
+        toolbarWindow?.setFrame(toolbarFrame(for: selectionRect, avoidingFrame: avoidingFrame), display: true)
+        canvasWindow?.contentView = AllInOneCanvasHostingView(rootView: AllInOneAnnotationCanvasView(
             session: session,
             displayScale: displayScale(for: sourceImage, selectionRect: selectionRect)
         ))
@@ -70,7 +92,7 @@ final class CaptureAllInOneAnnotationOverlay {
         panel.acceptsMouseMovedEvents = true
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
 
-        panel.contentView = NSHostingView(rootView: AllInOneAnnotationCanvasView(
+        panel.contentView = AllInOneCanvasHostingView(rootView: AllInOneAnnotationCanvasView(
             session: session,
             displayScale: displayScale(for: session.sourceImage, selectionRect: selectionRect)
         ))
@@ -79,9 +101,9 @@ final class CaptureAllInOneAnnotationOverlay {
         panel.makeKey()
     }
 
-    private func showToolbar(session: AllInOneAnnotationSession, selectionRect: CGRect) {
+    private func showToolbar(session: AllInOneAnnotationSession, selectionRect: CGRect, avoidingFrame: CGRect?) {
         let panel = AllInOneAnnotationPanel(
-            contentRect: toolbarFrame(for: selectionRect),
+            contentRect: toolbarFrame(for: selectionRect, avoidingFrame: avoidingFrame),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -99,6 +121,23 @@ final class CaptureAllInOneAnnotationOverlay {
         panel.orderFrontRegardless()
     }
 
+    func repositionToolbar(selectionRect: CGRect, avoidingFrame: CGRect?, animated: Bool) {
+        let frame = toolbarFrame(for: selectionRect, avoidingFrame: avoidingFrame)
+        if animated {
+            toolbarWindow?.setFrame(frame, display: true, animate: true)
+        } else {
+            toolbarWindow?.setFrame(frame, display: true)
+        }
+    }
+
+    private func focusCanvas() {
+        guard let canvasWindow else { return }
+        canvasWindow.makeKey()
+        if let canvas = canvasWindow.contentView?.firstSubview(of: AnnotationCanvasNSView.self) {
+            canvasWindow.makeFirstResponder(canvas)
+        }
+    }
+
     private func canvasFrame(for selectionRect: CGRect) -> CGRect {
         let inset: CGFloat = 2
         let rect = selectionRect.insetBy(dx: inset, dy: inset)
@@ -110,34 +149,94 @@ final class CaptureAllInOneAnnotationOverlay {
         )
     }
 
-    private func toolbarFrame(for selectionRect: CGRect) -> CGRect {
+    private func toolbarFrame(for selectionRect: CGRect, avoidingFrame: CGRect?) -> CGRect {
         let margin: CGFloat = 12
         let gap: CGFloat = 10
-        let width = min(max(760, selectionRect.width), screen.visibleFrame.width - margin * 2)
-        let height: CGFloat = 58
         let globalRect = CGRect(
             x: screen.frame.minX + selectionRect.minX,
             y: screen.frame.minY + selectionRect.minY,
             width: selectionRect.width,
             height: selectionRect.height
         )
+        let session = session
+        let usesCompact = session?.usesCompactToolbar ?? (globalRect.width < 760)
+        let usesMini = session?.usesMiniToolbar ?? (globalRect.width < 420)
+        let showsOverflow = session?.showsOverflow ?? false
+        let width: CGFloat
+        let height: CGFloat
+        let maxToolbarWidth = screen.visibleFrame.width - margin * 2
+        if usesCompact {
+            if usesMini && !showsOverflow {
+                width = min(268, maxToolbarWidth)
+            } else if showsOverflow {
+                width = min(760, maxToolbarWidth)
+            } else {
+                width = min(max(420, globalRect.width), min(760, maxToolbarWidth))
+            }
+            height = showsOverflow ? 102 : 54
+        } else {
+            width = min(max(760, globalRect.width), min(960, maxToolbarWidth))
+            height = 58
+        }
 
-        let minX = screen.visibleFrame.minX + margin
-        let maxX = screen.visibleFrame.maxX - width - margin
-        let x = min(max(globalRect.midX - width / 2, minX), maxX)
+        func clampedX(width: CGFloat) -> CGFloat {
+            let minX = screen.visibleFrame.minX + margin
+            let maxX = screen.visibleFrame.maxX - width - margin
+            return min(max(globalRect.midX - width / 2, minX), maxX)
+        }
 
         let belowY = globalRect.minY - height - gap
         let aboveY = globalRect.maxY + gap
-        let y: CGFloat
+
+        var candidates: [CGRect] = []
         if belowY >= screen.visibleFrame.minY + margin {
-            y = belowY
-        } else if aboveY + height <= screen.visibleFrame.maxY - margin {
-            y = aboveY
-        } else {
-            y = max(screen.visibleFrame.minY + margin, min(globalRect.minY + margin, screen.visibleFrame.maxY - height - margin))
+            candidates.append(CGRect(x: clampedX(width: width), y: belowY, width: width, height: height))
+        }
+        if aboveY + height <= screen.visibleFrame.maxY - margin {
+            candidates.append(CGRect(x: clampedX(width: width), y: aboveY, width: width, height: height))
+        }
+        candidates.append(CGRect(
+            x: clampedX(width: width),
+            y: max(screen.visibleFrame.minY + margin, min(globalRect.minY + margin, screen.visibleFrame.maxY - height - margin)),
+            width: width,
+            height: height
+        ))
+
+        guard let avoidingFrame else {
+            return candidates[0]
         }
 
-        return CGRect(x: x, y: y, width: width, height: height)
+        let inflatedAvoidance = avoidingFrame.insetBy(dx: -8, dy: -8)
+        for candidate in candidates {
+            let adjusted = toolbarFrame(candidate, avoiding: inflatedAvoidance, margin: margin, gap: gap)
+            if !adjusted.intersects(inflatedAvoidance) {
+                return adjusted
+            }
+        }
+
+        return toolbarFrame(candidates[0], avoiding: inflatedAvoidance, margin: margin, gap: gap)
+    }
+
+    private func toolbarFrame(_ frame: CGRect, avoiding avoidance: CGRect, margin: CGFloat, gap: CGFloat) -> CGRect {
+        guard frame.maxY > avoidance.minY && frame.minY < avoidance.maxY else {
+            return frame
+        }
+
+        let visible = screen.visibleFrame
+        let leftWidth = avoidance.minX - gap - (visible.minX + margin)
+        let rightWidth = (visible.maxX - margin) - (avoidance.maxX + gap)
+
+        if frame.midX <= avoidance.midX, leftWidth >= frame.width {
+            return CGRect(x: avoidance.minX - gap - frame.width, y: frame.minY, width: frame.width, height: frame.height)
+        }
+        if rightWidth >= frame.width {
+            return CGRect(x: avoidance.maxX + gap, y: frame.minY, width: frame.width, height: frame.height)
+        }
+        if leftWidth >= frame.width {
+            return CGRect(x: avoidance.minX - gap - frame.width, y: frame.minY, width: frame.width, height: frame.height)
+        }
+
+        return frame
     }
 
     private func displayScale(for image: CGImage, selectionRect: CGRect) -> CGFloat {
@@ -153,6 +252,32 @@ private final class AllInOneAnnotationPanel: NSPanel {
     override var canBecomeMain: Bool { false }
 }
 
+private final class AllInOneCanvasHostingView<Content: View>: NSHostingView<Content> {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.makeKey()
+        if let canvas = firstSubview(of: AnnotationCanvasNSView.self) {
+            window?.makeFirstResponder(canvas)
+        }
+        super.mouseDown(with: event)
+    }
+}
+
+private extension NSView {
+    func firstSubview<T: NSView>(of type: T.Type) -> T? {
+        if let view = self as? T {
+            return view
+        }
+        for subview in subviews {
+            if let match = subview.firstSubview(of: type) {
+                return match
+            }
+        }
+        return nil
+    }
+}
+
 @MainActor
 final class AllInOneAnnotationSession: ObservableObject {
     @Published var sourceImage: CGImage
@@ -166,8 +291,12 @@ final class AllInOneAnnotationSession: ObservableObject {
     @Published var refreshTrigger = 0
     @Published var commitEditingTrigger = 0
     @Published var textRegions: [CGRect] = []
+    @Published var availableWidth: CGFloat = 0
+    @Published var showsOverflow = false
 
     let document: AnnotationDocument
+    var onRequestCanvasFocus: (() -> Void)?
+    var onRequestToolbarLayout: (() -> Void)?
 
     private var savedLineWidth: Double {
         get { UserDefaults.standard.object(forKey: "annotationShapeWidth") as? Double ?? 3 }
@@ -210,6 +339,14 @@ final class AllInOneAnnotationSession: ObservableObject {
         (currentTool == .text || isEditingText) ? lineWidth : Self.storedTextFontSize()
     }
 
+    var usesCompactToolbar: Bool {
+        availableWidth < 760
+    }
+
+    var usesMiniToolbar: Bool {
+        availableWidth < 420
+    }
+
     func replaceSourceImage(_ image: CGImage) {
         sourceImage = image
         document.replaceImage(size: CGSize(width: image.width, height: image.height))
@@ -222,6 +359,13 @@ final class AllInOneAnnotationSession: ObservableObject {
         currentTool = newTool
         lineWidth = Self.storedWidth(for: newTool)
         UserDefaults.standard.set(newTool.rawValue, forKey: "annotationLastTool")
+        onRequestCanvasFocus?()
+    }
+
+    func toggleOverflow() {
+        guard usesCompactToolbar else { return }
+        showsOverflow.toggle()
+        onRequestToolbarLayout?()
     }
 
     func updateSelectedStyle() {
@@ -367,131 +511,74 @@ private struct AllInOneAnnotationToolbarView: View {
     }
 
     var body: some View {
-        HStack(spacing: 10) {
-            HStack(spacing: 4) {
-                toolButton(.select)
-                toolButton(.arrow)
-                toolButton(.line)
-                toolButton(.rectangle)
-                toolButton(.ellipse)
-                toolButton(.text)
-                toolButton(.freehand)
-                toolButton(.pixelate)
-                toolButton(.counter)
-                toolButton(.highlighter)
-            }
+        if session.usesMiniToolbar && !session.showsOverflow {
+            miniToolbar
+        } else {
+            adaptiveToolbar
+        }
+    }
 
-            divider
+    private var adaptiveToolbar: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 10) {
+                toolRow(primaryTools)
 
-            AnnotationColorControls(
-                currentColor: Binding(
-                    get: { session.currentColor },
-                    set: {
-                        session.currentColor = $0
-                        UserDefaults.standard.set($0.rawValue, forKey: "annotationLastColor")
-                        session.updateSelectedStyle()
-                    }
-                ),
-                swatchSize: 17,
-                selectedRingColor: .white
-            )
+                divider
 
-            divider
-
-            HStack(spacing: 7) {
-                if !(session.currentTool == .pixelate && session.redactionMode == .solid) {
-                    Slider(value: Binding(
-                        get: { session.lineWidth },
-                        set: {
-                            session.lineWidth = $0
-                            session.persistWidth($0, for: session.currentTool)
-                            session.updateSelectedStyle()
-                        }
-                    ), in: sliderRange, step: sliderStep)
-                    .frame(width: 92)
-                    .help(sliderHelp)
-                }
-
-                if session.currentTool == .pixelate {
-                    Picker("", selection: Binding(
-                        get: { session.redactionMode },
-                        set: {
-                            session.redactionMode = $0
-                            UserDefaults.standard.set($0.rawValue, forKey: "annotationRedactionMode")
-                            session.updateSelectedStyle()
-                        }
-                    )) {
-                        ForEach(RedactionMode.allCases, id: \.self) { mode in
-                            Text(mode.label).tag(mode)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .labelsHidden()
-                    .frame(width: 168)
-                    .help("Redaction Mode")
-                }
-
-                if session.currentTool == .arrow || session.currentTool == .line {
-                    Picker("", selection: Binding(
-                        get: { session.strokePattern },
-                        set: {
-                            session.strokePattern = $0
-                            UserDefaults.standard.set($0.rawValue, forKey: "annotationStrokePattern")
-                            session.updateSelectedStyle()
-                        }
-                    )) {
-                        ForEach(StrokePattern.allCases, id: \.self) { pattern in
-                            StrokePatternGlyph(pattern: pattern)
-                                .tag(pattern)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .labelsHidden()
-                    .frame(width: 104)
-                    .help("Stroke Pattern")
-                }
-
-                if session.currentTool != .counter
-                    && session.currentTool != .arrow
-                    && session.currentTool != .line
-                    && session.currentTool != .highlighter
-                    && session.currentTool != .pixelate
-                    && !isFontSizeMode {
-                    iconButton(
-                        systemName: session.filled ? "square.fill" : "square",
-                        help: "Fill Shape",
-                        isActive: session.filled,
-                        action: {
-                            session.filled.toggle()
-                            UserDefaults.standard.set(session.filled, forKey: "annotationFilled")
-                            session.updateSelectedStyle()
-                        }
+                if !session.usesCompactToolbar {
+                    AnnotationColorControls(
+                        currentColor: Binding(
+                            get: { session.currentColor },
+                            set: {
+                                session.currentColor = $0
+                                UserDefaults.standard.set($0.rawValue, forKey: "annotationLastColor")
+                                session.updateSelectedStyle()
+                            }
+                        ),
+                        swatchSize: 17,
+                        selectedRingColor: .white
                     )
+
+                    divider
+                    primaryControls
+                } else {
+                    compactStatus
+                }
+
+                if session.usesCompactToolbar {
+                    iconButton(
+                        systemName: session.showsOverflow ? "chevron.up" : "ellipsis",
+                        help: session.showsOverflow ? "Hide tools" : "More tools",
+                        action: { session.toggleOverflow() }
+                    )
+                } else {
+                    divider
+                    undoRedoControls
                 }
             }
 
-            divider
-
-            HStack(spacing: 4) {
-                iconButton(
-                    systemName: "arrow.uturn.backward",
-                    help: "Undo",
-                    isEnabled: session.document.canUndo,
-                    action: {
-                        session.document.undo()
-                        session.markChanged()
-                    }
-                )
-
-                iconButton(
-                    systemName: "arrow.uturn.forward",
-                    help: "Redo",
-                    isEnabled: session.document.canRedo,
-                    action: {
-                        session.document.redo()
-                        session.markChanged()
-                    }
-                )
+            if session.usesCompactToolbar && session.showsOverflow {
+                HStack(spacing: 10) {
+                    toolRow(overflowTools)
+                    divider
+                    AnnotationColorControls(
+                        currentColor: Binding(
+                            get: { session.currentColor },
+                            set: {
+                                session.currentColor = $0
+                                UserDefaults.standard.set($0.rawValue, forKey: "annotationLastColor")
+                                session.updateSelectedStyle()
+                            }
+                        ),
+                        swatchSize: 17,
+                        selectedRingColor: .white
+                    )
+                    divider
+                    primaryControls
+                    divider
+                    undoRedoControls
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
         .padding(.horizontal, 14)
@@ -504,6 +591,163 @@ private struct AllInOneAnnotationToolbarView: View {
         )
         .shadow(color: .black.opacity(0.32), radius: 18, y: 8)
         .environment(\.colorScheme, .dark)
+        .animation(.spring(response: 0.20, dampingFraction: 0.88), value: session.showsOverflow)
+    }
+
+    private var miniToolbar: some View {
+        HStack(spacing: 9) {
+            currentToolGlyph
+                .frame(width: 30, height: 28)
+                .background(Color.accentColor.opacity(0.45), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+            Circle()
+                .fill(Color(cgColor: session.currentColor.cgColor))
+                .frame(width: 18, height: 18)
+                .overlay(Circle().stroke(Color.white.opacity(0.62), lineWidth: 1.5))
+
+            Text(compactValueLabel)
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                .foregroundStyle(.white.opacity(0.86))
+                .frame(minWidth: 34)
+
+            iconButton(
+                systemName: "ellipsis",
+                help: "More tools",
+                action: { session.toggleOverflow() }
+            )
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Color.white.opacity(0.18), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.32), radius: 18, y: 8)
+        .environment(\.colorScheme, .dark)
+    }
+
+    private var primaryTools: [AnnotationTool] {
+        session.usesCompactToolbar
+            ? [.select, .arrow, .line, .rectangle, .text, .freehand]
+            : AnnotationTool.allCases
+    }
+
+    private var overflowTools: [AnnotationTool] {
+        [.ellipse, .pixelate, .counter, .highlighter]
+    }
+
+    private var compactStatus: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(Color(cgColor: session.currentColor.cgColor))
+                .frame(width: 18, height: 18)
+                .overlay(Circle().stroke(Color.white.opacity(0.62), lineWidth: 1.5))
+
+            Text(compactValueLabel)
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                .foregroundStyle(.white.opacity(0.86))
+                .frame(minWidth: 36)
+        }
+    }
+
+    private var primaryControls: some View {
+        HStack(spacing: 7) {
+            if !(session.currentTool == .pixelate && session.redactionMode == .solid) {
+                Slider(value: Binding(
+                    get: { session.lineWidth },
+                    set: {
+                        session.lineWidth = $0
+                        session.persistWidth($0, for: session.currentTool)
+                        session.updateSelectedStyle()
+                    }
+                ), in: sliderRange, step: sliderStep)
+                .frame(width: 92)
+                .help(sliderHelp)
+            }
+
+            if session.currentTool == .pixelate {
+                redactionModeControl
+            }
+
+            if session.currentTool == .arrow || session.currentTool == .line {
+                strokePatternControl
+            }
+
+            if session.currentTool != .counter
+                && session.currentTool != .arrow
+                && session.currentTool != .line
+                && session.currentTool != .highlighter
+                && session.currentTool != .pixelate
+                && !isFontSizeMode {
+                iconButton(
+                    systemName: session.filled ? "square.fill" : "square",
+                    help: "Fill Shape",
+                    isActive: session.filled,
+                    action: {
+                        session.filled.toggle()
+                        UserDefaults.standard.set(session.filled, forKey: "annotationFilled")
+                        session.updateSelectedStyle()
+                    }
+                )
+            }
+        }
+    }
+
+    private var undoRedoControls: some View {
+        HStack(spacing: 4) {
+            iconButton(
+                systemName: "arrow.uturn.backward",
+                help: "Undo",
+                isEnabled: session.document.canUndo,
+                action: {
+                    session.document.undo()
+                    session.markChanged()
+                }
+            )
+
+            iconButton(
+                systemName: "arrow.uturn.forward",
+                help: "Redo",
+                isEnabled: session.document.canRedo,
+                action: {
+                    session.document.redo()
+                    session.markChanged()
+                }
+            )
+        }
+    }
+
+    private func toolRow(_ tools: [AnnotationTool]) -> some View {
+        HStack(spacing: 4) {
+            ForEach(tools, id: \.self) { tool in
+                toolButton(tool)
+            }
+        }
+    }
+
+    private var currentToolGlyph: some View {
+        Group {
+            if session.currentTool == .text {
+                Text(verbatim: "Aa")
+                    .font(.system(size: 13, weight: .semibold))
+            } else {
+                Image(systemName: iconName(for: session.currentTool))
+                    .font(.system(size: 14, weight: .medium))
+            }
+        }
+        .foregroundStyle(.white)
+    }
+
+    private var compactValueLabel: String {
+        if session.currentTool == .pixelate {
+            return "\(Int(session.lineWidth))px"
+        }
+        if isFontSizeMode {
+            return "\(Int(session.lineWidth))pt"
+        }
+        return "\(Int(session.lineWidth))px"
     }
 
     private var divider: some View {
@@ -537,6 +781,65 @@ private struct AllInOneAnnotationToolbarView: View {
         case .highlighter: return "\(String(localized: "Highlighter Width")): \(Int(session.lineWidth))"
         default: return "\(String(localized: "Line Width")): \(Int(session.lineWidth))"
         }
+    }
+
+    private var redactionModeControl: some View {
+        HStack(spacing: 2) {
+            ForEach(RedactionMode.allCases, id: \.self) { mode in
+                Button {
+                    session.redactionMode = mode
+                    UserDefaults.standard.set(mode.rawValue, forKey: "annotationRedactionMode")
+                    session.updateSelectedStyle()
+                } label: {
+                    Text(mode.label)
+                        .font(.system(size: 11, weight: .semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                        .foregroundStyle(.white)
+                        .frame(width: 48, height: 26)
+                        .background(optionBackground(isActive: session.redactionMode == mode))
+                        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .help(Text(mode.label))
+            }
+        }
+        .padding(2)
+        .background(optionGroupBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .help("Redaction Mode")
+    }
+
+    private var strokePatternControl: some View {
+        HStack(spacing: 2) {
+            ForEach(StrokePattern.allCases, id: \.self) { pattern in
+                Button {
+                    session.strokePattern = pattern
+                    UserDefaults.standard.set(pattern.rawValue, forKey: "annotationStrokePattern")
+                    session.updateSelectedStyle()
+                } label: {
+                    StrokePatternGlyph(pattern: pattern)
+                        .foregroundStyle(.white)
+                        .frame(width: 30, height: 26)
+                        .background(optionBackground(isActive: session.strokePattern == pattern))
+                        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .help(Text(pattern.rawValue.capitalized))
+            }
+        }
+        .padding(2)
+        .background(optionGroupBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .help("Stroke Pattern")
+    }
+
+    private var optionGroupBackground: Color {
+        Color.white.opacity(0.09)
+    }
+
+    private func optionBackground(isActive: Bool) -> Color {
+        isActive ? Color.accentColor.opacity(0.48) : Color.white.opacity(0.001)
     }
 
     @ViewBuilder

--- a/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
+++ b/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
@@ -17,7 +17,10 @@ final class CaptureAllInOneAnnotationOverlay {
     }
 
     func show(sourceImage: CGImage, selectionRect: CGRect, avoidingFrame: CGRect?) {
-        let session = AllInOneAnnotationSession(sourceImage: sourceImage)
+        let session = AllInOneAnnotationSession(
+            sourceImage: sourceImage,
+            displayScale: displayScale(for: sourceImage, selectionRect: selectionRect)
+        )
         session.onRequestCanvasFocus = { [weak self] in
             self?.focusCanvas()
         }
@@ -32,10 +35,13 @@ final class CaptureAllInOneAnnotationOverlay {
         showToolbar(session: session, selectionRect: selectionRect, avoidingFrame: avoidingFrame)
     }
 
-    func update(sourceImage: CGImage, selectionRect: CGRect, avoidingFrame: CGRect?) {
+    func update(sourceImage: CGImage, selectionRect: CGRect, avoidingFrame: CGRect?, isLive: Bool = false) {
         let previousSelectionRect = currentSelectionRect
         if session == nil {
-            let newSession = AllInOneAnnotationSession(sourceImage: sourceImage)
+            let newSession = AllInOneAnnotationSession(
+                sourceImage: sourceImage,
+                displayScale: displayScale(for: sourceImage, selectionRect: selectionRect)
+            )
             newSession.onRequestCanvasFocus = { [weak self] in
                 self?.focusCanvas()
             }
@@ -51,7 +57,11 @@ final class CaptureAllInOneAnnotationOverlay {
             to: selectionRect,
             sourceImage: session.sourceImage
         )
-        session.replaceSourceImage(sourceImage, objectOffset: objectOffset)
+        session.replaceSourceImage(
+            sourceImage,
+            displayScale: displayScale(for: sourceImage, selectionRect: selectionRect),
+            objectOffset: objectOffset
+        )
         let wasCompact = session.usesCompactToolbar
         session.availableWidth = selectionRect.width
         if wasCompact != session.usesCompactToolbar {
@@ -60,12 +70,8 @@ final class CaptureAllInOneAnnotationOverlay {
         session.onRequestToolbarLayout = { [weak self] in
             self?.repositionToolbar(selectionRect: selectionRect, avoidingFrame: avoidingFrame, animated: true)
         }
-        canvasWindow?.setFrame(canvasFrame(for: selectionRect), display: true)
-        toolbarWindow?.setFrame(toolbarFrame(for: selectionRect, avoidingFrame: avoidingFrame), display: true)
-        canvasWindow?.contentView = AllInOneCanvasHostingView(rootView: AllInOneAnnotationCanvasView(
-            session: session,
-            displayScale: displayScale(for: sourceImage, selectionRect: selectionRect)
-        ))
+        canvasWindow?.setFrame(canvasFrame(for: selectionRect), display: !isLive)
+        toolbarWindow?.setFrame(toolbarFrame(for: selectionRect, avoidingFrame: avoidingFrame), display: !isLive)
         currentSelectionRect = selectionRect
     }
 
@@ -102,8 +108,7 @@ final class CaptureAllInOneAnnotationOverlay {
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
 
         panel.contentView = AllInOneCanvasHostingView(rootView: AllInOneAnnotationCanvasView(
-            session: session,
-            displayScale: displayScale(for: session.sourceImage, selectionRect: selectionRect)
+            session: session
         ))
         canvasWindow = panel
         panel.orderFrontRegardless()
@@ -312,6 +317,7 @@ private extension NSView {
 @MainActor
 final class AllInOneAnnotationSession: ObservableObject {
     @Published var sourceImage: CGImage
+    @Published var displayScale: CGFloat
     @Published var currentTool: AnnotationTool
     @Published var currentColor: AnnotationColor
     @Published var filled: Bool
@@ -334,8 +340,9 @@ final class AllInOneAnnotationSession: ObservableObject {
         set { UserDefaults.standard.set(newValue, forKey: "annotationShapeWidth") }
     }
 
-    init(sourceImage: CGImage) {
+    init(sourceImage: CGImage, displayScale: CGFloat) {
         self.sourceImage = sourceImage
+        self.displayScale = displayScale
         self.document = AnnotationDocument(imageSize: CGSize(width: sourceImage.width, height: sourceImage.height))
         self.currentTool = Self.storedTool()
         self.currentColor = Self.storedColor()
@@ -378,8 +385,9 @@ final class AllInOneAnnotationSession: ObservableObject {
         availableWidth < 420
     }
 
-    func replaceSourceImage(_ image: CGImage, objectOffset: CGSize = .zero) {
+    func replaceSourceImage(_ image: CGImage, displayScale: CGFloat, objectOffset: CGSize = .zero) {
         sourceImage = image
+        self.displayScale = displayScale
         document.updateImageSizePreservingObjects(
             size: CGSize(width: image.width, height: image.height),
             objectOffset: objectOffset
@@ -503,7 +511,6 @@ final class AllInOneAnnotationSession: ObservableObject {
 
 private struct AllInOneAnnotationCanvasView: View {
     @ObservedObject var session: AllInOneAnnotationSession
-    let displayScale: CGFloat
 
     var body: some View {
         AnnotationCanvasView(
@@ -513,7 +520,7 @@ private struct AllInOneAnnotationCanvasView: View {
             currentStyle: session.currentStyle,
             redactionMode: session.redactionMode,
             textFontSize: session.effectiveTextFontSize,
-            zoomScale: displayScale,
+            zoomScale: session.displayScale,
             refreshTrigger: session.refreshTrigger,
             textRegions: session.textRegions,
             commitEditingTrigger: session.commitEditingTrigger,

--- a/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
+++ b/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
@@ -116,7 +116,13 @@ final class CaptureAllInOneAnnotationOverlay {
         panel.acceptsMouseMovedEvents = true
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
 
-        panel.contentView = NSHostingView(rootView: AllInOneAnnotationToolbarView(session: session))
+        let hostingView = AllInOneAnnotationToolbarHostingView(rootView: AllInOneAnnotationToolbarView(session: session))
+        hostingView.wantsLayer = true
+        hostingView.layer?.backgroundColor = NSColor.clear.cgColor
+        hostingView.layer?.cornerRadius = 14
+        hostingView.layer?.cornerCurve = .continuous
+        hostingView.layer?.masksToBounds = true
+        panel.contentView = hostingView
         toolbarWindow = panel
         panel.orderFrontRegardless()
     }
@@ -261,6 +267,13 @@ private final class AllInOneCanvasHostingView<Content: View>: NSHostingView<Cont
             window?.makeFirstResponder(canvas)
         }
         super.mouseDown(with: event)
+    }
+}
+
+private final class AllInOneAnnotationToolbarHostingView<Content: View>: NSHostingView<Content> {
+    override var isOpaque: Bool {
+        get { false }
+        set { }
     }
 }
 
@@ -584,12 +597,12 @@ private struct AllInOneAnnotationToolbarView: View {
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .background(toolbarBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .stroke(Color.white.opacity(0.18), lineWidth: 0.5)
         )
-        .shadow(color: .black.opacity(0.32), radius: 18, y: 8)
         .environment(\.colorScheme, .dark)
         .animation(.spring(response: 0.20, dampingFraction: 0.88), value: session.showsOverflow)
     }
@@ -619,13 +632,19 @@ private struct AllInOneAnnotationToolbarView: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .background(toolbarBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .stroke(Color.white.opacity(0.18), lineWidth: 0.5)
         )
-        .shadow(color: .black.opacity(0.32), radius: 18, y: 8)
         .environment(\.colorScheme, .dark)
+    }
+
+    private var toolbarBackground: some View {
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .fill(.regularMaterial)
+            .shadow(color: .black.opacity(0.32), radius: 18, y: 8)
     }
 
     private var primaryTools: [AnnotationTool] {

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -15,6 +15,8 @@ final class CaptureAllInOneToolbarWindow {
     private var annotationOverlay: CaptureAllInOneAnnotationOverlay?
     private var globalEscMonitor: Any?
     private var localEscMonitor: Any?
+    private var globalSelectionMouseMonitor: Any?
+    private var localSelectionMouseMonitor: Any?
     private var screenLocalSelectionRect: CGRect
     private let toolbarState: CaptureAllInOneToolbarState
     private let presets: [CapturePreset]
@@ -76,6 +78,7 @@ final class CaptureAllInOneToolbarWindow {
         removeEscMonitor()
         annotationOverlay?.close()
         annotationOverlay = nil
+        removeSelectionMouseMonitor()
         toolbarWindow?.close()
         toolbarWindow = nil
         selectionOverlayWindow?.close()
@@ -135,6 +138,7 @@ final class CaptureAllInOneToolbarWindow {
         selectionOverlayWindow = panel
         panel.orderFrontRegardless()
         panel.makeKey()
+        installSelectionMouseMonitorIfNeeded()
     }
 
     private func showToolbar() {
@@ -298,6 +302,7 @@ final class CaptureAllInOneToolbarWindow {
         if shouldRefreshAnnotationOverlay(isLive: isLive) {
             updateAnnotationOverlayIfPossible(isLive: isLive)
         }
+        updateSelectionMouseHandling()
     }
 
     private func updateToolbarState() {
@@ -441,6 +446,46 @@ final class CaptureAllInOneToolbarWindow {
             NSEvent.removeMonitor(localEscMonitor)
             self.localEscMonitor = nil
         }
+    }
+
+    private func installSelectionMouseMonitorIfNeeded() {
+        guard frozenImage != nil else { return }
+
+        let mask: NSEvent.EventTypeMask = [.mouseMoved, .leftMouseDown, .leftMouseDragged, .leftMouseUp]
+        globalSelectionMouseMonitor = NSEvent.addGlobalMonitorForEvents(matching: mask) { [weak self] _ in
+            Task { @MainActor in self?.updateSelectionMouseHandling() }
+        }
+        localSelectionMouseMonitor = NSEvent.addLocalMonitorForEvents(matching: mask) { [weak self] event in
+            self?.updateSelectionMouseHandling()
+            return event
+        }
+        updateSelectionMouseHandling()
+    }
+
+    private func removeSelectionMouseMonitor() {
+        if let globalSelectionMouseMonitor {
+            NSEvent.removeMonitor(globalSelectionMouseMonitor)
+            self.globalSelectionMouseMonitor = nil
+        }
+        if let localSelectionMouseMonitor {
+            NSEvent.removeMonitor(localSelectionMouseMonitor)
+            self.localSelectionMouseMonitor = nil
+        }
+    }
+
+    private func updateSelectionMouseHandling() {
+        guard frozenImage != nil,
+              let selectionOverlayWindow,
+              let selectionOverlayView else {
+            return
+        }
+
+        let mouseLocation = NSEvent.mouseLocation
+        let screenLocalPoint = CGPoint(
+            x: mouseLocation.x - screen.frame.minX,
+            y: mouseLocation.y - screen.frame.minY
+        )
+        selectionOverlayWindow.ignoresMouseEvents = !selectionOverlayView.wantsMouseEvents(at: screenLocalPoint)
     }
 }
 
@@ -1024,12 +1069,7 @@ private final class AllInOneSelectionOverlayView: NSView {
 
     override func hitTest(_ point: NSPoint) -> NSView? {
         if passesThroughSelectionBody,
-           selectionRect.contains(point),
-           case .move? = CaptureSelectionGeometry.hitTarget(
-                at: point,
-                selectionRect: selectionRect,
-                hitSlop: hitSlop
-           ) {
+           !wantsMouseEvents(at: point) {
             return nil
         }
 
@@ -1122,14 +1162,15 @@ private final class AllInOneSelectionOverlayView: NSView {
             )
         }
 
-        let bodyRect = rect.insetBy(dx: slop, dy: slop)
-        if bodyRect.width > 0, bodyRect.height > 0 {
-            addCursorRect(bodyRect, cursor: .openHand)
+        if !passesThroughSelectionBody {
+            let bodyRect = rect.insetBy(dx: slop, dy: slop)
+            if bodyRect.width > 0, bodyRect.height > 0 {
+                addCursorRect(bodyRect, cursor: .openHand)
+            }
         }
     }
 
     override func mouseDown(with event: NSEvent) {
-        window?.makeKey()
         window?.makeFirstResponder(self)
 
         let point = convert(event.locationInWindow, from: nil)
@@ -1267,6 +1308,8 @@ private final class AllInOneSelectionOverlayView: NSView {
     }
 
     private func updateCursor(for point: CGPoint) {
+        guard wantsMouseEvents(at: point) else { return }
+
         if activePreset.isFixedSize {
             if selectionRect.contains(point) {
                 NSCursor.openHand.set()
@@ -1284,6 +1327,23 @@ private final class AllInOneSelectionOverlayView: NSView {
             ),
             at: point,
         ).set()
+    }
+
+    func wantsMouseEvents(at point: CGPoint) -> Bool {
+        guard passesThroughSelectionBody else { return true }
+
+        switch CaptureSelectionGeometry.hitTarget(
+            at: point,
+            selectionRect: selectionRect,
+            hitSlop: hitSlop
+        ) {
+        case .resize:
+            return true
+        case .move:
+            return false
+        case nil:
+            return true
+        }
     }
 
     private func cursor(for target: CaptureSelectionHitTarget?, at point: CGPoint) -> NSCursor {

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -103,7 +103,7 @@ final class CaptureAllInOneToolbarWindow {
             defer: false
         )
         panel.onEscape = { [weak self] in self?.onCancel?() }
-        panel.level = .screenSaver
+        panel.level = frozenImage == nil ? .screenSaver : .screenSaver + 2
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = false
@@ -118,6 +118,7 @@ final class CaptureAllInOneToolbarWindow {
             minSelectionSize: Self.minimumSelectionSize,
             activePreset: activePreset
         )
+        overlayView.passesThroughSelectionBody = frozenImage != nil
         overlayView.onSelectionChanged = { [weak self] selectionRect in
             self?.updateSelection(selectionRect)
         }
@@ -140,7 +141,7 @@ final class CaptureAllInOneToolbarWindow {
             defer: false
         )
         panel.onEscape = { [weak self] in self?.onCancel?() }
-        panel.level = .screenSaver + 1
+        panel.level = frozenImage == nil ? .screenSaver + 1 : .screenSaver + 3
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = false
@@ -955,6 +956,7 @@ private struct CaptureAllInOneToolbarView: View {
 private final class AllInOneSelectionOverlayView: NSView {
     var onSelectionChanged: ((CGRect) -> Void)?
     var onCancel: (() -> Void)?
+    var passesThroughSelectionBody = false
 
     private enum DragOperation {
         case none
@@ -990,6 +992,20 @@ private final class AllInOneSelectionOverlayView: NSView {
     required init?(coder: NSCoder) { fatalError() }
 
     override var acceptsFirstResponder: Bool { true }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        if passesThroughSelectionBody,
+           selectionRect.contains(point),
+           case .move? = CaptureSelectionGeometry.hitTarget(
+                at: point,
+                selectionRect: selectionRect,
+                hitSlop: hitSlop
+           ) {
+            return nil
+        }
+
+        return super.hitTest(point)
+    }
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -12,12 +12,14 @@ final class CaptureAllInOneToolbarWindow {
     private var selectionOverlayWindow: NSPanel?
     private weak var selectionOverlayView: AllInOneSelectionOverlayView?
     private var toolbarWindow: NSPanel?
+    private var annotationOverlay: CaptureAllInOneAnnotationOverlay?
     private var globalEscMonitor: Any?
     private var localEscMonitor: Any?
     private var screenLocalSelectionRect: CGRect
     private let toolbarState: CaptureAllInOneToolbarState
     private let presets: [CapturePreset]
     private var activePreset: CapturePreset
+    private let frozenImage: CGImage?
 
     let screen: NSScreen
 
@@ -31,18 +33,22 @@ final class CaptureAllInOneToolbarWindow {
     var onRecording: ((CGRect) -> Void)?
     var onAnnotate: ((CGRect) -> Void)?
     var onCopy: ((CGRect) -> Void)?
+    var onCopyRendered: ((CGImage, CGRect) -> Void)?
+    var onOCRRendered: ((CGImage, CGRect) -> Void)?
     var onCancel: (() -> Void)?
 
     init(
         selectionRect: CGRect,
         screen: NSScreen,
         presets: [CapturePreset],
-        activePreset: CapturePreset
+        activePreset: CapturePreset,
+        frozenImage: CGImage? = nil
     ) {
         let visiblePresets = presets.isEmpty ? [.freeform] : presets
         self.screenLocalSelectionRect = selectionRect.standardized
         self.presets = visiblePresets
         self.activePreset = activePreset
+        self.frozenImage = frozenImage
         self.toolbarState = CaptureAllInOneToolbarState(
             selectionRect: selectionRect.standardized,
             presets: visiblePresets,
@@ -61,11 +67,14 @@ final class CaptureAllInOneToolbarWindow {
 
         showSelectionOverlay()
         showToolbar()
+        showAnnotationOverlayIfPossible()
         installEscMonitor()
     }
 
     func close() {
         removeEscMonitor()
+        annotationOverlay?.close()
+        annotationOverlay = nil
         toolbarWindow?.close()
         toolbarWindow = nil
         selectionOverlayWindow?.close()
@@ -158,7 +167,18 @@ final class CaptureAllInOneToolbarWindow {
             },
             onOCR: { [weak self] in
                 guard let self else { return }
-                self.onOCR?(self.screenLocalSelectionRect)
+                if let annotationOverlay = self.annotationOverlay {
+                    annotationOverlay.renderImage(afterCommit: { [weak self] rendered in
+                        guard let self else { return }
+                        if let rendered {
+                            self.onOCRRendered?(rendered, self.screenLocalSelectionRect)
+                        } else {
+                            self.onOCR?(self.screenLocalSelectionRect)
+                        }
+                    })
+                } else {
+                    self.onOCR?(self.screenLocalSelectionRect)
+                }
             },
             onRecording: { [weak self] in
                 guard let self else { return }
@@ -170,7 +190,18 @@ final class CaptureAllInOneToolbarWindow {
             },
             onCopy: { [weak self] in
                 guard let self else { return }
-                self.onCopy?(self.screenLocalSelectionRect)
+                if let annotationOverlay = self.annotationOverlay {
+                    annotationOverlay.renderImage(afterCommit: { [weak self] rendered in
+                        guard let self else { return }
+                        if let rendered {
+                            self.onCopyRendered?(rendered, self.screenLocalSelectionRect)
+                        } else {
+                            self.onCopy?(self.screenLocalSelectionRect)
+                        }
+                    })
+                } else {
+                    self.onCopy?(self.screenLocalSelectionRect)
+                }
             },
             onPresetSelected: { [weak self] preset in
                 self?.applyPreset(preset)
@@ -193,13 +224,14 @@ final class CaptureAllInOneToolbarWindow {
         let gap: CGFloat = 12
         let toolbarWidth = min(max(980, selectionRect.width), screen.visibleFrame.width - margin * 2)
         let toolbarHeight: CGFloat = 78
+        let annotationHeight: CGFloat = frozenImage == nil ? 0 : 58 + gap
 
         let minX = screen.visibleFrame.minX + margin
         let maxX = screen.visibleFrame.maxX - toolbarWidth - margin
         let x = min(max(selectionRect.midX - toolbarWidth / 2, minX), maxX)
 
-        let belowY = selectionRect.minY - toolbarHeight - gap
-        let aboveY = selectionRect.maxY + gap
+        let belowY = selectionRect.minY - toolbarHeight - gap - annotationHeight
+        let aboveY = selectionRect.maxY + gap + annotationHeight
         let y: CGFloat
         if belowY >= screen.visibleFrame.minY + margin {
             y = belowY
@@ -220,6 +252,7 @@ final class CaptureAllInOneToolbarWindow {
         )
         updateToolbarState()
         toolbarWindow?.setFrame(toolbarFrame(for: globalSelectionRect), display: true)
+        updateAnnotationOverlayIfPossible()
     }
 
     private func updateToolbarState() {
@@ -237,7 +270,37 @@ final class CaptureAllInOneToolbarWindow {
         selectionOverlayView?.setSelectionRect(fittedRect)
         updateToolbarState()
         toolbarWindow?.setFrame(toolbarFrame(for: globalSelectionRect), display: true)
+        updateAnnotationOverlayIfPossible()
         onPresetChanged?(preset)
+    }
+
+    private func showAnnotationOverlayIfPossible() {
+        guard let sourceImage = croppedFrozenImage(for: screenLocalSelectionRect) else { return }
+        let overlay = CaptureAllInOneAnnotationOverlay(screen: screen)
+        annotationOverlay = overlay
+        overlay.show(sourceImage: sourceImage, selectionRect: screenLocalSelectionRect)
+    }
+
+    private func updateAnnotationOverlayIfPossible() {
+        guard let sourceImage = croppedFrozenImage(for: screenLocalSelectionRect) else { return }
+        if annotationOverlay == nil {
+            let overlay = CaptureAllInOneAnnotationOverlay(screen: screen)
+            annotationOverlay = overlay
+            overlay.show(sourceImage: sourceImage, selectionRect: screenLocalSelectionRect)
+        } else {
+            annotationOverlay?.update(sourceImage: sourceImage, selectionRect: screenLocalSelectionRect)
+        }
+    }
+
+    private func croppedFrozenImage(for selectionRect: CGRect) -> CGImage? {
+        guard let frozenImage else { return nil }
+        let cropRect = CaptureDisplayGeometry.frozenImageCropRect(
+            screenLocalRect: selectionRect,
+            screenSize: screen.frame.size,
+            imageSize: CGSize(width: frozenImage.width, height: frozenImage.height)
+        )
+        guard !cropRect.isEmpty else { return nil }
+        return frozenImage.cropping(to: cropRect)
     }
 
     private func fittedSelectionRect(for preset: CapturePreset) -> CGRect {
@@ -380,7 +443,6 @@ private struct CaptureAllInOneToolbarView: View {
             HStack(spacing: 8) {
                 dimensionPill
                 presetMenu
-                iconButton("pencil", kind: .annotate, help: "Annotate in place", action: onAnnotate)
                 iconButton("doc.on.doc", kind: .copy, help: "Copy selected area", action: onCopy)
                 iconButton("xmark", kind: .cancel, help: "Cancel", action: onCancel)
             }

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -151,6 +151,10 @@ final class CaptureAllInOneToolbarWindow {
 
         let hostingView = AllInOneToolbarHostingView(rootView: CaptureAllInOneToolbarView(
             state: toolbarState,
+            isSideRail: frozenImage != nil,
+            onChromeStateChanged: { [weak self] in
+                self?.layoutChrome(animated: true)
+            },
             onArea: { [weak self] in
                 guard let self else { return }
                 self.onArea?(self.screenLocalSelectionRect)
@@ -220,18 +224,21 @@ final class CaptureAllInOneToolbarWindow {
     }
 
     private func toolbarFrame(for selectionRect: CGRect) -> CGRect {
+        if frozenImage != nil {
+            return sideRailFrame(for: selectionRect)
+        }
+
         let margin: CGFloat = 12
         let gap: CGFloat = 12
         let toolbarWidth = min(max(980, selectionRect.width), screen.visibleFrame.width - margin * 2)
         let toolbarHeight: CGFloat = 78
-        let annotationHeight: CGFloat = frozenImage == nil ? 0 : 58 + gap
 
         let minX = screen.visibleFrame.minX + margin
         let maxX = screen.visibleFrame.maxX - toolbarWidth - margin
         let x = min(max(selectionRect.midX - toolbarWidth / 2, minX), maxX)
 
-        let belowY = selectionRect.minY - toolbarHeight - gap - annotationHeight
-        let aboveY = selectionRect.maxY + gap + annotationHeight
+        let belowY = selectionRect.minY - toolbarHeight - gap
+        let aboveY = selectionRect.maxY + gap
         let y: CGFloat
         if belowY >= screen.visibleFrame.minY + margin {
             y = belowY
@@ -244,6 +251,31 @@ final class CaptureAllInOneToolbarWindow {
         return CGRect(x: x, y: y, width: toolbarWidth, height: toolbarHeight)
     }
 
+    private func sideRailFrame(for selectionRect: CGRect) -> CGRect {
+        let margin: CGFloat = 12
+        let gap: CGFloat = 10
+        let toolbarWidth: CGFloat = 84
+        let toolbarHeight = min(toolbarState.preferredRailHeight, screen.visibleFrame.height - margin * 2)
+
+        let preferredRightX = selectionRect.maxX + gap
+        let preferredLeftX = selectionRect.minX - toolbarWidth - gap
+        let x: CGFloat
+        if preferredRightX + toolbarWidth <= screen.visibleFrame.maxX - margin {
+            x = preferredRightX
+        } else if preferredLeftX >= screen.visibleFrame.minX + margin {
+            x = preferredLeftX
+        } else {
+            x = screen.visibleFrame.maxX - toolbarWidth - margin
+        }
+
+        let y = min(
+            max(selectionRect.midY - toolbarHeight / 2, screen.visibleFrame.minY + margin),
+            screen.visibleFrame.maxY - toolbarHeight - margin
+        )
+
+        return CGRect(x: x, y: y, width: toolbarWidth, height: toolbarHeight)
+    }
+
     private func updateSelection(_ selectionRect: CGRect) {
         screenLocalSelectionRect = CaptureSelectionGeometry.move(
             selectionRect.standardized,
@@ -251,13 +283,19 @@ final class CaptureAllInOneToolbarWindow {
             in: screenLocalBounds
         )
         updateToolbarState()
-        toolbarWindow?.setFrame(toolbarFrame(for: globalSelectionRect), display: true)
+        layoutChrome(animated: true)
         updateAnnotationOverlayIfPossible()
     }
 
     private func updateToolbarState() {
         toolbarState.width = max(1, Int(screenLocalSelectionRect.width.rounded()))
         toolbarState.height = max(1, Int(screenLocalSelectionRect.height.rounded()))
+        let shouldCompact = frozenImage != nil
+            && screenLocalSelectionRect.height < 520
+        if toolbarState.isCompact != shouldCompact {
+            toolbarState.isCompact = shouldCompact
+            toolbarState.showsOverflow = false
+        }
     }
 
     private func applyPreset(_ preset: CapturePreset) {
@@ -269,16 +307,34 @@ final class CaptureAllInOneToolbarWindow {
         screenLocalSelectionRect = fittedRect
         selectionOverlayView?.setSelectionRect(fittedRect)
         updateToolbarState()
-        toolbarWindow?.setFrame(toolbarFrame(for: globalSelectionRect), display: true)
+        layoutChrome(animated: true)
         updateAnnotationOverlayIfPossible()
         onPresetChanged?(preset)
+    }
+
+    private func layoutChrome(animated: Bool) {
+        let frame = toolbarFrame(for: globalSelectionRect)
+        if animated {
+            toolbarWindow?.setFrame(frame, display: true, animate: true)
+        } else {
+            toolbarWindow?.setFrame(frame, display: true)
+        }
+        annotationOverlay?.repositionToolbar(
+            selectionRect: screenLocalSelectionRect,
+            avoidingFrame: toolbarWindow?.frame,
+            animated: animated
+        )
     }
 
     private func showAnnotationOverlayIfPossible() {
         guard let sourceImage = croppedFrozenImage(for: screenLocalSelectionRect) else { return }
         let overlay = CaptureAllInOneAnnotationOverlay(screen: screen)
         annotationOverlay = overlay
-        overlay.show(sourceImage: sourceImage, selectionRect: screenLocalSelectionRect)
+        overlay.show(
+            sourceImage: sourceImage,
+            selectionRect: screenLocalSelectionRect,
+            avoidingFrame: toolbarWindow?.frame
+        )
     }
 
     private func updateAnnotationOverlayIfPossible() {
@@ -286,9 +342,17 @@ final class CaptureAllInOneToolbarWindow {
         if annotationOverlay == nil {
             let overlay = CaptureAllInOneAnnotationOverlay(screen: screen)
             annotationOverlay = overlay
-            overlay.show(sourceImage: sourceImage, selectionRect: screenLocalSelectionRect)
+            overlay.show(
+                sourceImage: sourceImage,
+                selectionRect: screenLocalSelectionRect,
+                avoidingFrame: toolbarWindow?.frame
+            )
         } else {
-            annotationOverlay?.update(sourceImage: sourceImage, selectionRect: screenLocalSelectionRect)
+            annotationOverlay?.update(
+                sourceImage: sourceImage,
+                selectionRect: screenLocalSelectionRect,
+                avoidingFrame: toolbarWindow?.frame
+            )
         }
     }
 
@@ -392,6 +456,35 @@ private final class CaptureAllInOneToolbarState {
     var height: Int
     let presets: [CapturePreset]
     var activePreset: CapturePreset
+    var isCompact = false
+    var showsOverflow = false
+
+    var preferredRailHeight: CGFloat {
+        let gap: CGFloat = 7
+        let verticalPadding: CGFloat = 20
+        let rowHeight: CGFloat = 38
+        let presetHeight: CGFloat = 42
+        let dimensionHeight: CGFloat = 54
+        let dividerHeight: CGFloat = 5
+
+        let itemHeights: [CGFloat]
+        if isCompact && !showsOverflow {
+            itemHeights = [dimensionHeight, rowHeight, rowHeight, dividerHeight, rowHeight]
+        } else {
+            itemHeights = [
+                rowHeight, rowHeight, rowHeight, rowHeight, rowHeight, rowHeight, rowHeight,
+                dividerHeight,
+                dimensionHeight,
+                presetHeight,
+                rowHeight,
+                rowHeight
+            ]
+        }
+
+        return verticalPadding
+            + itemHeights.reduce(0, +)
+            + CGFloat(max(0, itemHeights.count - 1)) * gap
+    }
 
     init(selectionRect: CGRect, presets: [CapturePreset], activePreset: CapturePreset) {
         self.width = max(1, Int(selectionRect.width.rounded()))
@@ -407,10 +500,12 @@ private struct CaptureAllInOneToolbarView: View {
     }
 
     private enum UtilityAction: Hashable {
-        case annotate, copy, cancel
+        case annotate, copy, cancel, overflow
     }
 
     let state: CaptureAllInOneToolbarState
+    let isSideRail: Bool
+    let onChromeStateChanged: () -> Void
     let onArea: () -> Void
     let onFullscreen: () -> Void
     let onWindow: () -> Void
@@ -427,6 +522,14 @@ private struct CaptureAllInOneToolbarView: View {
     @State private var hoveredUtility: UtilityAction?
 
     var body: some View {
+        if isSideRail {
+            sideRail
+        } else {
+            horizontalBar
+        }
+    }
+
+    private var horizontalBar: some View {
         HStack(spacing: 12) {
             HStack(spacing: 3) {
                 modeButton(.area, icon: "viewfinder", title: "Area", action: onArea)
@@ -466,10 +569,69 @@ private struct CaptureAllInOneToolbarView: View {
         }
     }
 
+    private var sideRail: some View {
+        VStack(spacing: 7) {
+            if !state.isCompact || state.showsOverflow {
+                railActionButton(.area, icon: "viewfinder", title: "Area", action: onArea)
+                railActionButton(.fullscreen, icon: "display", title: "Fullscreen", action: onFullscreen)
+                railActionButton(.window, icon: "macwindow", title: "Window", action: onWindow)
+                railActionButton(.scrolling, icon: "arrow.down.to.line.compact", title: "Scrolling", action: onScrolling)
+                railActionButton(.timer, icon: "timer", title: "Timer", action: onTimer)
+                railActionButton(.ocr, textIcon: "Aa", title: "OCR", action: onOCR)
+                railActionButton(.recording, icon: "video", title: "Recording", action: onRecording)
+
+                railDivider
+            }
+
+            railDimensionPill
+
+            if !state.isCompact || state.showsOverflow {
+                railPresetMenu
+            }
+
+            railIconButton("doc.on.doc", kind: .copy, help: "Copy selected area", action: onCopy)
+            railIconButton("xmark", kind: .cancel, help: "Cancel", action: onCancel)
+
+            if state.isCompact {
+                railDivider
+                railIconButton(
+                    state.showsOverflow ? "chevron.up" : "ellipsis",
+                    kind: .overflow,
+                    help: state.showsOverflow ? "Hide actions" : "More actions",
+                    action: toggleOverflow
+                )
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Color.white.opacity(0.20), lineWidth: 0.5)
+        )
+        .shadow(color: .black.opacity(0.30), radius: 18, y: 8)
+        .environment(\.colorScheme, .dark)
+        .animation(.spring(response: 0.20, dampingFraction: 0.88), value: state.showsOverflow)
+        .onHover { hovering in
+            if hovering {
+                NSCursor.arrow.set()
+            }
+        }
+    }
+
     private var divider: some View {
         Rectangle()
             .fill(Color.white.opacity(0.13))
             .frame(width: 1, height: 44)
+    }
+
+    private var railDivider: some View {
+        Rectangle()
+            .fill(Color.white.opacity(0.13))
+            .frame(width: 42, height: 1)
+            .padding(.vertical, 2)
     }
 
     private var presetMenu: some View {
@@ -511,6 +673,44 @@ private struct CaptureAllInOneToolbarView: View {
         .help("Capture preset")
     }
 
+    private var railPresetMenu: some View {
+        Menu {
+            ForEach(state.presets) { preset in
+                Button {
+                    onPresetSelected(preset)
+                } label: {
+                    if preset == state.activePreset {
+                        Label(localizedPresetDisplayName(preset), systemImage: "checkmark")
+                    } else {
+                        Text(localizedPresetDisplayName(preset))
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(railPresetLabel)
+                    .font(.system(size: 11, weight: .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.68)
+                    .frame(maxWidth: .infinity)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .heavy))
+                    .foregroundStyle(.white.opacity(0.72))
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 8)
+            .frame(width: 60, height: 42)
+            .background(Color.white.opacity(0.13), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+            )
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .help(localizedPresetDisplayName(state.activePreset))
+    }
+
     private var presetLabel: String {
         switch state.activePreset {
         case .freeform:
@@ -519,6 +719,20 @@ private struct CaptureAllInOneToolbarView: View {
             return "\(width):\(height)"
         case .fixedSize(let width, let height, let name):
             return name ?? "\(width)x\(height)"
+        }
+    }
+
+    private var railPresetLabel: String {
+        switch state.activePreset {
+        case .freeform:
+            return String(localized: "Free")
+        case .aspectRatio(let width, let height, _):
+            return "\(width):\(height)"
+        case .fixedSize(let width, let height, let name):
+            if let name, name.count <= 6 {
+                return localizedPresetName(name)
+            }
+            return "\(width)x\(height)"
         }
     }
 
@@ -567,6 +781,27 @@ private struct CaptureAllInOneToolbarView: View {
         .help("Selected area size")
     }
 
+    private var railDimensionPill: some View {
+        VStack(spacing: 1) {
+            Text("\(state.width)")
+            Text("x")
+                .font(.system(size: 9, weight: .bold, design: .monospaced))
+                .foregroundStyle(.white.opacity(0.58))
+            Text("\(state.height)")
+        }
+        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+        .foregroundStyle(.white)
+        .lineLimit(1)
+        .minimumScaleFactor(0.68)
+        .frame(width: 60, height: 54)
+        .background(Color.white.opacity(0.11), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+        )
+        .help("Selected area size")
+    }
+
     private func modeButton(
         _ kind: ModeAction,
         icon: String? = nil,
@@ -602,6 +837,33 @@ private struct CaptureAllInOneToolbarView: View {
         .help(title)
     }
 
+    private func railActionButton(
+        _ kind: ModeAction,
+        icon: String? = nil,
+        textIcon: String? = nil,
+        title: LocalizedStringKey,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Group {
+                if let textIcon {
+                    Text(verbatim: textIcon)
+                        .font(.system(size: 15, weight: .bold))
+                } else if let icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 16, weight: .semibold))
+                }
+            }
+            .foregroundStyle(.white)
+            .frame(width: 60, height: 38)
+            .background(modeBackground(kind), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+            .contentShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .onHover { hoveredMode = $0 ? kind : nil }
+        .help(title)
+    }
+
     private func modeBackground(_ kind: ModeAction) -> Color {
         hoveredMode == kind ? Color.white.opacity(0.12) : Color.white.opacity(0.001)
     }
@@ -628,8 +890,36 @@ private struct CaptureAllInOneToolbarView: View {
         .help(help)
     }
 
+    private func railIconButton(
+        _ systemName: String,
+        kind: UtilityAction,
+        help: LocalizedStringKey,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 60, height: 38)
+                .background(utilityBackground(kind), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 9, style: .continuous)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+                )
+        }
+        .buttonStyle(.plain)
+        .onHover { hoveredUtility = $0 ? kind : nil }
+        .help(help)
+    }
+
     private func utilityBackground(_ kind: UtilityAction) -> Color {
         hoveredUtility == kind ? Color.white.opacity(0.18) : Color.white.opacity(0.11)
+    }
+
+    private func toggleOverflow() {
+        guard state.isCompact else { return }
+        state.showsOverflow.toggle()
+        onChromeStateChanged()
     }
 }
 

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -553,14 +553,12 @@ private struct CaptureAllInOneToolbarView: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .background(toolbarBackground)
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .stroke(Color.white.opacity(0.20), lineWidth: 0.5)
         )
-        .shadow(color: .black.opacity(0.30), radius: 18, y: 8)
-        .shadow(color: .black.opacity(0.14), radius: 3, y: 1)
         .environment(\.colorScheme, .dark)
         .onHover { hovering in
             if hovering {
@@ -572,13 +570,13 @@ private struct CaptureAllInOneToolbarView: View {
     private var sideRail: some View {
         VStack(spacing: 7) {
             if !state.isCompact || state.showsOverflow {
-                railActionButton(.area, icon: "viewfinder", title: "Area", action: onArea)
-                railActionButton(.fullscreen, icon: "display", title: "Fullscreen", action: onFullscreen)
-                railActionButton(.window, icon: "macwindow", title: "Window", action: onWindow)
-                railActionButton(.scrolling, icon: "arrow.down.to.line.compact", title: "Scrolling", action: onScrolling)
-                railActionButton(.timer, icon: "timer", title: "Timer", action: onTimer)
-                railActionButton(.ocr, textIcon: "Aa", title: "OCR", action: onOCR)
-                railActionButton(.recording, icon: "video", title: "Recording", action: onRecording)
+                railActionButton(.area, icon: "viewfinder", title: "Area", label: String(localized: "Area"), action: onArea)
+                railActionButton(.fullscreen, icon: "display", title: "Fullscreen", label: String(localized: "Full"), action: onFullscreen)
+                railActionButton(.window, icon: "macwindow", title: "Window", label: String(localized: "Window"), action: onWindow)
+                railActionButton(.scrolling, icon: "arrow.down.to.line.compact", title: "Scrolling", label: String(localized: "Scroll"), action: onScrolling)
+                railActionButton(.timer, icon: "timer", title: "Timer", label: String(localized: "Timer"), action: onTimer)
+                railActionButton(.ocr, textIcon: "Aa", title: "OCR", label: String(localized: "OCR"), action: onOCR)
+                railActionButton(.recording, icon: "video", title: "Recording", label: String(localized: "Record"), action: onRecording)
 
                 railDivider
             }
@@ -589,8 +587,8 @@ private struct CaptureAllInOneToolbarView: View {
                 railPresetMenu
             }
 
-            railIconButton("doc.on.doc", kind: .copy, help: "Copy selected area", action: onCopy)
-            railIconButton("xmark", kind: .cancel, help: "Cancel", action: onCancel)
+            railIconButton("doc.on.doc", kind: .copy, help: "Copy selected area", label: String(localized: "Copy"), action: onCopy)
+            railIconButton("xmark", kind: .cancel, help: "Cancel", label: String(localized: "Close"), action: onCancel)
 
             if state.isCompact {
                 railDivider
@@ -598,6 +596,7 @@ private struct CaptureAllInOneToolbarView: View {
                     state.showsOverflow ? "chevron.up" : "ellipsis",
                     kind: .overflow,
                     help: state.showsOverflow ? "Hide actions" : "More actions",
+                    label: state.showsOverflow ? String(localized: "Less") : String(localized: "More"),
                     action: toggleOverflow
                 )
             }
@@ -605,13 +604,12 @@ private struct CaptureAllInOneToolbarView: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .background(toolbarBackground)
         .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .stroke(Color.white.opacity(0.20), lineWidth: 0.5)
         )
-        .shadow(color: .black.opacity(0.30), radius: 18, y: 8)
         .environment(\.colorScheme, .dark)
         .animation(.spring(response: 0.20, dampingFraction: 0.88), value: state.showsOverflow)
         .onHover { hovering in
@@ -619,6 +617,13 @@ private struct CaptureAllInOneToolbarView: View {
                 NSCursor.arrow.set()
             }
         }
+    }
+
+    private var toolbarBackground: some View {
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .fill(.regularMaterial)
+            .shadow(color: .black.opacity(0.30), radius: 18, y: 8)
+            .shadow(color: .black.opacity(0.14), radius: 3, y: 1)
     }
 
     private var divider: some View {
@@ -842,16 +847,28 @@ private struct CaptureAllInOneToolbarView: View {
         icon: String? = nil,
         textIcon: String? = nil,
         title: LocalizedStringKey,
+        label: String,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
-            Group {
-                if let textIcon {
-                    Text(verbatim: textIcon)
-                        .font(.system(size: 15, weight: .bold))
-                } else if let icon {
-                    Image(systemName: icon)
-                        .font(.system(size: 16, weight: .semibold))
+            VStack(spacing: hoveredMode == kind ? 1 : 0) {
+                Group {
+                    if let textIcon {
+                        Text(verbatim: textIcon)
+                            .font(.system(size: 15, weight: .bold))
+                    } else if let icon {
+                        Image(systemName: icon)
+                            .font(.system(size: 16, weight: .semibold))
+                    }
+                }
+                .frame(height: hoveredMode == kind ? 17 : 38)
+
+                if hoveredMode == kind {
+                    Text(label)
+                        .font(.system(size: 8.5, weight: .semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.68)
+                        .transition(.opacity)
                 }
             }
             .foregroundStyle(.white)
@@ -894,18 +911,30 @@ private struct CaptureAllInOneToolbarView: View {
         _ systemName: String,
         kind: UtilityAction,
         help: LocalizedStringKey,
+        label: String,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
-            Image(systemName: systemName)
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(.white)
-                .frame(width: 60, height: 38)
-                .background(utilityBackground(kind), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 9, style: .continuous)
-                        .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
-                )
+            VStack(spacing: hoveredUtility == kind ? 1 : 0) {
+                Image(systemName: systemName)
+                    .font(.system(size: 15, weight: .semibold))
+                    .frame(height: hoveredUtility == kind ? 17 : 38)
+
+                if hoveredUtility == kind {
+                    Text(label)
+                        .font(.system(size: 8.5, weight: .semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.68)
+                        .transition(.opacity)
+                }
+            }
+            .foregroundStyle(.white)
+            .frame(width: 60, height: 38)
+            .background(utilityBackground(kind), in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 9, style: .continuous)
+                    .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+            )
         }
         .buttonStyle(.plain)
         .onHover { hoveredUtility = $0 ? kind : nil }

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -1129,6 +1129,7 @@ private final class AllInOneSelectionOverlayView: NSView {
     }
 
     override func mouseDown(with event: NSEvent) {
+        window?.makeKey()
         window?.makeFirstResponder(self)
 
         let point = convert(event.locationInWindow, from: nil)

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -20,6 +20,7 @@ final class CaptureAllInOneToolbarWindow {
     private let presets: [CapturePreset]
     private var activePreset: CapturePreset
     private let frozenImage: CGImage?
+    private var lastLiveAnnotationUpdateTime: TimeInterval = 0
 
     let screen: NSScreen
 
@@ -119,8 +120,11 @@ final class CaptureAllInOneToolbarWindow {
             activePreset: activePreset
         )
         overlayView.passesThroughSelectionBody = frozenImage != nil
+        overlayView.onSelectionPreviewChanged = { [weak self] selectionRect in
+            self?.updateSelection(selectionRect, phase: .live)
+        }
         overlayView.onSelectionChanged = { [weak self] selectionRect in
-            self?.updateSelection(selectionRect)
+            self?.updateSelection(selectionRect, phase: .final)
         }
         overlayView.onCancel = { [weak self] in
             self?.onCancel?()
@@ -277,15 +281,23 @@ final class CaptureAllInOneToolbarWindow {
         return CGRect(x: x, y: y, width: toolbarWidth, height: toolbarHeight)
     }
 
-    private func updateSelection(_ selectionRect: CGRect) {
+    private enum SelectionUpdatePhase {
+        case live
+        case final
+    }
+
+    private func updateSelection(_ selectionRect: CGRect, phase: SelectionUpdatePhase = .final) {
         screenLocalSelectionRect = CaptureSelectionGeometry.move(
             selectionRect.standardized,
             by: .zero,
             in: screenLocalBounds
         )
         updateToolbarState()
-        layoutChrome(animated: true)
-        updateAnnotationOverlayIfPossible()
+        let isLive = phase == .live
+        layoutChrome(animated: !isLive)
+        if shouldRefreshAnnotationOverlay(isLive: isLive) {
+            updateAnnotationOverlayIfPossible(isLive: isLive)
+        }
     }
 
     private func updateToolbarState() {
@@ -309,7 +321,7 @@ final class CaptureAllInOneToolbarWindow {
         selectionOverlayView?.setSelectionRect(fittedRect)
         updateToolbarState()
         layoutChrome(animated: true)
-        updateAnnotationOverlayIfPossible()
+        updateAnnotationOverlayIfPossible(isLive: false)
         onPresetChanged?(preset)
     }
 
@@ -338,7 +350,7 @@ final class CaptureAllInOneToolbarWindow {
         )
     }
 
-    private func updateAnnotationOverlayIfPossible() {
+    private func updateAnnotationOverlayIfPossible(isLive: Bool) {
         guard let sourceImage = croppedFrozenImage(for: screenLocalSelectionRect) else { return }
         if annotationOverlay == nil {
             let overlay = CaptureAllInOneAnnotationOverlay(screen: screen)
@@ -352,9 +364,24 @@ final class CaptureAllInOneToolbarWindow {
             annotationOverlay?.update(
                 sourceImage: sourceImage,
                 selectionRect: screenLocalSelectionRect,
-                avoidingFrame: toolbarWindow?.frame
+                avoidingFrame: toolbarWindow?.frame,
+                isLive: isLive
             )
         }
+    }
+
+    private func shouldRefreshAnnotationOverlay(isLive: Bool) -> Bool {
+        guard isLive else {
+            lastLiveAnnotationUpdateTime = 0
+            return true
+        }
+
+        let now = ProcessInfo.processInfo.systemUptime
+        guard now - lastLiveAnnotationUpdateTime >= 1.0 / 30.0 else {
+            return false
+        }
+        lastLiveAnnotationUpdateTime = now
+        return true
     }
 
     private func croppedFrozenImage(for selectionRect: CGRect) -> CGImage? {
@@ -954,6 +981,7 @@ private struct CaptureAllInOneToolbarView: View {
 }
 
 private final class AllInOneSelectionOverlayView: NSView {
+    var onSelectionPreviewChanged: ((CGRect) -> Void)?
     var onSelectionChanged: ((CGRect) -> Void)?
     var onCancel: (() -> Void)?
     var passesThroughSelectionBody = false
@@ -992,6 +1020,7 @@ private final class AllInOneSelectionOverlayView: NSView {
     required init?(coder: NSCoder) { fatalError() }
 
     override var acceptsFirstResponder: Bool { true }
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
         if passesThroughSelectionBody,
@@ -1121,7 +1150,7 @@ private final class AllInOneSelectionOverlayView: NSView {
             )
             selectionRect = fixedRect
             dragOperation = .move(startRect: fixedRect, startPoint: point)
-            onSelectionChanged?(selectionRect)
+            onSelectionPreviewChanged?(selectionRect)
             NSCursor.closedHand.set()
             return
         }
@@ -1193,7 +1222,7 @@ private final class AllInOneSelectionOverlayView: NSView {
             }
         }
 
-        onSelectionChanged?(selectionRect)
+        onSelectionPreviewChanged?(selectionRect)
     }
 
     override func mouseUp(with event: NSEvent) {

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -118,7 +118,7 @@ final class CaptureCoordinator {
     func captureAllInOne() {
         pendingAction = .default
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
-            self?.showOverlay(mode: .area, isAllInOne: true)
+            self?.showFrozenAllInOneOverlay()
         }
     }
 
@@ -262,7 +262,49 @@ final class CaptureCoordinator {
         }
     }
 
-    private func showAllInOneToolbar(selectionRect: CGRect, screen: NSScreen) {
+    private func showFrozenAllInOneOverlay() {
+        dismissOverlay()
+
+        let frozenScreens = captureFrozenScreens()
+        guard !frozenScreens.isEmpty else {
+            showOverlay(mode: .area, isAllInOne: true)
+            return
+        }
+
+        showFreezeWindows(frozenScreens)
+        let frozenImagesByDisplayID = Dictionary(
+            uniqueKeysWithValues: frozenScreens.map { ($0.0.displayID, $0.1) }
+        )
+
+        for (screen, _) in frozenScreens {
+            let overlay = CaptureOverlayWindow(screen: screen, settings: settings)
+            overlay.onAreaSelected = { [weak self] rect, screen in
+                guard let self else { return }
+                self.dismissSelectionOverlays()
+                self.settings.lastCaptureSelection = .area(rect: rect, screenID: screen.displayID)
+                self.showAllInOneToolbar(
+                    selectionRect: rect,
+                    screen: screen,
+                    frozenImage: frozenImagesByDisplayID[screen.displayID]
+                )
+            }
+            overlay.onWindowSelected = { [weak self] windowID in
+                self?.dismissOverlay()
+                self?.performWindowCapture(windowID: windowID)
+            }
+            overlay.onCancelled = { [weak self] in
+                self?.dismissOverlay()
+            }
+            overlay.activate(mode: .area)
+            overlayWindows.append(overlay)
+        }
+    }
+
+    private func showAllInOneToolbar(
+        selectionRect: CGRect,
+        screen: NSScreen,
+        frozenImage: CGImage? = nil
+    ) {
         dismissAllInOneToolbar()
 
         let visiblePresets = settings.capturePresetsEnabled ? settings.visiblePresets : [.freeform]
@@ -280,27 +322,32 @@ final class CaptureCoordinator {
         toolbar.onArea = { [weak self] _ in
             guard let self else { return }
             self.dismissAllInOneToolbar()
-            self.showOverlay(mode: .area, isAllInOne: true)
+            self.dismissFreezeWindows()
+            self.captureAllInOne()
         }
         toolbar.onFullscreen = { [weak self] in
             guard let self else { return }
             self.dismissAllInOneToolbar()
+            self.dismissFreezeWindows()
             self.captureFullscreen()
         }
         toolbar.onWindow = { [weak self] in
             guard let self else { return }
             self.dismissAllInOneToolbar()
+            self.dismissFreezeWindows()
             self.captureWindow()
         }
         toolbar.onScrolling = { [weak self] rect in
             guard let self else { return }
             self.dismissAllInOneToolbar()
+            self.dismissFreezeWindows()
             self.settings.lastCaptureSelection = .area(rect: rect, screenID: screen.displayID)
             self.startScrollingCapture(rect: rect, screen: screen)
         }
         toolbar.onTimer = { [weak self] rect in
             guard let self else { return }
             self.dismissAllInOneToolbar()
+            self.dismissFreezeWindows()
             self.settings.lastCaptureSelection = .area(rect: rect, screenID: screen.displayID)
             self.runSelfTimerThenCapture(
                 rect: rect,
@@ -310,7 +357,16 @@ final class CaptureCoordinator {
         }
         toolbar.onOCR = { [weak self] rect in
             guard let self else { return }
+            if self.handleFrozenAllInOneAction(
+                rect: rect,
+                screen: screen,
+                frozenImage: frozenImage,
+                action: .ocr
+            ) {
+                return
+            }
             self.dismissAllInOneToolbar()
+            self.dismissFreezeWindows()
             self.settings.lastCaptureSelection = .area(rect: rect, screenID: screen.displayID)
             self.pendingAction = .ocr
             self.performAreaCapture(rect: rect, screen: screen)
@@ -318,25 +374,45 @@ final class CaptureCoordinator {
         toolbar.onRecording = { [weak self] rect in
             guard let self else { return }
             self.dismissAllInOneToolbar()
+            self.dismissFreezeWindows()
             self.settings.lastCaptureSelection = .area(rect: rect, screenID: screen.displayID)
             self.recordingCoordinator?.startRecordingFlow(withSelectedArea: rect, screen: screen)
         }
         toolbar.onAnnotate = { [weak self] rect in
             guard let self else { return }
+            if self.handleFrozenAllInOneAction(
+                rect: rect,
+                screen: screen,
+                frozenImage: frozenImage,
+                action: .inlineAnnotate
+            ) {
+                return
+            }
             self.dismissAllInOneToolbar()
+            self.dismissFreezeWindows()
             self.settings.lastCaptureSelection = .area(rect: rect, screenID: screen.displayID)
             self.pendingAction = .inlineAnnotate
             self.performAreaCapture(rect: rect, screen: screen)
         }
         toolbar.onCopy = { [weak self] rect in
             guard let self else { return }
+            if self.handleFrozenAllInOneAction(
+                rect: rect,
+                screen: screen,
+                frozenImage: frozenImage,
+                action: .clipboard
+            ) {
+                return
+            }
             self.dismissAllInOneToolbar()
+            self.dismissFreezeWindows()
             self.settings.lastCaptureSelection = .area(rect: rect, screenID: screen.displayID)
             self.pendingAction = .clipboard
             self.performAreaCapture(rect: rect, screen: screen)
         }
         toolbar.onCancel = { [weak self] in
             self?.dismissAllInOneToolbar()
+            self?.dismissFreezeWindows()
         }
 
         allInOneToolbarWindow = toolbar
@@ -383,19 +459,40 @@ final class CaptureCoordinator {
     private func showFrozenOverlay() {
         dismissOverlay()
 
-        var frozenScreens: [(NSScreen, CGImage)] = []
-        for screen in NSScreen.screens {
-            if let image = Self.syncCaptureDisplay(screen.displayID) {
-                frozenScreens.append((screen, image))
-            }
-        }
-
+        let frozenScreens = captureFrozenScreens()
         guard !frozenScreens.isEmpty else {
             showOverlay()
             return
         }
 
-        // Step 1: Create opaque freeze windows (bottom layer)
+        showFreezeWindows(frozenScreens)
+
+        // Step 2: Create transparent overlay windows (top layer) for selection
+        for (screen, frozenImage) in frozenScreens {
+            let overlay = CaptureOverlayWindow(screen: screen, settings: settings)
+            overlay.onAreaSelected = { [weak self] rect, screen in
+                self?.dismissOverlay()
+                self?.settings.lastCaptureSelection = .area(rect: rect, screenID: screen.displayID)
+                if let result = self?.frozenAreaResult(rect: rect, screen: screen, frozenImage: frozenImage) {
+                    self?.handleCaptureResult(result)
+                }
+            }
+            overlay.onCancelled = { [weak self] in
+                self?.dismissOverlay()
+            }
+            overlay.activate(mode: .area)
+            overlayWindows.append(overlay)
+        }
+    }
+
+    private func captureFrozenScreens() -> [(NSScreen, CGImage)] {
+        NSScreen.screens.compactMap { screen in
+            guard let image = Self.syncCaptureDisplay(screen.displayID) else { return nil }
+            return (screen, image)
+        }
+    }
+
+    private func showFreezeWindows(_ frozenScreens: [(NSScreen, CGImage)]) {
         for (screen, frozenImage) in frozenScreens {
             let freezeWin = NSWindow(
                 contentRect: screen.frame,
@@ -413,49 +510,9 @@ final class CaptureCoordinator {
             imageView.image = NSImage(cgImage: frozenImage, size: screen.frame.size)
             imageView.imageScaling = .scaleAxesIndependently
             freezeWin.contentView = imageView
-
-            // Pre-render and show
             freezeWin.displayIfNeeded()
             freezeWin.orderFrontRegardless()
             freezeWindows.append(freezeWin)
-        }
-
-        // Step 2: Create transparent overlay windows (top layer) for selection
-        for (screen, frozenImage) in frozenScreens {
-            let overlay = CaptureOverlayWindow(screen: screen, settings: settings)
-            overlay.onAreaSelected = { [weak self] rect, screen in
-                self?.dismissOverlay()
-                self?.settings.lastCaptureSelection = .area(rect: rect, screenID: screen.displayID)
-                let screenFrame = screen.frame
-                let scaleX = CGFloat(frozenImage.width) / screenFrame.width
-                let scaleY = CGFloat(frozenImage.height) / screenFrame.height
-                let cropRect = CGRect(
-                    x: rect.origin.x * scaleX,
-                    y: (screenFrame.height - rect.origin.y - rect.height) * scaleY,
-                    width: rect.width * scaleX,
-                    height: rect.height * scaleY
-                )
-                if let cropped = frozenImage.cropping(to: cropRect) {
-                    let captureRect = CGRect(
-                        x: rect.origin.x,
-                        y: screenFrame.height - rect.origin.y - rect.height,
-                        width: rect.width,
-                        height: rect.height
-                    )
-                    let result = CaptureResult(
-                        image: cropped,
-                        mode: .area,
-                        captureRect: captureRect,
-                        displayID: screen.displayID
-                    )
-                    self?.handleCaptureResult(result)
-                }
-            }
-            overlay.onCancelled = { [weak self] in
-                self?.dismissOverlay()
-            }
-            overlay.activate(mode: .area)
-            overlayWindows.append(overlay)
         }
     }
 
@@ -615,12 +672,18 @@ final class CaptureCoordinator {
     }
 
     private func dismissOverlay() {
+        dismissSelectionOverlays()
+        dismissFreezeWindows()
+    }
+
+    private func dismissSelectionOverlays() {
         for window in overlayWindows {
             window.deactivate()
         }
         overlayWindows.removeAll()
+    }
 
-        // Fade out freeze windows smoothly instead of instant removal
+    private func dismissFreezeWindows() {
         let windows = freezeWindows
         freezeWindows.removeAll()
         if windows.isEmpty { return }
@@ -760,6 +823,54 @@ final class CaptureCoordinator {
                 print("Area capture failed: \(error)")
             }
         }
+    }
+
+    private func handleFrozenAllInOneAction(
+        rect: CGRect,
+        screen: NSScreen,
+        frozenImage: CGImage?,
+        action: PostCaptureAction
+    ) -> Bool {
+        guard let frozenImage,
+              let result = frozenAreaResult(rect: rect, screen: screen, frozenImage: frozenImage) else {
+            return false
+        }
+
+        dismissAllInOneToolbar()
+        settings.lastCaptureSelection = .area(rect: rect, screenID: screen.displayID)
+        pendingAction = action
+        handleCaptureResult(result)
+        dismissFreezeWindows()
+        return true
+    }
+
+    private func frozenAreaResult(
+        rect: CGRect,
+        screen: NSScreen,
+        frozenImage: CGImage
+    ) -> CaptureResult? {
+        let cropRect = CaptureDisplayGeometry.frozenImageCropRect(
+            screenLocalRect: rect,
+            screenSize: screen.frame.size,
+            imageSize: CGSize(width: frozenImage.width, height: frozenImage.height)
+        )
+        guard !cropRect.isEmpty,
+              let cropped = frozenImage.cropping(to: cropRect) else {
+            return nil
+        }
+
+        let captureRect = CGRect(
+            x: rect.origin.x,
+            y: screen.frame.height - rect.origin.y - rect.height,
+            width: rect.width,
+            height: rect.height
+        )
+        return CaptureResult(
+            image: cropped,
+            mode: .area,
+            captureRect: captureRect,
+            displayID: screen.displayID
+        )
     }
 
     private func handleCaptureResult(_ result: CaptureResult) {

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -313,7 +313,8 @@ final class CaptureCoordinator {
             selectionRect: selectionRect,
             screen: screen,
             presets: visiblePresets,
-            activePreset: activePreset
+            activePreset: activePreset,
+            frozenImage: frozenImage
         )
         toolbar.onPresetChanged = { [weak self] preset in
             guard let self, self.settings.capturePresetsEnabled else { return }
@@ -371,6 +372,12 @@ final class CaptureCoordinator {
             self.pendingAction = .ocr
             self.performAreaCapture(rect: rect, screen: screen)
         }
+        toolbar.onOCRRendered = { [weak self] image, _ in
+            guard let self else { return }
+            self.dismissAllInOneToolbar()
+            self.dismissFreezeWindows()
+            self.ocrCoordinator?.startVisualOCR(image: image, anchorScreen: screen)
+        }
         toolbar.onRecording = { [weak self] rect in
             guard let self else { return }
             self.dismissAllInOneToolbar()
@@ -409,6 +416,12 @@ final class CaptureCoordinator {
             self.settings.lastCaptureSelection = .area(rect: rect, screenID: screen.displayID)
             self.pendingAction = .clipboard
             self.performAreaCapture(rect: rect, screen: screen)
+        }
+        toolbar.onCopyRendered = { [weak self] image, _ in
+            guard let self else { return }
+            self.dismissAllInOneToolbar()
+            self.dismissFreezeWindows()
+            self.copyRenderedImage(image)
         }
         toolbar.onCancel = { [weak self] in
             self?.dismissAllInOneToolbar()

--- a/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationDocument.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationDocument.swift
@@ -91,6 +91,18 @@ public final class AnnotationDocument {
         cropRect = nil
     }
 
+    /// Updates the backing image size while keeping annotation coordinates meaningful.
+    /// Used when the visible canvas grows or shifts around already-created objects.
+    public func updateImageSizePreservingObjects(size: CGSize, objectOffset: CGSize = .zero) {
+        imageSize = size
+        cropRect = nil
+        if objectOffset != .zero {
+            for object in objects {
+                object.move(by: objectOffset)
+            }
+        }
+    }
+
     private func currentSnapshot() -> Snapshot {
         Snapshot(objects: objects.map { $0.copy() }, cropRect: cropRect, imageSize: imageSize)
     }

--- a/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationObject.swift
@@ -4,7 +4,7 @@ import CoreGraphics
 import AppKit
 
 public enum AnnotationTool: String, CaseIterable, Sendable {
-    case select, arrow, rectangle, ellipse, text, freehand, pixelate, counter, highlighter
+    case select, arrow, line, rectangle, ellipse, text, freehand, pixelate, counter, highlighter
 }
 
 public enum RedactionMode: Int, Codable, CaseIterable, Sendable {

--- a/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationObject.swift
@@ -40,23 +40,97 @@ public struct StrokeStyle: Sendable {
     }
 }
 
-public enum AnnotationColor: String, CaseIterable, Sendable {
-    case red, orange, yellow, green, blue, purple, white, black
+public struct AnnotationColor: RawRepresentable, Codable, CaseIterable, Hashable, Sendable {
+    public let rawValue: String
+
+    public init?(rawValue: String) {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowercase = trimmed.lowercased()
+        if Self.presetColors.keys.contains(lowercase) {
+            self.rawValue = lowercase
+            return
+        }
+
+        let hex = trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed
+        guard hex.count == 6, UInt32(hex, radix: 16) != nil else { return nil }
+        self.rawValue = "#\(hex.uppercased())"
+    }
+
+    public init(nsColor: NSColor) {
+        guard let rgb = nsColor.usingColorSpace(.deviceRGB) else {
+            self.rawValue = Self.black.rawValue
+            return
+        }
+
+        self.rawValue = String(
+            format: "#%02X%02X%02X",
+            Int(round(rgb.redComponent * 255)),
+            Int(round(rgb.greenComponent * 255)),
+            Int(round(rgb.blueComponent * 255))
+        )
+    }
+
+    public static let red = AnnotationColor(rawValue: "red")!
+    public static let orange = AnnotationColor(rawValue: "orange")!
+    public static let yellow = AnnotationColor(rawValue: "yellow")!
+    public static let green = AnnotationColor(rawValue: "green")!
+    public static let blue = AnnotationColor(rawValue: "blue")!
+    public static let purple = AnnotationColor(rawValue: "purple")!
+    public static let white = AnnotationColor(rawValue: "white")!
+    public static let black = AnnotationColor(rawValue: "black")!
+
+    public static let allCases: [AnnotationColor] = [
+        .red, .orange, .yellow, .green, .blue, .purple, .white, .black,
+    ]
 
     public var cgColor: CGColor {
-        switch self {
-        case .red: return CGColor(red: 1, green: 0.23, blue: 0.19, alpha: 1)
-        case .orange: return CGColor(red: 1, green: 0.58, blue: 0, alpha: 1)
-        case .yellow: return CGColor(red: 1, green: 0.8, blue: 0, alpha: 1)
-        case .green: return CGColor(red: 0.2, green: 0.78, blue: 0.35, alpha: 1)
-        case .blue: return CGColor(red: 0, green: 0.48, blue: 1, alpha: 1)
-        case .purple: return CGColor(red: 0.69, green: 0.32, blue: 0.87, alpha: 1)
-        case .white: return CGColor(red: 1, green: 1, blue: 1, alpha: 1)
-        case .black: return CGColor(red: 0, green: 0, blue: 0, alpha: 1)
+        if let preset = Self.presetColors[rawValue] {
+            return preset
         }
+
+        let hex = rawValue.dropFirst()
+        guard let value = UInt32(hex, radix: 16) else {
+            return Self.presetColors[Self.black.rawValue]!
+        }
+
+        return CGColor(
+            red: CGFloat((value >> 16) & 0xFF) / 255,
+            green: CGFloat((value >> 8) & 0xFF) / 255,
+            blue: CGFloat(value & 0xFF) / 255,
+            alpha: 1
+        )
+    }
+
+    public var hexRGB: String {
+        if rawValue.hasPrefix("#") {
+            return rawValue
+        }
+
+        guard let components = cgColor.components, components.count >= 3 else { return "#000000" }
+        return String(
+            format: "#%02X%02X%02X",
+            Int(round(components[0] * 255)),
+            Int(round(components[1] * 255)),
+            Int(round(components[2] * 255))
+        )
     }
 
     public var nsColor: NSColor { NSColor(cgColor: cgColor)! }
+
+    public var displayName: String {
+        rawValue.hasPrefix("#") ? rawValue : rawValue.capitalized
+    }
+
+    private static let presetColors: [String: CGColor] = [
+        "red": CGColor(red: 1, green: 0.23, blue: 0.19, alpha: 1),
+        "orange": CGColor(red: 1, green: 0.58, blue: 0, alpha: 1),
+        "yellow": CGColor(red: 1, green: 0.8, blue: 0, alpha: 1),
+        "green": CGColor(red: 0.2, green: 0.78, blue: 0.35, alpha: 1),
+        "blue": CGColor(red: 0, green: 0.48, blue: 1, alpha: 1),
+        "purple": CGColor(red: 0.69, green: 0.32, blue: 0.87, alpha: 1),
+        "white": CGColor(red: 1, green: 1, blue: 1, alpha: 1),
+        "black": CGColor(red: 0, green: 0, blue: 0, alpha: 1),
+    ]
 }
 
 public protocol AnnotationObject: AnyObject, Sendable {

--- a/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationObject.swift
@@ -7,6 +7,20 @@ public enum AnnotationTool: String, CaseIterable, Sendable {
     case select, arrow, rectangle, ellipse, text, freehand, pixelate, counter, highlighter
 }
 
+public enum RedactionMode: Int, Codable, CaseIterable, Sendable {
+    case pixelate
+    case blur
+    case solid
+
+    public var label: String {
+        switch self {
+        case .pixelate: "Pixelate"
+        case .blur: "Blur"
+        case .solid: "Solid"
+        }
+    }
+}
+
 public struct ObjectID: Hashable, Sendable {
     public let value: UUID
     public init() { self.value = UUID() }

--- a/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationObject.swift
@@ -26,17 +26,42 @@ public struct ObjectID: Hashable, Sendable {
     public init() { self.value = UUID() }
 }
 
+public enum StrokePattern: String, Codable, CaseIterable, Sendable {
+    case solid
+    case dashed
+    case dotted
+
+    public func apply(to context: CGContext, lineWidth: CGFloat) {
+        switch self {
+        case .solid:
+            context.setLineDash(phase: 0, lengths: [])
+        case .dashed:
+            context.setLineDash(phase: 0, lengths: [lineWidth * 3, lineWidth * 2])
+        case .dotted:
+            context.setLineDash(phase: 0, lengths: [0, max(lineWidth * 2, 6)])
+        }
+    }
+}
+
 public struct StrokeStyle: Sendable {
     public var color: AnnotationColor
     public var lineWidth: CGFloat
     public var opacity: CGFloat
     public var filled: Bool
+    public var pattern: StrokePattern
 
-    public init(color: AnnotationColor = .red, lineWidth: CGFloat = 3, opacity: CGFloat = 1, filled: Bool = false) {
+    public init(
+        color: AnnotationColor = .red,
+        lineWidth: CGFloat = 3,
+        opacity: CGFloat = 1,
+        filled: Bool = false,
+        pattern: StrokePattern = .solid
+    ) {
         self.color = color
         self.lineWidth = lineWidth
         self.opacity = opacity
         self.filled = filled
+        self.pattern = pattern
     }
 }
 

--- a/Packages/AnnotationKit/Sources/AnnotationKit/Helpers/AnnotationGeometry.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/Helpers/AnnotationGeometry.swift
@@ -1,0 +1,55 @@
+import CoreGraphics
+import Foundation
+
+enum AnnotationGeometry {
+    static func distanceToQuadraticCurve(
+        point: CGPoint,
+        start: CGPoint,
+        control: CGPoint,
+        end: CGPoint
+    ) -> CGFloat {
+        var best = CGFloat.greatestFiniteMagnitude
+        var previous = start
+
+        for i in 1...32 {
+            let t = CGFloat(i) / 32
+            let current = quadraticPoint(t: t, start: start, control: control, end: end)
+            best = min(best, distanceToSegment(point: point, start: previous, end: current))
+            previous = current
+        }
+
+        return best
+    }
+
+    static func quadraticPoint(
+        t: CGFloat,
+        start: CGPoint,
+        control: CGPoint,
+        end: CGPoint
+    ) -> CGPoint {
+        let u = 1 - t
+        return CGPoint(
+            x: u * u * start.x + 2 * u * t * control.x + t * t * end.x,
+            y: u * u * start.y + 2 * u * t * control.y + t * t * end.y
+        )
+    }
+
+    static func distanceToSegment(point: CGPoint, start: CGPoint, end: CGPoint) -> CGFloat {
+        let dx = end.x - start.x
+        let dy = end.y - start.y
+        let lengthSq = dx * dx + dy * dy
+        guard lengthSq > 0 else { return hypot(point.x - start.x, point.y - start.y) }
+
+        var t = ((point.x - start.x) * dx + (point.y - start.y) * dy) / lengthSq
+        t = max(0, min(1, t))
+        let projection = CGPoint(x: start.x + t * dx, y: start.y + t * dy)
+        return hypot(point.x - projection.x, point.y - projection.y)
+    }
+
+    static func curveEndAngle(start: CGPoint, control: CGPoint?, end: CGPoint) -> CGFloat {
+        if let control, hypot(end.x - control.x, end.y - control.y) > 0 {
+            return atan2(end.y - control.y, end.x - control.x)
+        }
+        return atan2(end.y - start.y, end.x - start.x)
+    }
+}

--- a/Packages/AnnotationKit/Sources/AnnotationKit/Objects/ArrowObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/Objects/ArrowObject.swift
@@ -7,6 +7,7 @@ public final class ArrowObject: AnnotationObject, @unchecked Sendable {
     public var style: StrokeStyle
     public var start: CGPoint
     public var end: CGPoint
+    public var controlPoint: CGPoint?
     public var headLength: CGFloat = 15
 
     public init(start: CGPoint, end: CGPoint, style: StrokeStyle = StrokeStyle()) {
@@ -26,10 +27,27 @@ public final class ArrowObject: AnnotationObject, @unchecked Sendable {
         let minY = min(start.y, end.y) - hl
         let maxX = max(start.x, end.x) + hl
         let maxY = max(start.y, end.y) + hl
+        if let controlPoint {
+            return CGRect(
+                x: min(minX, controlPoint.x - hl),
+                y: min(minY, controlPoint.y - hl),
+                width: max(maxX, controlPoint.x + hl) - min(minX, controlPoint.x - hl),
+                height: max(maxY, controlPoint.y + hl) - min(minY, controlPoint.y - hl)
+            )
+        }
         return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
     }
 
     public func hitTest(point: CGPoint, threshold: CGFloat) -> Bool {
+        if let controlPoint {
+            return AnnotationGeometry.distanceToQuadraticCurve(
+                point: point,
+                start: start,
+                control: controlPoint,
+                end: end
+            ) <= threshold + style.lineWidth / 2
+        }
+
         let dx = end.x - start.x
         let dy = end.y - start.y
         let lengthSq = dx * dx + dy * dy
@@ -48,10 +66,17 @@ public final class ArrowObject: AnnotationObject, @unchecked Sendable {
         ctx.setLineWidth(style.lineWidth)
         ctx.setAlpha(style.opacity)
         ctx.setLineCap(.round)
+        style.pattern.apply(to: ctx, lineWidth: style.lineWidth)
         ctx.move(to: start)
-        ctx.addLine(to: end)
+        if let controlPoint {
+            ctx.addQuadCurve(to: end, control: controlPoint)
+        } else {
+            ctx.addLine(to: end)
+        }
         ctx.strokePath()
-        let angle = atan2(end.y - start.y, end.x - start.x)
+
+        ctx.setLineDash(phase: 0, lengths: [])
+        let angle = AnnotationGeometry.curveEndAngle(start: start, control: controlPoint, end: end)
         let headAngle: CGFloat = .pi / 6
         let hl = effectiveHeadLength
         let p1 = CGPoint(x: end.x - hl * cos(angle - headAngle), y: end.y - hl * sin(angle - headAngle))
@@ -65,10 +90,13 @@ public final class ArrowObject: AnnotationObject, @unchecked Sendable {
     public func move(by delta: CGSize) {
         start.x += delta.width; start.y += delta.height
         end.x += delta.width; end.y += delta.height
+        controlPoint?.x += delta.width
+        controlPoint?.y += delta.height
     }
 
     public func copy() -> any AnnotationObject {
         let c = ArrowObject(start: start, end: end, style: style)
+        c.controlPoint = controlPoint
         c.headLength = headLength
         return c
     }

--- a/Packages/AnnotationKit/Sources/AnnotationKit/Objects/LineObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/Objects/LineObject.swift
@@ -6,6 +6,7 @@ public final class LineObject: AnnotationObject, @unchecked Sendable {
     public var style: StrokeStyle
     public var start: CGPoint
     public var end: CGPoint
+    public var controlPoint: CGPoint?
 
     public init(start: CGPoint, end: CGPoint, style: StrokeStyle = StrokeStyle()) {
         self.start = start
@@ -19,10 +20,27 @@ public final class LineObject: AnnotationObject, @unchecked Sendable {
         let minY = min(start.y, end.y) - padding
         let maxX = max(start.x, end.x) + padding
         let maxY = max(start.y, end.y) + padding
+        if let controlPoint {
+            return CGRect(
+                x: min(minX, controlPoint.x - padding),
+                y: min(minY, controlPoint.y - padding),
+                width: max(maxX, controlPoint.x + padding) - min(minX, controlPoint.x - padding),
+                height: max(maxY, controlPoint.y + padding) - min(minY, controlPoint.y - padding)
+            )
+        }
         return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
     }
 
     public func hitTest(point: CGPoint, threshold: CGFloat) -> Bool {
+        if let controlPoint {
+            return Self.distanceToQuadraticCurve(
+                point: point,
+                start: start,
+                control: controlPoint,
+                end: end
+            ) <= threshold + style.lineWidth / 2
+        }
+
         let dx = end.x - start.x
         let dy = end.y - start.y
         let lengthSq = dx * dx + dy * dy
@@ -41,7 +59,11 @@ public final class LineObject: AnnotationObject, @unchecked Sendable {
         ctx.setAlpha(style.opacity)
         ctx.setLineCap(.round)
         ctx.move(to: start)
-        ctx.addLine(to: end)
+        if let controlPoint {
+            ctx.addQuadCurve(to: end, control: controlPoint)
+        } else {
+            ctx.addLine(to: end)
+        }
         ctx.strokePath()
         ctx.restoreGState()
     }
@@ -51,9 +73,57 @@ public final class LineObject: AnnotationObject, @unchecked Sendable {
         start.y += delta.height
         end.x += delta.width
         end.y += delta.height
+        controlPoint?.x += delta.width
+        controlPoint?.y += delta.height
     }
 
     public func copy() -> any AnnotationObject {
-        LineObject(start: start, end: end, style: style)
+        let copy = LineObject(start: start, end: end, style: style)
+        copy.controlPoint = controlPoint
+        return copy
+    }
+
+    private static func distanceToQuadraticCurve(
+        point: CGPoint,
+        start: CGPoint,
+        control: CGPoint,
+        end: CGPoint
+    ) -> CGFloat {
+        var best = CGFloat.greatestFiniteMagnitude
+        var previous = start
+
+        for i in 1...32 {
+            let t = CGFloat(i) / 32
+            let current = quadraticPoint(t: t, start: start, control: control, end: end)
+            best = min(best, distanceToSegment(point: point, start: previous, end: current))
+            previous = current
+        }
+
+        return best
+    }
+
+    private static func quadraticPoint(
+        t: CGFloat,
+        start: CGPoint,
+        control: CGPoint,
+        end: CGPoint
+    ) -> CGPoint {
+        let u = 1 - t
+        return CGPoint(
+            x: u * u * start.x + 2 * u * t * control.x + t * t * end.x,
+            y: u * u * start.y + 2 * u * t * control.y + t * t * end.y
+        )
+    }
+
+    private static func distanceToSegment(point: CGPoint, start: CGPoint, end: CGPoint) -> CGFloat {
+        let dx = end.x - start.x
+        let dy = end.y - start.y
+        let lengthSq = dx * dx + dy * dy
+        guard lengthSq > 0 else { return hypot(point.x - start.x, point.y - start.y) }
+
+        var t = ((point.x - start.x) * dx + (point.y - start.y) * dy) / lengthSq
+        t = max(0, min(1, t))
+        let projection = CGPoint(x: start.x + t * dx, y: start.y + t * dy)
+        return hypot(point.x - projection.x, point.y - projection.y)
     }
 }

--- a/Packages/AnnotationKit/Sources/AnnotationKit/Objects/LineObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/Objects/LineObject.swift
@@ -1,0 +1,59 @@
+import Foundation
+import CoreGraphics
+
+public final class LineObject: AnnotationObject, @unchecked Sendable {
+    public let id = ObjectID()
+    public var style: StrokeStyle
+    public var start: CGPoint
+    public var end: CGPoint
+
+    public init(start: CGPoint, end: CGPoint, style: StrokeStyle = StrokeStyle()) {
+        self.start = start
+        self.end = end
+        self.style = style
+    }
+
+    public var bounds: CGRect {
+        let padding = max(style.lineWidth, 1)
+        let minX = min(start.x, end.x) - padding
+        let minY = min(start.y, end.y) - padding
+        let maxX = max(start.x, end.x) + padding
+        let maxY = max(start.y, end.y) + padding
+        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    }
+
+    public func hitTest(point: CGPoint, threshold: CGFloat) -> Bool {
+        let dx = end.x - start.x
+        let dy = end.y - start.y
+        let lengthSq = dx * dx + dy * dy
+        guard lengthSq > 0 else { return hypot(point.x - start.x, point.y - start.y) <= threshold }
+
+        var t = ((point.x - start.x) * dx + (point.y - start.y) * dy) / lengthSq
+        t = max(0, min(1, t))
+        let projection = CGPoint(x: start.x + t * dx, y: start.y + t * dy)
+        return hypot(point.x - projection.x, point.y - projection.y) <= threshold + style.lineWidth / 2
+    }
+
+    public func render(in ctx: CGContext) {
+        ctx.saveGState()
+        ctx.setStrokeColor(style.color.cgColor)
+        ctx.setLineWidth(style.lineWidth)
+        ctx.setAlpha(style.opacity)
+        ctx.setLineCap(.round)
+        ctx.move(to: start)
+        ctx.addLine(to: end)
+        ctx.strokePath()
+        ctx.restoreGState()
+    }
+
+    public func move(by delta: CGSize) {
+        start.x += delta.width
+        start.y += delta.height
+        end.x += delta.width
+        end.y += delta.height
+    }
+
+    public func copy() -> any AnnotationObject {
+        LineObject(start: start, end: end, style: style)
+    }
+}

--- a/Packages/AnnotationKit/Sources/AnnotationKit/Objects/LineObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/Objects/LineObject.swift
@@ -33,7 +33,7 @@ public final class LineObject: AnnotationObject, @unchecked Sendable {
 
     public func hitTest(point: CGPoint, threshold: CGFloat) -> Bool {
         if let controlPoint {
-            return Self.distanceToQuadraticCurve(
+            return AnnotationGeometry.distanceToQuadraticCurve(
                 point: point,
                 start: start,
                 control: controlPoint,
@@ -58,6 +58,7 @@ public final class LineObject: AnnotationObject, @unchecked Sendable {
         ctx.setLineWidth(style.lineWidth)
         ctx.setAlpha(style.opacity)
         ctx.setLineCap(.round)
+        style.pattern.apply(to: ctx, lineWidth: style.lineWidth)
         ctx.move(to: start)
         if let controlPoint {
             ctx.addQuadCurve(to: end, control: controlPoint)
@@ -81,49 +82,5 @@ public final class LineObject: AnnotationObject, @unchecked Sendable {
         let copy = LineObject(start: start, end: end, style: style)
         copy.controlPoint = controlPoint
         return copy
-    }
-
-    private static func distanceToQuadraticCurve(
-        point: CGPoint,
-        start: CGPoint,
-        control: CGPoint,
-        end: CGPoint
-    ) -> CGFloat {
-        var best = CGFloat.greatestFiniteMagnitude
-        var previous = start
-
-        for i in 1...32 {
-            let t = CGFloat(i) / 32
-            let current = quadraticPoint(t: t, start: start, control: control, end: end)
-            best = min(best, distanceToSegment(point: point, start: previous, end: current))
-            previous = current
-        }
-
-        return best
-    }
-
-    private static func quadraticPoint(
-        t: CGFloat,
-        start: CGPoint,
-        control: CGPoint,
-        end: CGPoint
-    ) -> CGPoint {
-        let u = 1 - t
-        return CGPoint(
-            x: u * u * start.x + 2 * u * t * control.x + t * t * end.x,
-            y: u * u * start.y + 2 * u * t * control.y + t * t * end.y
-        )
-    }
-
-    private static func distanceToSegment(point: CGPoint, start: CGPoint, end: CGPoint) -> CGFloat {
-        let dx = end.x - start.x
-        let dy = end.y - start.y
-        let lengthSq = dx * dx + dy * dy
-        guard lengthSq > 0 else { return hypot(point.x - start.x, point.y - start.y) }
-
-        var t = ((point.x - start.x) * dx + (point.y - start.y) * dy) / lengthSq
-        t = max(0, min(1, t))
-        let projection = CGPoint(x: start.x + t * dx, y: start.y + t * dy)
-        return hypot(point.x - projection.x, point.y - projection.y)
     }
 }

--- a/Packages/AnnotationKit/Sources/AnnotationKit/Objects/PixelateObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/Objects/PixelateObject.swift
@@ -76,33 +76,85 @@ public final class PixelateObject: AnnotationObject, @unchecked Sendable {
 
         guard !cropRect.isEmpty, let cropped = sourceImage.cropping(to: cropRect) else { return }
 
-        let ciImage = CIImage(cgImage: cropped)
-        let outputImage: CIImage?
+        let redacted: CGImage?
 
         switch mode {
         case .pixelate:
-            let filter = CIFilter(name: "CIPixellate")
-            filter?.setValue(ciImage, forKey: kCIInputImageKey)
-            filter?.setValue(blockSize, forKey: kCIInputScaleKey)
-            outputImage = filter?.outputImage
+            redacted = Self.makePixelatedImage(from: cropped, blockSize: blockSize)
         case .blur:
+            let ciImage = CIImage(cgImage: cropped)
             let filter = CIFilter(name: "CIGaussianBlur")
             filter?.setValue(ciImage.clampedToExtent(), forKey: kCIInputImageKey)
             filter?.setValue(max(4, blockSize * 0.9), forKey: kCIInputRadiusKey)
-            outputImage = filter?.outputImage?.cropped(to: ciImage.extent)
+            if let outputImage = filter?.outputImage?.cropped(to: ciImage.extent) {
+                redacted = Self.ciContext.createCGImage(outputImage, from: ciImage.extent)
+            } else {
+                redacted = nil
+            }
         case .solid:
-            outputImage = nil
+            redacted = nil
         }
 
-        guard let outputImage,
-              let redacted = Self.ciContext.createCGImage(outputImage, from: ciImage.extent) else { return }
+        guard let redacted else { return }
 
         // Draw pixelated result — flip for CGContext.draw in flipped coordinate system
         ctx.saveGState()
+        if mode == .pixelate {
+            ctx.interpolationQuality = .none
+        }
         ctx.translateBy(x: rect.origin.x, y: rect.origin.y + rect.height)
         ctx.scaleBy(x: 1, y: -1)
         ctx.draw(redacted, in: CGRect(origin: .zero, size: rect.size))
         ctx.restoreGState()
+    }
+
+    private static func makePixelatedImage(from image: CGImage, blockSize: CGFloat) -> CGImage? {
+        let block = max(4, Int(blockSize.rounded()))
+        let tinyWidth = max(1, image.width / block)
+        let tinyHeight = max(1, image.height / block)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+
+        guard let downsampledContext = CGContext(
+            data: nil,
+            width: tinyWidth,
+            height: tinyHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ) else { return nil }
+        downsampledContext.interpolationQuality = .low
+        downsampledContext.draw(image, in: CGRect(x: 0, y: 0, width: tinyWidth, height: tinyHeight))
+        guard let downsampled = downsampledContext.makeImage() else { return nil }
+
+        let chunkyWidth = max(1, tinyWidth / 2)
+        let chunkyHeight = max(1, tinyHeight / 2)
+        guard let chunkyContext = CGContext(
+            data: nil,
+            width: chunkyWidth,
+            height: chunkyHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ) else { return nil }
+        chunkyContext.interpolationQuality = .low
+        chunkyContext.draw(downsampled, in: CGRect(x: 0, y: 0, width: chunkyWidth, height: chunkyHeight))
+        guard let chunky = chunkyContext.makeImage() else { return nil }
+
+        guard let outputContext = CGContext(
+            data: nil,
+            width: max(1, image.width),
+            height: max(1, image.height),
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ) else { return nil }
+        outputContext.interpolationQuality = .none
+        outputContext.draw(chunky, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
+        return outputContext.makeImage()
     }
 
     public func move(by delta: CGSize) {

--- a/Packages/AnnotationKit/Sources/AnnotationKit/Objects/PixelateObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/Objects/PixelateObject.swift
@@ -3,15 +3,19 @@ import CoreGraphics
 import CoreImage
 
 public final class PixelateObject: AnnotationObject, @unchecked Sendable {
+    private static let ciContext = CIContext()
+
     public let id = ObjectID()
     public var style: StrokeStyle
     public var rect: CGRect
     public var blockSize: CGFloat = 12
+    public var mode: RedactionMode
 
-    public init(rect: CGRect, blockSize: CGFloat = 12) {
+    public init(rect: CGRect, blockSize: CGFloat = 12, mode: RedactionMode = .pixelate) {
         self.rect = rect
         self.style = StrokeStyle()
         self.blockSize = blockSize
+        self.mode = mode
     }
 
     public var bounds: CGRect { rect }
@@ -22,31 +26,43 @@ public final class PixelateObject: AnnotationObject, @unchecked Sendable {
 
     public func render(in ctx: CGContext) {
         ctx.saveGState()
-        ctx.setFillColor(CGColor(gray: 0.5, alpha: 0.3))
-        ctx.fill(rect)
-        ctx.setStrokeColor(CGColor(gray: 0.5, alpha: 0.2))
-        ctx.setLineWidth(0.5)
-        var x = rect.minX
-        while x <= rect.maxX {
-            ctx.move(to: CGPoint(x: x, y: rect.minY))
-            ctx.addLine(to: CGPoint(x: x, y: rect.maxY))
-            x += blockSize
+        switch mode {
+        case .solid:
+            ctx.setAlpha(style.opacity)
+            ctx.setFillColor(style.color.cgColor)
+            ctx.fill(rect)
+        case .pixelate, .blur:
+            ctx.setFillColor(CGColor(gray: 0.5, alpha: 0.3))
+            ctx.fill(rect)
+            ctx.setStrokeColor(CGColor(gray: 0.5, alpha: 0.2))
+            ctx.setLineWidth(0.5)
+            var x = rect.minX
+            while x <= rect.maxX {
+                ctx.move(to: CGPoint(x: x, y: rect.minY))
+                ctx.addLine(to: CGPoint(x: x, y: rect.maxY))
+                x += blockSize
+            }
+            var y = rect.minY
+            while y <= rect.maxY {
+                ctx.move(to: CGPoint(x: rect.minX, y: y))
+                ctx.addLine(to: CGPoint(x: rect.maxX, y: y))
+                y += blockSize
+            }
+            ctx.strokePath()
         }
-        var y = rect.minY
-        while y <= rect.maxY {
-            ctx.move(to: CGPoint(x: rect.minX, y: y))
-            ctx.addLine(to: CGPoint(x: rect.maxX, y: y))
-            y += blockSize
-        }
-        ctx.strokePath()
         ctx.restoreGState()
     }
 
-    /// Apply actual pixelation using CIFilter on the source image region.
+    /// Apply the selected redaction filter on the source image region.
     /// `rect` is in image coordinates (top-left origin, matching source image pixel dimensions).
     /// The CGContext is assumed to be in a flipped coordinate system (isFlipped NSView).
     public func renderWithSource(in ctx: CGContext, sourceImage: CGImage) {
         guard rect.width > 0, rect.height > 0 else { return }
+
+        if mode == .solid {
+            render(in: ctx)
+            return
+        }
 
         let imgH = CGFloat(sourceImage.height)
 
@@ -60,21 +76,32 @@ public final class PixelateObject: AnnotationObject, @unchecked Sendable {
 
         guard !cropRect.isEmpty, let cropped = sourceImage.cropping(to: cropRect) else { return }
 
-        // Apply pixelate filter
         let ciImage = CIImage(cgImage: cropped)
-        let filter = CIFilter(name: "CIPixellate")!
-        filter.setValue(ciImage, forKey: kCIInputImageKey)
-        filter.setValue(blockSize, forKey: kCIInputScaleKey)
+        let outputImage: CIImage?
 
-        let ciCtx = CIContext()
-        guard let output = filter.outputImage,
-              let pixelated = ciCtx.createCGImage(output, from: ciImage.extent) else { return }
+        switch mode {
+        case .pixelate:
+            let filter = CIFilter(name: "CIPixellate")
+            filter?.setValue(ciImage, forKey: kCIInputImageKey)
+            filter?.setValue(blockSize, forKey: kCIInputScaleKey)
+            outputImage = filter?.outputImage
+        case .blur:
+            let filter = CIFilter(name: "CIGaussianBlur")
+            filter?.setValue(ciImage.clampedToExtent(), forKey: kCIInputImageKey)
+            filter?.setValue(max(4, blockSize * 0.9), forKey: kCIInputRadiusKey)
+            outputImage = filter?.outputImage?.cropped(to: ciImage.extent)
+        case .solid:
+            outputImage = nil
+        }
+
+        guard let outputImage,
+              let redacted = Self.ciContext.createCGImage(outputImage, from: ciImage.extent) else { return }
 
         // Draw pixelated result — flip for CGContext.draw in flipped coordinate system
         ctx.saveGState()
         ctx.translateBy(x: rect.origin.x, y: rect.origin.y + rect.height)
         ctx.scaleBy(x: 1, y: -1)
-        ctx.draw(pixelated, in: CGRect(origin: .zero, size: rect.size))
+        ctx.draw(redacted, in: CGRect(origin: .zero, size: rect.size))
         ctx.restoreGState()
     }
 
@@ -84,6 +111,8 @@ public final class PixelateObject: AnnotationObject, @unchecked Sendable {
     }
 
     public func copy() -> any AnnotationObject {
-        PixelateObject(rect: rect, blockSize: blockSize)
+        let copy = PixelateObject(rect: rect, blockSize: blockSize, mode: mode)
+        copy.style = style
+        return copy
     }
 }

--- a/Packages/AnnotationKit/Sources/AnnotationKit/Objects/PixelateObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/Objects/PixelateObject.swift
@@ -3,8 +3,6 @@ import CoreGraphics
 import CoreImage
 
 public final class PixelateObject: AnnotationObject, @unchecked Sendable {
-    private static let ciContext = CIContext()
-
     public let id = ObjectID()
     public var style: StrokeStyle
     public var rect: CGRect
@@ -87,7 +85,7 @@ public final class PixelateObject: AnnotationObject, @unchecked Sendable {
             filter?.setValue(ciImage.clampedToExtent(), forKey: kCIInputImageKey)
             filter?.setValue(max(4, blockSize * 0.9), forKey: kCIInputRadiusKey)
             if let outputImage = filter?.outputImage?.cropped(to: ciImage.extent) {
-                redacted = Self.ciContext.createCGImage(outputImage, from: ciImage.extent)
+                redacted = CIContext().createCGImage(outputImage, from: ciImage.extent)
             } else {
                 redacted = nil
             }

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationDocumentTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationDocumentTests.swift
@@ -98,4 +98,29 @@ struct AnnotationDocumentTests {
         #expect(doc.objects.count == 0)
         #expect(doc.cropRect == nil)
     }
+
+    @Test("Update image size preserves and offsets objects without pushing undo")
+    @MainActor
+    func updateImageSizePreservesObjects() {
+        let doc = AnnotationDocument(imageSize: CGSize(width: 400, height: 300))
+        let line = LineObject(start: CGPoint(x: 20, y: 30), end: CGPoint(x: 120, y: 30))
+        doc.addObject(line)
+        doc.setCropRect(CGRect(x: 5, y: 5, width: 50, height: 50))
+        doc.undo()
+        #expect(doc.canUndo)
+
+        doc.updateImageSizePreservingObjects(
+            size: CGSize(width: 520, height: 380),
+            objectOffset: CGSize(width: 15, height: 25)
+        )
+
+        #expect(doc.imageSize == CGSize(width: 520, height: 380))
+        #expect(doc.cropRect == nil)
+        let movedLine = doc.objects[0] as? LineObject
+        #expect(movedLine?.start == CGPoint(x: 35, y: 55))
+        #expect(movedLine?.end == CGPoint(x: 135, y: 55))
+
+        doc.undo()
+        #expect(doc.objects.count == 0)
+    }
 }

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationObjectTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationObjectTests.swift
@@ -78,6 +78,37 @@ struct LineObjectTests {
         #expect(line.start == CGPoint(x: 15, y: 15))
         #expect(line.end == CGPoint(x: 55, y: 55))
     }
+
+    @Test("Line control point bends hit testing and travels with the line")
+    func controlPointBendsLine() {
+        let line = LineObject(
+            start: CGPoint(x: 0, y: 0),
+            end: CGPoint(x: 100, y: 0),
+            style: StrokeStyle(lineWidth: 4)
+        )
+        line.controlPoint = CGPoint(x: 50, y: 80)
+
+        #expect(line.bounds.contains(CGPoint(x: 50, y: 80)))
+        #expect(line.hitTest(point: CGPoint(x: 50, y: 40), threshold: 4))
+        #expect(!line.hitTest(point: CGPoint(x: 50, y: 0), threshold: 4))
+
+        line.move(by: CGSize(width: 10, height: -5))
+        #expect(line.start == CGPoint(x: 10, y: -5))
+        #expect(line.end == CGPoint(x: 110, y: -5))
+        #expect(line.controlPoint == CGPoint(x: 60, y: 75))
+    }
+
+    @Test("Line copy preserves bend state")
+    func copyPreservesControlPoint() {
+        let line = LineObject(start: CGPoint(x: 0, y: 0), end: CGPoint(x: 100, y: 0))
+        line.controlPoint = CGPoint(x: 40, y: 60)
+
+        let copy = line.copy() as? LineObject
+
+        #expect(copy?.start == line.start)
+        #expect(copy?.end == line.end)
+        #expect(copy?.controlPoint == line.controlPoint)
+    }
 }
 
 @Suite("ArrowObject")

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationObjectTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationObjectTests.swift
@@ -20,6 +20,26 @@ struct AnnotationObjectTests {
         #expect(style.opacity == 1.0)
     }
 
+    @Test("AnnotationColor keeps preset raw values")
+    func presetColorRawValues() {
+        #expect(AnnotationColor(rawValue: "red") == .red)
+        #expect(AnnotationColor.blue.rawValue == "blue")
+        #expect(AnnotationColor.allCases.contains(.purple))
+    }
+
+    @Test("AnnotationColor supports custom hex colors")
+    func customHexColor() {
+        let color = AnnotationColor(rawValue: "#3366CC")
+        #expect(color?.rawValue == "#3366CC")
+        #expect(color?.hexRGB == "#3366CC")
+
+        let components = color?.cgColor.components
+        #expect(components?[0] == 0.2)
+        #expect(components?[1] == 0.4)
+        #expect(components?[2] == 0.8)
+        #expect(components?[3] == 1.0)
+    }
+
     @Test("ObjectID is unique")
     func uniqueIDs() {
         let id1 = ObjectID()

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationObjectTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationObjectTests.swift
@@ -8,8 +8,8 @@ import CoreGraphics
 struct AnnotationObjectTests {
     @Test("AnnotationTool has all cases")
     func tools() {
-        let tools: [AnnotationTool] = [.select, .arrow, .rectangle, .ellipse, .text, .freehand, .pixelate, .counter, .highlighter]
-        #expect(tools.count == 9)
+        let tools: [AnnotationTool] = [.select, .arrow, .line, .rectangle, .ellipse, .text, .freehand, .pixelate, .counter, .highlighter]
+        #expect(tools.count == 10)
     }
 
     @Test("StrokeStyle has defaults")
@@ -45,6 +45,38 @@ struct AnnotationObjectTests {
         let id1 = ObjectID()
         let id2 = ObjectID()
         #expect(id1 != id2)
+    }
+}
+
+@Suite("LineObject")
+struct LineObjectTests {
+    @Test("Line has bounds padded by stroke width")
+    func bounds() {
+        let line = LineObject(
+            start: CGPoint(x: 10, y: 20),
+            end: CGPoint(x: 110, y: 70),
+            style: StrokeStyle(lineWidth: 6)
+        )
+        let b = line.bounds
+        #expect(b.minX <= 10)
+        #expect(b.minY <= 20)
+        #expect(b.maxX >= 110)
+        #expect(b.maxY >= 70)
+    }
+
+    @Test("Line hit test follows the segment")
+    func hitTest() {
+        let line = LineObject(start: CGPoint(x: 0, y: 0), end: CGPoint(x: 100, y: 0))
+        #expect(line.hitTest(point: CGPoint(x: 50, y: 0), threshold: 5))
+        #expect(!line.hitTest(point: CGPoint(x: 50, y: 20), threshold: 5))
+    }
+
+    @Test("Line move keeps endpoints together")
+    func move() {
+        let line = LineObject(start: CGPoint(x: 10, y: 10), end: CGPoint(x: 50, y: 50))
+        line.move(by: CGSize(width: 5, height: 5))
+        #expect(line.start == CGPoint(x: 15, y: 15))
+        #expect(line.end == CGPoint(x: 55, y: 55))
     }
 }
 

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationObjectTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationObjectTests.swift
@@ -18,6 +18,17 @@ struct AnnotationObjectTests {
         #expect(style.color == .red)
         #expect(style.lineWidth == 3.0)
         #expect(style.opacity == 1.0)
+        #expect(style.pattern == .solid)
+    }
+
+    @Test("StrokeStyle stores non-solid line patterns")
+    func strokePatterns() {
+        let dashed = StrokeStyle(pattern: .dashed)
+        let dotted = StrokeStyle(pattern: .dotted)
+
+        #expect(StrokePattern.allCases == [.solid, .dashed, .dotted])
+        #expect(dashed.pattern == .dashed)
+        #expect(dotted.pattern == .dotted)
     }
 
     @Test("AnnotationColor keeps preset raw values")
@@ -102,12 +113,14 @@ struct LineObjectTests {
     func copyPreservesControlPoint() {
         let line = LineObject(start: CGPoint(x: 0, y: 0), end: CGPoint(x: 100, y: 0))
         line.controlPoint = CGPoint(x: 40, y: 60)
+        line.style.pattern = .dashed
 
         let copy = line.copy() as? LineObject
 
         #expect(copy?.start == line.start)
         #expect(copy?.end == line.end)
         #expect(copy?.controlPoint == line.controlPoint)
+        #expect(copy?.style.pattern == .dashed)
     }
 }
 
@@ -136,6 +149,42 @@ struct ArrowObjectTests {
         arrow.move(by: CGSize(width: 5, height: 5))
         #expect(arrow.start == CGPoint(x: 15, y: 15))
         #expect(arrow.end == CGPoint(x: 55, y: 55))
+    }
+
+    @Test("Arrow control point bends hit testing and travels with the arrow")
+    func controlPointBendsArrow() {
+        let arrow = ArrowObject(
+            start: CGPoint(x: 0, y: 0),
+            end: CGPoint(x: 100, y: 0),
+            style: StrokeStyle(lineWidth: 4)
+        )
+        arrow.controlPoint = CGPoint(x: 50, y: 80)
+
+        #expect(arrow.bounds.contains(CGPoint(x: 50, y: 80)))
+        #expect(arrow.hitTest(point: CGPoint(x: 50, y: 40), threshold: 4))
+        #expect(!arrow.hitTest(point: CGPoint(x: 50, y: 0), threshold: 4))
+
+        arrow.move(by: CGSize(width: 10, height: -5))
+        #expect(arrow.start == CGPoint(x: 10, y: -5))
+        #expect(arrow.end == CGPoint(x: 110, y: -5))
+        #expect(arrow.controlPoint == CGPoint(x: 60, y: 75))
+    }
+
+    @Test("Arrow copy preserves bend and stroke pattern")
+    func copyPreservesControlPoint() {
+        let arrow = ArrowObject(
+            start: CGPoint(x: 0, y: 0),
+            end: CGPoint(x: 100, y: 0),
+            style: StrokeStyle(pattern: .dotted)
+        )
+        arrow.controlPoint = CGPoint(x: 60, y: 40)
+
+        let copy = arrow.copy() as? ArrowObject
+
+        #expect(copy?.start == arrow.start)
+        #expect(copy?.end == arrow.end)
+        #expect(copy?.controlPoint == arrow.controlPoint)
+        #expect(copy?.style.pattern == .dotted)
     }
 }
 

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/RedactionObjectTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/RedactionObjectTests.swift
@@ -55,6 +55,21 @@ struct RedactionObjectTests {
         #expect(sampleRGBA(rendered, x: 7, y: 7) != sampleRGBA(source, x: 7, y: 7))
         #expect(sampleRGBA(rendered, x: 1, y: 1) == sampleRGBA(source, x: 1, y: 1))
     }
+
+    @Test("Pixelate redaction renders repeated block pixels")
+    func pixelateRedactionRendersBlockPixels() throws {
+        let source = try makeHorizontalGradientImage(width: 16, height: 16)
+        let redaction = PixelateObject(
+            rect: CGRect(x: 0, y: 0, width: 16, height: 16),
+            blockSize: 4,
+            mode: .pixelate
+        )
+
+        let rendered = try #require(AnnotationRenderer.render(sourceImage: source, objects: [redaction]))
+
+        #expect(sampleRGBA(rendered, x: 1, y: 8) == sampleRGBA(rendered, x: 6, y: 8))
+        #expect(sampleRGBA(rendered, x: 1, y: 8) != sampleRGBA(rendered, x: 10, y: 8))
+    }
 }
 
 private struct RGBA: Equatable {
@@ -77,6 +92,16 @@ private func makeSplitImage(width: Int, height: Int) throws -> CGImage {
     context.fill(CGRect(x: 0, y: 0, width: width, height: height))
     context.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: 1))
     context.fill(CGRect(x: width / 2, y: 0, width: width / 2, height: height))
+    return try #require(context.makeImage())
+}
+
+private func makeHorizontalGradientImage(width: Int, height: Int) throws -> CGImage {
+    let context = try #require(makeBitmapContext(width: width, height: height))
+    for x in 0..<width {
+        let gray = CGFloat(x) / CGFloat(max(1, width - 1))
+        context.setFillColor(CGColor(red: gray, green: gray, blue: gray, alpha: 1))
+        context.fill(CGRect(x: x, y: 0, width: 1, height: height))
+    }
     return try #require(context.makeImage())
 }
 

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/RedactionObjectTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/RedactionObjectTests.swift
@@ -1,0 +1,108 @@
+import Testing
+import Foundation
+import CoreGraphics
+@testable import AnnotationKit
+
+@Suite("Redaction object")
+struct RedactionObjectTests {
+    @Test("Pixelate object copy preserves redaction mode")
+    func copyPreservesRedactionMode() {
+        let original = PixelateObject(
+            rect: CGRect(x: 10, y: 12, width: 40, height: 30),
+            blockSize: 16,
+            mode: .blur
+        )
+
+        let copied = original.copy()
+        guard let redactionCopy = copied as? PixelateObject else {
+            Issue.record("copy() did not return PixelateObject")
+            return
+        }
+
+        #expect(redactionCopy.id != original.id)
+        #expect(redactionCopy.rect == original.rect)
+        #expect(redactionCopy.blockSize == original.blockSize)
+        #expect(redactionCopy.mode == .blur)
+    }
+
+    @Test("Solid redaction renders a flat filled region")
+    func solidRedactionRendersFill() throws {
+        let source = try makeTestImage(width: 8, height: 8, color: CGColor(gray: 1, alpha: 1))
+        let redaction = PixelateObject(
+            rect: CGRect(x: 2, y: 2, width: 4, height: 4),
+            blockSize: 12,
+            mode: .solid
+        )
+        redaction.style = StrokeStyle(color: .black, lineWidth: 1, opacity: 1)
+
+        let rendered = try #require(AnnotationRenderer.render(sourceImage: source, objects: [redaction]))
+
+        #expect(sampleRGBA(rendered, x: 3, y: 3) == RGBA(r: 0, g: 0, b: 0, a: 255))
+        #expect(sampleRGBA(rendered, x: 0, y: 0) == RGBA(r: 255, g: 255, b: 255, a: 255))
+    }
+
+    @Test("Blur redaction changes source pixels inside the selected region")
+    func blurRedactionChangesInteriorPixels() throws {
+        let source = try makeSplitImage(width: 16, height: 16)
+        let redaction = PixelateObject(
+            rect: CGRect(x: 4, y: 4, width: 8, height: 8),
+            blockSize: 12,
+            mode: .blur
+        )
+
+        let rendered = try #require(AnnotationRenderer.render(sourceImage: source, objects: [redaction]))
+
+        #expect(sampleRGBA(rendered, x: 7, y: 7) != sampleRGBA(source, x: 7, y: 7))
+        #expect(sampleRGBA(rendered, x: 1, y: 1) == sampleRGBA(source, x: 1, y: 1))
+    }
+}
+
+private struct RGBA: Equatable {
+    var r: UInt8
+    var g: UInt8
+    var b: UInt8
+    var a: UInt8
+}
+
+private func makeTestImage(width: Int, height: Int, color: CGColor) throws -> CGImage {
+    let context = try #require(makeBitmapContext(width: width, height: height))
+    context.setFillColor(color)
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    return try #require(context.makeImage())
+}
+
+private func makeSplitImage(width: Int, height: Int) throws -> CGImage {
+    let context = try #require(makeBitmapContext(width: width, height: height))
+    context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    context.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: 1))
+    context.fill(CGRect(x: width / 2, y: 0, width: width / 2, height: height))
+    return try #require(context.makeImage())
+}
+
+private func makeBitmapContext(width: Int, height: Int) -> CGContext? {
+    CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    )
+}
+
+private func sampleRGBA(_ image: CGImage, x: Int, y: Int) -> RGBA {
+    let context = makeBitmapContext(width: 1, height: 1)!
+    context.draw(
+        image,
+        in: CGRect(
+            x: -x,
+            y: -(image.height - 1 - y),
+            width: image.width,
+            height: image.height
+        )
+    )
+    let data = context.data!.assumingMemoryBound(to: UInt8.self)
+    return RGBA(r: data[0], g: data[1], b: data[2], a: data[3])
+}

--- a/Packages/CaptureKit/Sources/CaptureKit/CaptureDisplayGeometry.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/CaptureDisplayGeometry.swift
@@ -23,4 +23,29 @@ public enum CaptureDisplayGeometry {
 
         return min(screenRect.width / imageSize.width, screenRect.height / imageSize.height)
     }
+
+    public static func frozenImageCropRect(
+        screenLocalRect: CGRect,
+        screenSize: CGSize,
+        imageSize: CGSize
+    ) -> CGRect {
+        guard screenLocalRect.width > 0,
+              screenLocalRect.height > 0,
+              screenSize.width > 0,
+              screenSize.height > 0,
+              imageSize.width > 0,
+              imageSize.height > 0 else {
+            return .null
+        }
+
+        let scaleX = imageSize.width / screenSize.width
+        let scaleY = imageSize.height / screenSize.height
+
+        return CGRect(
+            x: screenLocalRect.origin.x * scaleX,
+            y: (screenSize.height - screenLocalRect.origin.y - screenLocalRect.height) * scaleY,
+            width: screenLocalRect.width * scaleX,
+            height: screenLocalRect.height * scaleY
+        ).integral
+    }
 }

--- a/Packages/CaptureKit/Tests/CaptureKitTests/CaptureDisplayGeometryTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/CaptureDisplayGeometryTests.swift
@@ -33,4 +33,26 @@ struct CaptureDisplayGeometryTests {
             screenRect: CGRect(x: 0, y: 0, width: 400, height: 240)
         ) == nil)
     }
+
+    @Test("Maps a screen-local selection to frozen screenshot pixels")
+    func frozenImageCropRect() {
+        let crop = CaptureDisplayGeometry.frozenImageCropRect(
+            screenLocalRect: CGRect(x: 120, y: 180, width: 320, height: 160),
+            screenSize: CGSize(width: 800, height: 600),
+            imageSize: CGSize(width: 1600, height: 1200)
+        )
+
+        #expect(crop == CGRect(x: 240, y: 520, width: 640, height: 320))
+    }
+
+    @Test("Rejects invalid frozen screenshot crop geometry")
+    func invalidFrozenImageCropRect() {
+        let crop = CaptureDisplayGeometry.frozenImageCropRect(
+            screenLocalRect: CGRect(x: 0, y: 0, width: 100, height: 100),
+            screenSize: .zero,
+            imageSize: CGSize(width: 1600, height: 1200)
+        )
+
+        #expect(crop.isNull)
+    }
 }


### PR DESCRIPTION
## Summary
- bring annotation controls into the All-in-One capture flow with adaptive toolbar layouts
- improve line/arrow path editing, redaction polish, and custom color handling
- refine floating toolbar chrome with compact overflow, readable side-rail preset controls, immediate hover labels, and shape-bound glass shadows

## Verification
- xcodebuild -quiet -project Capso.xcodeproj -scheme Capso -configuration Debug build
- swift test --package-path Packages/CaptureKit
- swift test --package-path Packages/AnnotationKit
- git diff --check

## Notes
- Manual multi-display hover timing has not been fully exercised.