### PR TITLE
fix: improve annotation text trace and toolbar

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -7,6 +7,21 @@ import AnnotationKit
 private enum ResizeHandle {
     case topLeft, topRight, bottomLeft, bottomRight
     case pathStart, pathEnd, pathControl
+
+    var textResizeHandle: TextResizeHandle? {
+        switch self {
+        case .topLeft:
+            .topLeft
+        case .topRight:
+            .topRight
+        case .bottomLeft:
+            .bottomLeft
+        case .bottomRight:
+            .bottomRight
+        case .pathStart, .pathEnd, .pathControl:
+            nil
+        }
+    }
 }
 
 private protocol PathEditableAnnotation: AnnotationObject {
@@ -32,13 +47,30 @@ final class AnnotationCanvasNSView: NSView {
     var currentTextFontSize: CGFloat = 48 {
         didSet { textEditor?.fontSize = currentTextFontSize }
     }
+    /// Optional text effects for newly created text and active inline edits.
+    var currentTextFillColor: AnnotationColor? {
+        didSet {
+            textEditor?.fillColor = currentTextFillColor?.nsColor.withAlphaComponent(0.5)
+            needsDisplay = true
+        }
+    }
+    var currentTextOutlineColor: AnnotationColor? {
+        didSet {
+            textEditor?.boxOutlineColor = currentTextOutlineColor?.nsColor
+            needsDisplay = true
+        }
+    }
+    var currentTextGlyphStrokeColor: AnnotationColor? {
+        didSet {
+            textEditor?.glyphStrokeColor = currentTextGlyphStrokeColor?.nsColor
+            needsDisplay = true
+        }
+    }
     var onDocumentChanged: (() -> Void)?
     var onObjectCreated: (() -> Void)?
     /// Fired when an inline text edit begins. Passes the effective fontSize
-    /// (matches the existing object when re-editing, or `currentTextFontSize`
-    /// for a fresh edit). SwiftUI uses it to flip `isEditingText` and — for
-    /// double-click re-edits — to sync the font-size slider to the object.
-    var onTextEditingStarted: ((CGFloat) -> Void)?
+    /// and text effect states, so SwiftUI can sync toolbar state.
+    var onTextEditingStarted: ((CGFloat, Bool, Bool, Bool) -> Void)?
     /// Fired on commit / cancel.
     var onTextEditingEnded: (() -> Void)?
 
@@ -81,6 +113,10 @@ final class AnnotationCanvasNSView: NSView {
     /// When re-editing an existing TextObject (double-click), holds it so we
     /// can mutate it on commit rather than creating a new object.
     private var editingOriginalObject: TextObject?
+    private var isResizingTextEditor = false
+    private var textEditorResizeHandle: ResizeHandle?
+    private var textEditorResizeStart: CGPoint?
+    private var textEditorOriginalBounds: CGRect?
 
     private let handleRadius: CGFloat = 5  // in image coords (adjusted by zoom in drawing)
 
@@ -137,6 +173,13 @@ final class AnnotationCanvasNSView: NSView {
 
     // MARK: - Cursor Management
 
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        if liveTextHandleHitTest(pointInView: point) != nil {
+            return self
+        }
+        return super.hitTest(point)
+    }
+
     override func resetCursorRects() {
         discardCursorRects()
         let cursor: NSCursor = currentTool == .select ? .arrow : .crosshair
@@ -144,7 +187,13 @@ final class AnnotationCanvasNSView: NSView {
     }
 
     override func mouseMoved(with event: NSEvent) {
-        let point = toImagePoint(convert(event.locationInWindow, from: nil))
+        let pointInView = convert(event.locationInWindow, from: nil)
+        if let handle = liveTextHandleHitTest(pointInView: pointInView) {
+            cursorForHandle(handle).set()
+            return
+        }
+
+        let point = toImagePoint(pointInView)
         guard let doc = document else { return }
 
         if let selected = doc.selectedObject {
@@ -233,7 +282,9 @@ final class AnnotationCanvasNSView: NSView {
             }
 
             if let selected = doc.selectedObject {
-                if let pathObject = selected as? any PathEditableAnnotation {
+                if let text = selected as? TextObject, text === editingOriginalObject {
+                    // The live inline editor draws matching selection chrome below.
+                } else if let pathObject = selected as? any PathEditableAnnotation {
                     drawPathSelectionHandles(ctx: ctx, object: pathObject)
                 } else {
                     drawSelectionHandles(ctx: ctx, bounds: selected.bounds)
@@ -248,6 +299,54 @@ final class AnnotationCanvasNSView: NSView {
         }
 
         ctx.restoreGState()
+
+        drawLiveTextEditorChrome()
+    }
+
+    private func drawLiveTextEditorChrome() {
+        guard let editor = textEditor else { return }
+        let boxFrame = editor.viewBoxFrame
+        guard !boxFrame.isEmpty else { return }
+
+        let pillRect = boxFrame.insetBy(dx: -4, dy: -4)
+        let path = NSBezierPath(roundedRect: pillRect, xRadius: 4, yRadius: 4)
+        if let fillColor = editor.fillColor {
+            fillColor.setFill()
+            path.fill()
+        } else {
+            NSColor.black.withAlphaComponent(0.08).setFill()
+            path.fill()
+        }
+
+        if let outlineColor = editor.boxOutlineColor {
+            outlineColor.setStroke()
+            path.lineWidth = 2
+            path.stroke()
+        }
+
+        editor.drawGlyphTraceBehindText()
+
+        NSColor.controlAccentColor.withAlphaComponent(0.82).setStroke()
+        let selection = NSBezierPath(rect: boxFrame)
+        selection.lineWidth = 1
+        selection.setLineDash([4, 3], count: 2, phase: 0)
+        selection.stroke()
+
+        let handleSize: CGFloat = 8
+        for (_, center) in liveTextHandleCenters(boxFrame: boxFrame) {
+            let rect = CGRect(
+                x: center.x - handleSize / 2,
+                y: center.y - handleSize / 2,
+                width: handleSize,
+                height: handleSize
+            )
+            NSColor.windowBackgroundColor.setFill()
+            NSBezierPath(ovalIn: rect).fill()
+            NSColor.controlAccentColor.setStroke()
+            let border = NSBezierPath(ovalIn: rect.insetBy(dx: 0.5, dy: 0.5))
+            border.lineWidth = 1.5
+            border.stroke()
+        }
     }
 
     private func drawPathSelectionHandles(ctx: CGContext, object: any PathEditableAnnotation) {
@@ -357,6 +456,26 @@ final class AnnotationCanvasNSView: NSView {
         ]
     }
 
+    private func liveTextHandleCenters(boxFrame: CGRect) -> [(ResizeHandle, CGPoint)] {
+        [
+            (.topLeft, CGPoint(x: boxFrame.minX, y: boxFrame.minY)),
+            (.topRight, CGPoint(x: boxFrame.maxX, y: boxFrame.minY)),
+            (.bottomLeft, CGPoint(x: boxFrame.minX, y: boxFrame.maxY)),
+            (.bottomRight, CGPoint(x: boxFrame.maxX, y: boxFrame.maxY)),
+        ]
+    }
+
+    private func liveTextHandleHitTest(pointInView: CGPoint) -> ResizeHandle? {
+        guard let editor = textEditor else { return nil }
+        let hitRadius: CGFloat = 12
+        for (handle, center) in liveTextHandleCenters(boxFrame: editor.viewBoxFrame) {
+            if hypot(pointInView.x - center.x, pointInView.y - center.y) <= hitRadius {
+                return handle
+            }
+        }
+        return nil
+    }
+
     private func drawPreview(ctx: CGContext, from start: CGPoint, to end: CGPoint) {
         ctx.saveGState()
         ctx.setStrokeColor(currentStyle.color.cgColor)
@@ -383,9 +502,17 @@ final class AnnotationCanvasNSView: NSView {
         // editor commits the edit; clicks inside are forwarded to the editor.
         if let editor = textEditor {
             let pointInSelf = convert(event.locationInWindow, from: nil)
+            if let handle = liveTextHandleHitTest(pointInView: pointInSelf) {
+                isResizingTextEditor = true
+                textEditorResizeHandle = handle
+                textEditorResizeStart = toImagePoint(pointInSelf)
+                textEditorOriginalBounds = CGRect(origin: editor.imageOrigin, size: editor.boxSize)
+                cursorForHandle(handle).set()
+                needsDisplay = true
+                return
+            }
             if editor.containsCanvasPoint(pointInSelf) {
-                // Let the NSTextView handle the click (focus / caret placement).
-                super.mouseDown(with: event)
+                editor.focusTextView()
                 return
             } else {
                 commitTextEditing()
@@ -480,6 +607,23 @@ final class AnnotationCanvasNSView: NSView {
         let point = toImagePoint(convert(event.locationInWindow, from: nil))
         dragCurrent = point
 
+        if isResizingTextEditor,
+           let editor = textEditor,
+           let handle = textEditorResizeHandle?.textResizeHandle,
+           let start = textEditorResizeStart,
+           let originalBounds = textEditorOriginalBounds {
+            let delta = CGSize(width: point.x - start.x, height: point.y - start.y)
+            let rect = TextResizeGeometry.rect(
+                originalBounds: originalBounds,
+                handle: handle,
+                dragDelta: delta,
+                minSize: CGSize(width: 60, height: max(28, editor.fontSize + 12))
+            )
+            editor.resizeBox(to: rect)
+            needsDisplay = true
+            return
+        }
+
         if let handle = activeResizeHandle, let objID = dragObjectID,
            let origBounds = resizeOriginalBounds, let start = dragStart {
             // Resize handles remain active even while a drawing tool is selected.
@@ -561,45 +705,36 @@ final class AnnotationCanvasNSView: NSView {
         else if let ellipse = obj as? EllipseObject { ellipse.rect = newRect }
         else if let pixelate = obj as? PixelateObject { pixelate.rect = newRect }
         else if let text = obj as? TextObject {
+            if text.boxSize != nil, let textHandle = handle.textResizeHandle {
+                let rect = TextResizeGeometry.rect(
+                    originalBounds: originalBounds,
+                    handle: textHandle,
+                    dragDelta: CGSize(width: dx, height: dy),
+                    minSize: CGSize(width: 60, height: max(28, text.fontSize + 12))
+                )
+                text.origin = rect.origin
+                text.boxSize = rect.size
+                return
+            }
+
             // Text has intrinsic bounds derived from fontSize, so we scale fontSize
             // uniformly and then reposition origin so the corner opposite the dragged
             // handle stays fixed.
             guard let origFontSize = resizeOriginalTextFontSize,
-                  originalBounds.width > 0, originalBounds.height > 0 else { return }
-            let scaleX = newRect.width / originalBounds.width
-            let scaleY = newRect.height / originalBounds.height
-            // Use the larger scale so the text grows to fill the dragged rect.
-            let scale = max(scaleX, scaleY)
-            let minFontSize: CGFloat = 6
-            text.fontSize = max(minFontSize, origFontSize * scale)
+                  let textHandle = handle.textResizeHandle else { return }
+            text.fontSize = TextResizeGeometry.fontSize(
+                originalBounds: originalBounds,
+                originalFontSize: origFontSize,
+                handle: textHandle,
+                dragDelta: CGSize(width: dx, height: dy)
+            )
 
             // Intrinsic size after fontSize change.
-            let newSize = text.bounds.size
-            switch handle {
-            case .topLeft:
-                // Anchor: bottomRight of original bounds
-                text.origin = CGPoint(
-                    x: originalBounds.maxX - newSize.width,
-                    y: originalBounds.maxY - newSize.height
-                )
-            case .topRight:
-                // Anchor: bottomLeft of original bounds
-                text.origin = CGPoint(
-                    x: originalBounds.minX,
-                    y: originalBounds.maxY - newSize.height
-                )
-            case .bottomLeft:
-                // Anchor: topRight of original bounds
-                text.origin = CGPoint(
-                    x: originalBounds.maxX - newSize.width,
-                    y: originalBounds.minY
-                )
-            case .bottomRight:
-                // Anchor: topLeft of original bounds
-                text.origin = originalBounds.origin
-            case .pathStart, .pathEnd, .pathControl:
-                break
-            }
+            text.origin = TextResizeGeometry.origin(
+                originalBounds: originalBounds,
+                resizedSize: text.bounds.size,
+                handle: textHandle
+            )
         }
         else if let arrow = obj as? ArrowObject {
             guard let endpoints = resizeOriginalEndpoints else { return }
@@ -632,6 +767,16 @@ final class AnnotationCanvasNSView: NSView {
     }
 
     override func mouseUp(with event: NSEvent) {
+        if isResizingTextEditor {
+            isResizingTextEditor = false
+            textEditorResizeHandle = nil
+            textEditorResizeStart = nil
+            textEditorOriginalBounds = nil
+            textEditor?.focusTextView()
+            needsDisplay = true
+            return
+        }
+
         guard let doc = document, let start = dragStart else {
             isDragging = false; return
         }
@@ -753,34 +898,46 @@ final class AnnotationCanvasNSView: NSView {
         if textEditor != nil { commitTextEditing() }
 
         let editor = AnnotationTextEditor(frame: .zero)
-        editor.delegate = self
+        editor.editorDelegate = self
         editor.zoomScale = zoomScale
         editor.imageOrigin = imagePoint
+        addSubview(editor)
+        textEditor = editor
 
         if let existing {
             editor.fontSize = existing.fontSize
             editor.fontName = existing.fontName
             editor.textColor = existing.style.color.nsColor
                 .withAlphaComponent(existing.style.opacity)
+            editor.boxSize = existing.boxSize ?? existing.bounds.size
+            editor.fillColor = existing.fillColor?.nsColor.withAlphaComponent(0.5)
+            editor.boxOutlineColor = existing.outlineColor?.nsColor
+            editor.glyphStrokeColor = existing.glyphStrokeColor?.nsColor
             editor.beginEditing(initialText: existing.text)
             editingOriginalObject = existing
         } else {
             editor.fontSize = currentTextFontSize
             editor.textColor = currentStyle.color.nsColor
                 .withAlphaComponent(currentStyle.opacity)
+            editor.fillColor = currentTextFillColor?.nsColor.withAlphaComponent(0.5)
+            editor.boxOutlineColor = currentTextOutlineColor?.nsColor
+            editor.glyphStrokeColor = currentTextGlyphStrokeColor?.nsColor
             editor.beginEditing(initialText: "")
             editingOriginalObject = nil
         }
 
-        addSubview(editor)
-        textEditor = editor
         repositionEditor()
         editor.focusTextView()
         needsDisplay = true
 
         // Notify SwiftUI so the toolbar can flip into font-size mode and
         // — for re-edits — sync the slider to the object's fontSize.
-        onTextEditingStarted?(editor.fontSize)
+        onTextEditingStarted?(
+            editor.fontSize,
+            editor.fillColor != nil,
+            editor.boxOutlineColor != nil,
+            editor.glyphStrokeColor != nil
+        )
     }
 
     /// Position the editor's frame based on its `imageOrigin` and the current
@@ -802,16 +959,29 @@ final class AnnotationCanvasNSView: NSView {
 
         let finalText = editor.text.trimmingCharacters(in: .whitespacesAndNewlines)
         let origin = editor.imageOrigin
+        let boxSize = editor.boxSize
+        let editorFillColor = editor.fillColor.map(AnnotationColor.init(nsColor:))
+        let editorOutlineColor = editor.boxOutlineColor.map(AnnotationColor.init(nsColor:))
+        let editorGlyphStrokeColor = editor.glyphStrokeColor.map(AnnotationColor.init(nsColor:))
 
         if let existing = editingOriginalObject {
             if finalText.isEmpty {
                 // Edited to empty → delete the original.
                 doc.removeObject(id: existing.id)
-            } else if finalText != existing.text || editor.fontSize != existing.fontSize {
+            } else if finalText != existing.text
+                || editor.fontSize != existing.fontSize
+                || boxSize != existing.boxSize
+                || editorFillColor != existing.fillColor
+                || editorOutlineColor != existing.outlineColor
+                || editorGlyphStrokeColor != existing.glyphStrokeColor {
                 // Mutated text or fontSize — push one undo step, then update.
                 doc.beginDrag()
                 existing.text = finalText
+                existing.boxSize = boxSize
                 existing.fontSize = editor.fontSize
+                existing.fillColor = editorFillColor
+                existing.outlineColor = editorOutlineColor
+                existing.glyphStrokeColor = editorGlyphStrokeColor
             }
         } else if !finalText.isEmpty {
             // Fresh edit with content → create a new TextObject using the
@@ -819,7 +989,11 @@ final class AnnotationCanvasNSView: NSView {
             let newObj = TextObject(
                 text: finalText,
                 origin: origin,
+                boxSize: boxSize,
                 fontSize: editor.fontSize,
+                fillColor: editorFillColor,
+                outlineColor: editorOutlineColor,
+                glyphStrokeColor: editorGlyphStrokeColor,
                 style: currentStyle
             )
             doc.addObject(newObj)

--- a/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
@@ -12,6 +12,9 @@ struct AnnotationCanvasView: NSViewRepresentable {
     /// Font size for the text tool / active inline edit. Bound to the
     /// font-size slider in SwiftUI.
     let textFontSize: CGFloat
+    let textFillColor: AnnotationColor?
+    let textOutlineColor: AnnotationColor?
+    let textGlyphStrokeColor: AnnotationColor?
     let zoomScale: CGFloat
     let refreshTrigger: Int
     var textRegions: [CGRect] = []
@@ -22,7 +25,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
     /// fontSize (existing object's size when re-editing, current slider
     /// value for a new edit). SwiftUI flips `isEditingText` and — for
     /// re-edits — syncs the size slider.
-    var onTextEditingStarted: ((CGFloat) -> Void)?
+    var onTextEditingStarted: ((CGFloat, Bool, Bool, Bool) -> Void)?
     /// Called when the inline text editor commits / dismisses.
     var onTextEditingEnded: (() -> Void)?
 
@@ -44,6 +47,9 @@ struct AnnotationCanvasView: NSViewRepresentable {
         view.currentStyle = currentStyle
         view.redactionMode = redactionMode
         view.currentTextFontSize = textFontSize
+        view.currentTextFillColor = textFillColor
+        view.currentTextOutlineColor = textOutlineColor
+        view.currentTextGlyphStrokeColor = textGlyphStrokeColor
         view.zoomScale = zoomScale
         view.textRegions = textRegions
         view.onDocumentChanged = { onDocumentChanged?() }
@@ -52,7 +58,9 @@ struct AnnotationCanvasView: NSViewRepresentable {
                 onSwitchToSelect?()
             }
         }
-        view.onTextEditingStarted = { fontSize in onTextEditingStarted?(fontSize) }
+        view.onTextEditingStarted = { fontSize, hasFill, hasOutline, hasStroke in
+            onTextEditingStarted?(fontSize, hasFill, hasOutline, hasStroke)
+        }
         view.onTextEditingEnded = { onTextEditingEnded?() }
         return view
     }
@@ -68,6 +76,9 @@ struct AnnotationCanvasView: NSViewRepresentable {
         nsView.currentStyle = currentStyle
         nsView.redactionMode = redactionMode
         nsView.currentTextFontSize = textFontSize
+        nsView.currentTextFillColor = textFillColor
+        nsView.currentTextOutlineColor = textOutlineColor
+        nsView.currentTextGlyphStrokeColor = textGlyphStrokeColor
         nsView.zoomScale = zoomScale
         nsView.textRegions = textRegions
         nsView.onDocumentChanged = { onDocumentChanged?() }
@@ -76,7 +87,9 @@ struct AnnotationCanvasView: NSViewRepresentable {
                 onSwitchToSelect?()
             }
         }
-        nsView.onTextEditingStarted = { fontSize in onTextEditingStarted?(fontSize) }
+        nsView.onTextEditingStarted = { fontSize, hasFill, hasOutline, hasStroke in
+            onTextEditingStarted?(fontSize, hasFill, hasOutline, hasStroke)
+        }
         nsView.onTextEditingEnded = { onTextEditingEnded?() }
         if context.coordinator.lastCommitEditingTrigger != commitEditingTrigger {
             context.coordinator.lastCommitEditingTrigger = commitEditingTrigger

--- a/App/Sources/AnnotationEditor/AnnotationEditorView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorView.swift
@@ -47,6 +47,9 @@ struct AnnotationEditorView: View {
     @AppStorage("annotationHighlighterWidth") private var savedHighlighterWidth: Double = 20
     @AppStorage("annotationRedactionMode") private var redactionMode: RedactionMode = .pixelate
     @AppStorage("annotationStrokePattern") private var savedStrokePattern: StrokePattern = .solid
+    @AppStorage("annotationTextFillEnabled") private var textFillEnabled: Bool = false
+    @AppStorage("annotationTextOutlineEnabled") private var textOutlineEnabled: Bool = false
+    @AppStorage("annotationTextStrokeEnabled") private var textStrokeEnabled: Bool = true
     /// Preserved font size for the Text tool. Swapped in/out of `lineWidth`
     /// as the user toggles tools — same pattern as savedBlockSize etc.
     @AppStorage("annotationTextFontSize") private var savedTextFontSize: Double = 48
@@ -125,6 +128,18 @@ struct AnnotationEditorView: View {
     /// fall back to the preserved value from the last text session.
     private var effectiveTextFontSize: CGFloat {
         (currentTool == .text || isEditingText) ? lineWidth : CGFloat(savedTextFontSize)
+    }
+
+    private var textFillColor: AnnotationColor? {
+        textFillEnabled ? .black : nil
+    }
+
+    private var textOutlineColor: AnnotationColor? {
+        textOutlineEnabled ? .white : nil
+    }
+
+    private var textGlyphStrokeColor: AnnotationColor? {
+        textStrokeEnabled ? .white : nil
     }
 
     /// Preserved width for the given tool. Bridges between the `Double`
@@ -206,6 +221,9 @@ struct AnnotationEditorView: View {
                     lineWidth: $lineWidth,
                     strokePattern: $strokePattern,
                     filled: $filled,
+                    textFillEnabled: $textFillEnabled,
+                    textOutlineEnabled: $textOutlineEnabled,
+                    textStrokeEnabled: $textStrokeEnabled,
                     redactionMode: $redactionMode,
                     showBeautifyPanel: $showBeautifyPanel,
                     isEditingText: isEditingText,
@@ -242,6 +260,9 @@ struct AnnotationEditorView: View {
                                 currentStyle: currentStyle,
                                 redactionMode: redactionMode,
                                 textFontSize: effectiveTextFontSize,
+                                textFillColor: textFillColor,
+                                textOutlineColor: textOutlineColor,
+                                textGlyphStrokeColor: textGlyphStrokeColor,
                                 zoomScale: zoomScale,
                                 refreshTrigger: refreshTrigger,
                                 textRegions: textRegions,
@@ -250,8 +271,11 @@ struct AnnotationEditorView: View {
                                     document.clearSelection()
                                     currentTool = .select
                                 },
-                                onTextEditingStarted: { fontSize in
+                                onTextEditingStarted: { fontSize, hasFill, hasOutline, hasStroke in
                                     isEditingText = true
+                                    textFillEnabled = hasFill
+                                    textOutlineEnabled = hasOutline
+                                    textStrokeEnabled = hasStroke
                                     // Sync slider to the object's fontSize when
                                     // re-editing. Harmless for fresh edits: the
                                     // value matches what we just pushed in.
@@ -327,6 +351,9 @@ struct AnnotationEditorView: View {
                         updateSelectedStyle()
                     }
                     .onChange(of: filled) { _, _ in updateSelectedStyle() }
+                    .onChange(of: textFillEnabled) { _, _ in updateSelectedStyle() }
+                    .onChange(of: textOutlineEnabled) { _, _ in updateSelectedStyle() }
+                    .onChange(of: textStrokeEnabled) { _, _ in updateSelectedStyle() }
                     .onChange(of: redactionMode) { _, _ in updateSelectedStyle() }
                     .onChange(of: geo.size) { _, newSize in
                         // Re-fit if window is resized and we're at fit scale
@@ -406,6 +433,11 @@ struct AnnotationEditorView: View {
             } else if let counter = obj as? CounterObject {
                 counter.radius = lineWidth
                 counter.style = AnnotationKit.StrokeStyle(color: currentColor, lineWidth: lineWidth, filled: filled)
+            } else if let text = obj as? TextObject {
+                text.fillColor = textFillColor
+                text.outlineColor = textOutlineColor
+                text.glyphStrokeColor = textGlyphStrokeColor
+                text.style = currentStyle
             } else {
                 obj.style = currentStyle
             }

--- a/App/Sources/AnnotationEditor/AnnotationTextEditor.swift
+++ b/App/Sources/AnnotationEditor/AnnotationTextEditor.swift
@@ -1,43 +1,32 @@
 // App/Sources/AnnotationEditor/AnnotationTextEditor.swift
-//
-// Inline, in-canvas text editor that replaces the modal NSAlert popup the
-// annotation text tool used before. Appears at the click point, grows with
-// content, commits on **Esc or outside-click** (no Return-commit — Return and
-// Shift+Return both insert newlines, matching CleanShot X). IME composition
-// is respected so Chinese / Japanese / Korean users can confirm candidates
-// with Return without committing the whole edit.
-//
-// Visual language: refined native macOS — a hairline accent-tinted rounded
-// outline and a soft dark backdrop. Intentionally quieter than CleanShot X,
-// so it never fights the content being annotated.
-
 import AppKit
 
 @MainActor
 protocol AnnotationTextEditorDelegate: AnyObject {
-    /// Called when the user commits the edit (Return / Esc / outside-click).
-    /// `text` may be empty — the canvas decides whether to discard or delete.
     func textEditor(_ editor: AnnotationTextEditor, didCommitText text: String)
 }
 
 @MainActor
-final class AnnotationTextEditor: NSView {
-    weak var delegate: AnnotationTextEditorDelegate?
+final class AnnotationTextEditor: NSScrollView {
+    private static let liveGlyphTraceStrokeWidth: CGFloat = 2.0
 
-    /// Origin in **image coordinates**. The owning canvas multiplies by
-    /// `zoomScale` to position us in its view space.
-    var imageOrigin: CGPoint = .zero
+    weak var editorDelegate: AnnotationTextEditorDelegate?
 
-    /// Zoom of the owning canvas. Controls the effective on-screen font size
-    /// so typed glyphs line up 1:1 with what `TextObject.render` will draw.
+    var imageOrigin: CGPoint = .zero {
+        didSet { updateFrameFromImageGeometry() }
+    }
+    var boxSize: CGSize = .zero {
+        didSet { updateFrameFromImageGeometry() }
+    }
+
     var zoomScale: CGFloat = 1.0 {
         didSet {
             guard zoomScale != oldValue else { return }
             applyAttributes()
+            updateFrameFromImageGeometry()
         }
     }
 
-    /// Font size in **image coordinates** (what gets stored on TextObject).
     var fontSize: CGFloat = 48 {
         didSet {
             guard fontSize != oldValue else { return }
@@ -45,7 +34,6 @@ final class AnnotationTextEditor: NSView {
         }
     }
 
-    /// Font name matches what TextObject uses when rendering.
     var fontName: String = ".AppleSystemUIFont" {
         didSet {
             guard fontName != oldValue else { return }
@@ -53,7 +41,6 @@ final class AnnotationTextEditor: NSView {
         }
     }
 
-    /// Text color with style.opacity already applied.
     var textColor: NSColor = .red {
         didSet {
             guard textColor != oldValue else { return }
@@ -61,33 +48,58 @@ final class AnnotationTextEditor: NSView {
         }
     }
 
-    /// String currently in the editor.
+    var fillColor: NSColor?
+    var boxOutlineColor: NSColor?
+    var glyphStrokeColor: NSColor? {
+        didSet {
+            applyAttributes()
+            invalidateCanvasTrace()
+        }
+    }
+
     var text: String { textView.string }
+    var viewBoxFrame: CGRect { frame }
 
     private let textView: InlineTextView
-    private let innerPadding: CGFloat = 4
+    private let textInset: CGFloat = 4
+    private var manuallySizedWidth = false
+    private var hasBegunEditing = false
 
     override var isFlipped: Bool { true }
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
     override init(frame frameRect: NSRect) {
         self.textView = InlineTextView(frame: .zero)
         super.init(frame: frameRect)
-        wantsLayer = true
-        layer?.masksToBounds = false
 
+        configureScrollView()
         configureTextView()
-        addSubview(textView)
+        documentView = textView
 
         textView.commitHandler = { [weak self] in
             guard let self else { return }
-            self.delegate?.textEditor(self, didCommitText: self.textView.string)
+            self.editorDelegate?.textEditor(self, didCommitText: self.textView.string)
         }
         textView.sizeChangeHandler = { [weak self] in
             self?.resizeToFit()
+            self?.invalidateCanvasTrace()
         }
     }
 
     @available(*, unavailable) required init?(coder: NSCoder) { fatalError() }
+
+    private func configureScrollView() {
+        hasVerticalScroller = false
+        hasHorizontalScroller = false
+        autohidesScrollers = true
+        drawsBackground = false
+        borderType = .noBorder
+        contentView.drawsBackground = false
+        wantsLayer = true
+        layer?.masksToBounds = true
+        contentView.wantsLayer = true
+        contentView.layer?.masksToBounds = true
+    }
 
     private func configureTextView() {
         textView.isEditable = true
@@ -107,60 +119,72 @@ final class AnnotationTextEditor: NSView {
         textView.isAutomaticTextReplacementEnabled = false
         textView.smartInsertDeleteEnabled = false
 
-        // Unbounded container so multi-line grows horizontally with longest line.
-        textView.textContainerInset = .zero
+        textView.textContainerInset = NSSize(width: textInset, height: textInset)
         textView.textContainer?.lineFragmentPadding = 0
-        textView.textContainer?.widthTracksTextView = false
+        textView.textContainer?.widthTracksTextView = true
         textView.textContainer?.heightTracksTextView = false
-        textView.textContainer?.containerSize = NSSize(
-            width: CGFloat.greatestFiniteMagnitude,
-            height: CGFloat.greatestFiniteMagnitude
-        )
-        textView.isHorizontallyResizable = true
+        textView.isHorizontallyResizable = false
         textView.isVerticallyResizable = true
         textView.minSize = .zero
-        textView.maxSize = NSSize(
-            width: CGFloat.greatestFiniteMagnitude,
-            height: CGFloat.greatestFiniteMagnitude
-        )
-
-        // Make the caret visible on typical dark backgrounds.
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
         textView.insertionPointColor = .white
     }
 
-    // MARK: - Lifecycle
-
-    /// Seed the editor with `initialText`, apply current style, and select-all
-    /// (so that typing replaces a double-click-restored string).
     func beginEditing(initialText: String) {
+        hasBegunEditing = true
         textView.string = initialText
-        applyAttributes()
-        // Place caret at end (new text) or select all (existing text).
-        let len = (textView.string as NSString).length
-        if initialText.isEmpty {
-            textView.setSelectedRange(NSRange(location: 0, length: 0))
-        } else {
-            textView.setSelectedRange(NSRange(location: 0, length: len))
+        if boxSize == .zero {
+            boxSize = defaultBoxSize()
         }
+        applyAttributes()
+        let len = (textView.string as NSString).length
+        textView.setSelectedRange(initialText.isEmpty ? NSRange(location: 0, length: 0) : NSRange(location: 0, length: len))
         resizeToFit()
     }
 
-    /// Ask the window to make our text view first responder. Call after the
-    /// view is installed in the window hierarchy.
     func focusTextView() {
         window?.makeFirstResponder(textView)
     }
 
-    // MARK: - Attributes / layout
+    func containsCanvasPoint(_ pointInCanvas: CGPoint) -> Bool {
+        frame.contains(pointInCanvas)
+    }
+
+    func resizeBox(to rect: CGRect) {
+        manuallySizedWidth = true
+        imageOrigin = rect.origin
+        boxSize = rect.size
+        layoutTextView()
+        invalidateCanvasTrace()
+    }
 
     private var attributes: [NSAttributedString.Key: Any] {
         let effective = max(1, fontSize * zoomScale)
         let font = NSFont(name: fontName, size: effective)
             ?? NSFont.systemFont(ofSize: effective, weight: .medium)
-        return [
+        let attrs: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: textColor,
         ]
+        return attrs
+    }
+
+    func drawGlyphTraceBehindText() {
+        guard let glyphStrokeColor, !text.isEmpty else { return }
+        let effective = max(1, fontSize * zoomScale)
+        let font = NSFont(name: fontName, size: effective)
+            ?? NSFont.systemFont(ofSize: effective, weight: .medium)
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.clear,
+            .strokeColor: glyphStrokeColor,
+            .strokeWidth: Self.liveGlyphTraceStrokeWidth,
+        ]
+        (text as NSString).draw(
+            with: frame.insetBy(dx: textInset, dy: textInset),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: attrs
+        )
     }
 
     private func applyAttributes() {
@@ -168,92 +192,103 @@ final class AnnotationTextEditor: NSView {
         if let storage = textView.textStorage, storage.length > 0 {
             storage.setAttributes(attributes, range: NSRange(location: 0, length: storage.length))
         }
-        resizeToFit()
+        if hasBegunEditing {
+            resizeToFit()
+        }
+    }
+
+    private func defaultBoxSize() -> CGSize {
+        CGSize(width: min(220, maxAutoWidth()), height: max(28, fontSize + 12))
+    }
+
+    private func minBoxSize() -> CGSize {
+        CGSize(width: 60, height: max(28, fontSize + 12))
+    }
+
+    private func maxAutoWidth() -> CGFloat {
+        guard let superview else { return 420 }
+        let remaining = (superview.bounds.width - imageOrigin.x * zoomScale - 12) / max(zoomScale, 0.1)
+        return max(minBoxSize().width, remaining)
     }
 
     private func resizeToFit() {
-        guard let layoutManager = textView.layoutManager,
-              let container = textView.textContainer else { return }
-        layoutManager.ensureLayout(for: container)
-        let used = layoutManager.usedRect(for: container)
+        guard hasBegunEditing, let storage = textView.textStorage else { return }
 
-        // Reserve width for the caret so it doesn't clip on empty / trailing.
-        let caretRoom = max(2, (fontSize * zoomScale) * 0.05)
-        let minWidth = max(12, fontSize * zoomScale * 0.6)
-        let contentW = max(minWidth, ceil(used.width) + caretRoom)
-        let contentH = max(ceil(fontSize * zoomScale), ceil(used.height))
-
-        let outerW = contentW + innerPadding * 2
-        let outerH = contentH + innerPadding * 2
-
-        if frame.size.width != outerW || frame.size.height != outerH {
-            setFrameSize(NSSize(width: outerW, height: outerH))
+        let minSize = minBoxSize()
+        let naturalWidth = naturalTextWidth(storage: storage)
+        let targetWidth: CGFloat
+        if manuallySizedWidth {
+            targetWidth = max(minSize.width, boxSize.width)
+        } else {
+            targetWidth = min(maxAutoWidth(), max(minSize.width, naturalWidth))
         }
-        textView.frame = NSRect(
-            x: innerPadding, y: innerPadding,
-            width: contentW, height: contentH
+
+        let measuredHeight = measuredTextHeight(storage: storage, width: targetWidth)
+        boxSize = CGSize(width: targetWidth, height: max(minSize.height, measuredHeight))
+        layoutTextView()
+    }
+
+    private func naturalTextWidth(storage: NSTextStorage) -> CGFloat {
+        guard storage.length > 0 else { return boxSize == .zero ? defaultBoxSize().width : boxSize.width }
+        let scale = max(zoomScale, 0.1)
+        let rect = storage.boundingRect(
+            with: NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading]
         )
-        needsDisplay = true
+        return ceil(rect.width / scale) + (textInset * 2 + 2) / scale
     }
 
-    // MARK: - Drawing: thin solid outline + soft backdrop
-
-    override func draw(_ dirtyRect: NSRect) {
-        let outline = bounds.insetBy(dx: 0.5, dy: 0.5)
-        let path = NSBezierPath(roundedRect: outline, xRadius: 3, yRadius: 3)
-
-        // Soft, nearly-invisible backdrop — just enough to keep light text legible
-        // over messy backgrounds without visually competing with the capture.
-        NSColor.black.withAlphaComponent(0.08).setFill()
-        path.fill()
-
-        // Thin accent outline, intentionally understated.
-        NSColor.controlAccentColor.withAlphaComponent(0.55).setStroke()
-        path.lineWidth = 1
-        path.stroke()
+    private func measuredTextHeight(storage: NSTextStorage, width: CGFloat) -> CGFloat {
+        let scale = max(zoomScale, 0.1)
+        guard storage.length > 0 else { return fontSize + textInset * 2 / scale }
+        let contentWidth = max(1, width * scale - textInset * 2)
+        let rect = storage.boundingRect(
+            with: NSSize(width: contentWidth, height: CGFloat.greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading]
+        )
+        return ceil(rect.height / scale) + (textInset * 2) / scale
     }
 
-    // MARK: - Hit testing
+    private func updateFrameFromImageGeometry() {
+        guard boxSize.width > 0, boxSize.height > 0 else { return }
+        let scale = max(zoomScale, 0.1)
+        frame = CGRect(
+            x: imageOrigin.x * scale,
+            y: imageOrigin.y * scale,
+            width: boxSize.width * scale,
+            height: boxSize.height * scale
+        )
+        layoutTextView()
+        invalidateCanvasTrace()
+    }
 
-    /// True if `pointInSelfSuperview` (the canvas's coordinate space) lands
-    /// inside our frame. Used by the canvas to decide whether a click commits
-    /// (outside) or falls through to the text view (inside).
-    func containsCanvasPoint(_ pointInSelfSuperview: CGPoint) -> Bool {
-        frame.contains(pointInSelfSuperview)
+    private func layoutTextView() {
+        textView.frame = CGRect(origin: .zero, size: bounds.size)
+        textView.textContainer?.containerSize = NSSize(
+            width: max(1, bounds.width - textInset * 2),
+            height: CGFloat.greatestFiniteMagnitude
+        )
+    }
+
+    private func invalidateCanvasTrace() {
+        superview?.needsDisplay = true
     }
 }
 
-// MARK: - Inline text view with commit-on-Return semantics
-
-/// NSTextView subclass that commits on Esc and lets every other keystroke
-/// (including Return and Shift+Return) fall through to the default multi-line
-/// NSTextView behavior — which is to insert a newline. This mirrors the
-/// behavior the user confirmed in CleanShot X: no keystroke commits; only
-/// losing focus (Esc, or clicking outside the editor) finalizes the edit.
-///
-/// IME composition (`hasMarkedText()`) always bypasses interception so that
-/// Return confirms a Chinese / Japanese / Korean candidate instead of acting
-/// on the editor itself.
 @MainActor
 private final class InlineTextView: NSTextView {
     var commitHandler: (() -> Void)?
     var sizeChangeHandler: (() -> Void)?
 
     override func keyDown(with event: NSEvent) {
-        // While IME has marked text, let the input manager handle everything.
         if hasMarkedText() {
             super.keyDown(with: event)
             return
         }
-
-        // Escape (keyCode 53) commits. Everything else — including Return and
-        // Shift+Return — falls through and gets the default newline-insertion
-        // behavior for a multi-line NSTextView.
         if event.keyCode == 53 {
             commitHandler?()
             return
         }
-
         super.keyDown(with: event)
     }
 

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -8,6 +8,9 @@ struct AnnotationToolbar: View {
     @Binding var lineWidth: CGFloat
     @Binding var strokePattern: StrokePattern
     @Binding var filled: Bool
+    @Binding var textFillEnabled: Bool
+    @Binding var textOutlineEnabled: Bool
+    @Binding var textStrokeEnabled: Bool
     @Binding var redactionMode: RedactionMode
     @Binding var showBeautifyPanel: Bool
     /// True when an inline text edit is active (either via the text tool or
@@ -32,20 +35,27 @@ struct AnnotationToolbar: View {
     }
 
     var body: some View {
-        HStack(spacing: 12) {
-            toolGroup
-            toolbarDivider
-            colorGroup
-            toolbarDivider
-            strokeGroup
-            toolbarDivider
-            cropGroup
-            toolbarDivider
-            beautifyGroup
-            toolbarDivider
-            undoGroup
-            Spacer()
-            actionGroup
+        VStack(spacing: 6) {
+            HStack(spacing: 12) {
+                toolGroup
+                toolbarDivider
+                colorGroup
+                toolbarDivider
+                strokeGroup
+                toolbarDivider
+                cropGroup
+                toolbarDivider
+                beautifyGroup
+                toolbarDivider
+                undoGroup
+                Spacer()
+                actionGroup
+            }
+
+            if isFontSizeMode {
+                textEffectsGroup
+                    .transition(.opacity)
+            }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
@@ -168,6 +178,32 @@ struct AnnotationToolbar: View {
                 .help("Fill Shape")
             }
         }
+    }
+
+    private var textEffectsGroup: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                textEffectToggle("Fill", isOn: $textFillEnabled, help: "Text Fill")
+                textEffectToggle("Outline", isOn: $textOutlineEnabled, help: "Text Box Outline")
+                textEffectToggle("Trace", isOn: $textStrokeEnabled, help: "Text Trace")
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func textEffectToggle(
+        _ title: LocalizedStringKey,
+        isOn: Binding<Bool>,
+        help: LocalizedStringKey
+    ) -> some View {
+        Toggle(isOn: isOn) {
+            Text(title)
+                .font(.system(size: 11, weight: .semibold))
+                .frame(minWidth: 46, minHeight: 20)
+        }
+        .toggleStyle(.button)
+        .controlSize(.small)
+        .help(help)
     }
 
     private var cropGroup: some View {

--- a/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
@@ -102,6 +102,9 @@ private struct InlineAnnotationEditorView: View {
     @AppStorage("annotationRedactionMode") private var redactionMode: RedactionMode = .pixelate
     @AppStorage("annotationTextFontSize") private var savedTextFontSize: Double = 48
     @AppStorage("annotationStrokePattern") private var savedStrokePattern: StrokePattern = .solid
+    @AppStorage("annotationTextFillEnabled") private var textFillEnabled: Bool = false
+    @AppStorage("annotationTextOutlineEnabled") private var textOutlineEnabled: Bool = false
+    @AppStorage("annotationTextStrokeEnabled") private var textStrokeEnabled: Bool = true
 
     @State private var lineWidth: CGFloat = 3
     @State private var strokePattern: StrokePattern = .solid
@@ -135,6 +138,18 @@ private struct InlineAnnotationEditorView: View {
         (currentTool == .text || isEditingText) ? lineWidth : CGFloat(savedTextFontSize)
     }
 
+    private var textFillColor: AnnotationColor? {
+        textFillEnabled ? .black : nil
+    }
+
+    private var textOutlineColor: AnnotationColor? {
+        textOutlineEnabled ? .white : nil
+    }
+
+    private var textGlyphStrokeColor: AnnotationColor? {
+        textStrokeEnabled ? .white : nil
+    }
+
     private var canvasRect: CGRect {
         let width = imageSize.width * displayScale
         let height = imageSize.height * displayScale
@@ -151,7 +166,7 @@ private struct InlineAnnotationEditorView: View {
         let margin: CGFloat = 16
         let gap: CGFloat = 12
         let toolbarWidth = max(360, min(screenSize.width - margin * 2, 880))
-        let toolbarHeight: CGFloat = 58
+        let toolbarHeight: CGFloat = (currentTool == .text || isEditingText) ? 102 : 58
         let targetX = canvasRect.midX - toolbarWidth / 2
         let maxX = max(margin, screenSize.width - toolbarWidth - margin)
         let x = min(max(targetX, margin), maxX)
@@ -179,6 +194,9 @@ private struct InlineAnnotationEditorView: View {
                 currentStyle: currentStyle,
                 redactionMode: redactionMode,
                 textFontSize: effectiveTextFontSize,
+                textFillColor: textFillColor,
+                textOutlineColor: textOutlineColor,
+                textGlyphStrokeColor: textGlyphStrokeColor,
                 zoomScale: displayScale,
                 refreshTrigger: refreshTrigger,
                 textRegions: textRegions,
@@ -187,8 +205,11 @@ private struct InlineAnnotationEditorView: View {
                     document.clearSelection()
                     currentTool = .select
                 },
-                onTextEditingStarted: { fontSize in
+                onTextEditingStarted: { fontSize, hasFill, hasOutline, hasStroke in
                     isEditingText = true
+                    textFillEnabled = hasFill
+                    textOutlineEnabled = hasOutline
+                    textStrokeEnabled = hasStroke
                     if lineWidth != fontSize {
                         lineWidth = fontSize
                     }
@@ -213,6 +234,9 @@ private struct InlineAnnotationEditorView: View {
                 lineWidth: $lineWidth,
                 strokePattern: $strokePattern,
                 filled: $filled,
+                textFillEnabled: $textFillEnabled,
+                textOutlineEnabled: $textOutlineEnabled,
+                textStrokeEnabled: $textStrokeEnabled,
                 redactionMode: $redactionMode,
                 isEditingText: isEditingText,
                 canUndo: document.canUndo,
@@ -263,6 +287,9 @@ private struct InlineAnnotationEditorView: View {
             updateSelectedStyle()
         }
         .onChange(of: filled) { _, _ in updateSelectedStyle() }
+        .onChange(of: textFillEnabled) { _, _ in updateSelectedStyle() }
+        .onChange(of: textOutlineEnabled) { _, _ in updateSelectedStyle() }
+        .onChange(of: textStrokeEnabled) { _, _ in updateSelectedStyle() }
         .onChange(of: redactionMode) { _, _ in updateSelectedStyle() }
     }
 
@@ -299,6 +326,11 @@ private struct InlineAnnotationEditorView: View {
                     lineWidth: lineWidth,
                     filled: filled
                 )
+            } else if let text = obj as? TextObject {
+                text.fillColor = textFillColor
+                text.outlineColor = textOutlineColor
+                text.glyphStrokeColor = textGlyphStrokeColor
+                text.style = currentStyle
             } else {
                 obj.style = currentStyle
             }
@@ -355,6 +387,9 @@ private struct InlineAnnotationToolbar: View {
     @Binding var lineWidth: CGFloat
     @Binding var strokePattern: StrokePattern
     @Binding var filled: Bool
+    @Binding var textFillEnabled: Bool
+    @Binding var textOutlineEnabled: Bool
+    @Binding var textStrokeEnabled: Bool
     @Binding var redactionMode: RedactionMode
 
     let isEditingText: Bool
@@ -372,108 +407,44 @@ private struct InlineAnnotationToolbar: View {
     }
 
     var body: some View {
-        HStack(spacing: 10) {
-            HStack(spacing: 4) {
-                toolButton(.select)
-                toolButton(.arrow)
-                toolButton(.line)
-                toolButton(.rectangle)
-                toolButton(.ellipse)
-                toolButton(.text)
-                toolButton(.freehand)
-                toolButton(.pixelate)
-                toolButton(.counter)
-                toolButton(.highlighter)
-            }
-
-            divider
-
-            AnnotationColorControls(
-                currentColor: $currentColor,
-                swatchSize: 17,
-                selectedRingColor: .white
-            )
-
-            divider
-
-            HStack(spacing: 7) {
-                if !(currentTool == .pixelate && redactionMode == .solid) {
-                    Slider(value: $lineWidth, in: sliderRange, step: sliderStep)
-                        .frame(width: 82)
-                        .help(sliderHelp)
+        VStack(spacing: 6) {
+            HStack(spacing: 10) {
+                HStack(spacing: 4) {
+                    toolButton(.select)
+                    toolButton(.arrow)
+                    toolButton(.line)
+                    toolButton(.rectangle)
+                    toolButton(.ellipse)
+                    toolButton(.text)
+                    toolButton(.freehand)
+                    toolButton(.pixelate)
+                    toolButton(.counter)
+                    toolButton(.highlighter)
                 }
 
-                if currentTool == .pixelate {
-                    Picker("", selection: $redactionMode) {
-                        ForEach(RedactionMode.allCases, id: \.self) { mode in
-                            Text(mode.label).tag(mode)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .labelsHidden()
-                    .frame(width: 168)
-                    .help("Redaction Mode")
-                }
+                divider
 
-                if currentTool == .arrow || currentTool == .line {
-                    Picker("", selection: $strokePattern) {
-                        ForEach(StrokePattern.allCases, id: \.self) { pattern in
-                            StrokePatternGlyph(pattern: pattern)
-                                .tag(pattern)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .labelsHidden()
-                    .frame(width: 104)
-                    .help("Stroke Pattern")
-                }
-
-                if currentTool != .counter
-                    && currentTool != .arrow
-                    && currentTool != .line
-                    && currentTool != .highlighter
-                    && currentTool != .pixelate
-                    && !isFontSizeMode {
-                    iconButton(
-                        systemName: filled ? "square.fill" : "square",
-                        help: "Fill Shape",
-                        isActive: filled,
-                        action: { filled.toggle() }
-                    )
-                }
-            }
-
-            divider
-
-            HStack(spacing: 4) {
-                iconButton(
-                    systemName: "arrow.uturn.backward",
-                    help: "Undo",
-                    isEnabled: canUndo,
-                    action: onUndo
+                AnnotationColorControls(
+                    currentColor: $currentColor,
+                    swatchSize: 17,
+                    selectedRingColor: .white
                 )
-                .keyboardShortcut("z", modifiers: .command)
 
-                iconButton(
-                    systemName: "arrow.uturn.forward",
-                    help: "Redo",
-                    isEnabled: canRedo,
-                    action: onRedo
-                )
-                .keyboardShortcut("z", modifiers: [.command, .shift])
+                divider
+
+                primaryControls
+
+                divider
+
+                undoRedoControls
+
+                Spacer(minLength: 4)
+
+                actionControls
             }
 
-            Spacer(minLength: 4)
-
-            HStack(spacing: 4) {
-                iconButton(systemName: "xmark", help: "Close", action: onCancel)
-                    .keyboardShortcut(.escape, modifiers: [])
-                iconButton(systemName: "doc.on.doc", help: "Copy", action: onCopy)
-                    .keyboardShortcut("c", modifiers: .command)
-                iconButton(systemName: "pin", help: "Pin to Screen", action: onPin)
-                    .keyboardShortcut("p", modifiers: .command)
-                iconButton(systemName: "square.and.arrow.down", help: "Save", isPrimary: true, action: onSave)
-                    .keyboardShortcut("s", modifiers: .command)
+            if isFontSizeMode {
+                textEffectsGroup
             }
         }
         .padding(.horizontal, 14)
@@ -486,6 +457,114 @@ private struct InlineAnnotationToolbar: View {
         )
         .shadow(color: .black.opacity(0.32), radius: 18, y: 8)
         .environment(\.colorScheme, .dark)
+    }
+
+    private var primaryControls: some View {
+        HStack(spacing: 7) {
+            if !(currentTool == .pixelate && redactionMode == .solid) {
+                Slider(value: $lineWidth, in: sliderRange, step: sliderStep)
+                    .frame(width: 82)
+                    .help(sliderHelp)
+            }
+
+            if currentTool == .pixelate {
+                Picker("", selection: $redactionMode) {
+                    ForEach(RedactionMode.allCases, id: \.self) { mode in
+                        Text(mode.label).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 168)
+                .help("Redaction Mode")
+            }
+
+            if currentTool == .arrow || currentTool == .line {
+                Picker("", selection: $strokePattern) {
+                    ForEach(StrokePattern.allCases, id: \.self) { pattern in
+                        StrokePatternGlyph(pattern: pattern)
+                            .tag(pattern)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 104)
+                .help("Stroke Pattern")
+            }
+
+            if currentTool != .counter
+                && currentTool != .arrow
+                && currentTool != .line
+                && currentTool != .highlighter
+                && currentTool != .pixelate
+                && !isFontSizeMode {
+                iconButton(
+                    systemName: filled ? "square.fill" : "square",
+                    help: "Fill Shape",
+                    isActive: filled,
+                    action: { filled.toggle() }
+                )
+            }
+        }
+    }
+
+    private var undoRedoControls: some View {
+        HStack(spacing: 4) {
+            iconButton(
+                systemName: "arrow.uturn.backward",
+                help: "Undo",
+                isEnabled: canUndo,
+                action: onUndo
+            )
+            .keyboardShortcut("z", modifiers: .command)
+
+            iconButton(
+                systemName: "arrow.uturn.forward",
+                help: "Redo",
+                isEnabled: canRedo,
+                action: onRedo
+            )
+            .keyboardShortcut("z", modifiers: [.command, .shift])
+        }
+    }
+
+    private var actionControls: some View {
+        HStack(spacing: 4) {
+            iconButton(systemName: "xmark", help: "Close", action: onCancel)
+                .keyboardShortcut(.escape, modifiers: [])
+            iconButton(systemName: "doc.on.doc", help: "Copy", action: onCopy)
+                .keyboardShortcut("c", modifiers: .command)
+            iconButton(systemName: "pin", help: "Pin to Screen", action: onPin)
+                .keyboardShortcut("p", modifiers: .command)
+            iconButton(systemName: "square.and.arrow.down", help: "Save", isPrimary: true, action: onSave)
+                .keyboardShortcut("s", modifiers: .command)
+        }
+    }
+
+    private var textEffectsGroup: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                textEffectToggle("Fill", isOn: $textFillEnabled, help: "Text Fill")
+                textEffectToggle("Outline", isOn: $textOutlineEnabled, help: "Text Box Outline")
+                textEffectToggle("Trace", isOn: $textStrokeEnabled, help: "Text Trace")
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func textEffectToggle(
+        _ title: LocalizedStringKey,
+        isOn: Binding<Bool>,
+        help: LocalizedStringKey
+    ) -> some View {
+        Toggle(isOn: isOn) {
+            Text(title)
+                .font(.system(size: 11, weight: .semibold))
+                .frame(minWidth: 46, minHeight: 20)
+        }
+        .toggleStyle(.button)
+        .controlSize(.small)
+        .help(help)
     }
 
     private var divider: some View {

--- a/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
+++ b/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
@@ -182,6 +182,7 @@ final class CaptureAllInOneAnnotationOverlay {
         let usesCompact = session?.usesCompactToolbar ?? (globalRect.width < 760)
         let usesMini = session?.usesMiniToolbar ?? (globalRect.width < 420)
         let showsOverflow = session?.showsOverflow ?? false
+        let showsTextOptions = session.map { $0.currentTool == .text || $0.isEditingText } ?? false
         let width: CGFloat
         let height: CGFloat
         let maxToolbarWidth = screen.visibleFrame.width - margin * 2
@@ -193,7 +194,7 @@ final class CaptureAllInOneAnnotationOverlay {
             } else {
                 width = min(max(420, globalRect.width), min(760, maxToolbarWidth))
             }
-            height = showsOverflow ? 102 : 54
+            height = (showsOverflow ? 102 : 58) + (showsTextOptions ? 42 : 0)
         } else {
             width = min(max(760, globalRect.width), min(960, maxToolbarWidth))
             height = 58
@@ -321,6 +322,9 @@ final class AllInOneAnnotationSession: ObservableObject {
     @Published var currentTool: AnnotationTool
     @Published var currentColor: AnnotationColor
     @Published var filled: Bool
+    @Published var textFillEnabled: Bool
+    @Published var textOutlineEnabled: Bool
+    @Published var textStrokeEnabled: Bool
     @Published var lineWidth: CGFloat
     @Published var strokePattern: StrokePattern
     @Published var redactionMode: RedactionMode
@@ -347,6 +351,9 @@ final class AllInOneAnnotationSession: ObservableObject {
         self.currentTool = Self.storedTool()
         self.currentColor = Self.storedColor()
         self.filled = UserDefaults.standard.bool(forKey: "annotationFilled")
+        self.textFillEnabled = UserDefaults.standard.bool(forKey: "annotationTextFillEnabled")
+        self.textOutlineEnabled = UserDefaults.standard.bool(forKey: "annotationTextOutlineEnabled")
+        self.textStrokeEnabled = Self.storedTextStrokeEnabled()
         self.lineWidth = Self.storedWidth(for: Self.storedTool())
         self.strokePattern = Self.storedStrokePattern()
         self.redactionMode = Self.storedRedactionMode()
@@ -375,6 +382,18 @@ final class AllInOneAnnotationSession: ObservableObject {
 
     var effectiveTextFontSize: CGFloat {
         (currentTool == .text || isEditingText) ? lineWidth : Self.storedTextFontSize()
+    }
+
+    var textFillColor: AnnotationColor? {
+        textFillEnabled ? .black : nil
+    }
+
+    var textOutlineColor: AnnotationColor? {
+        textOutlineEnabled ? .white : nil
+    }
+
+    var textGlyphStrokeColor: AnnotationColor? {
+        textStrokeEnabled ? .white : nil
     }
 
     var usesCompactToolbar: Bool {
@@ -423,6 +442,11 @@ final class AllInOneAnnotationSession: ObservableObject {
                     lineWidth: lineWidth,
                     filled: filled
                 )
+            } else if let text = obj as? TextObject {
+                text.fillColor = textFillColor
+                text.outlineColor = textOutlineColor
+                text.glyphStrokeColor = textGlyphStrokeColor
+                text.style = currentStyle
             } else {
                 obj.style = currentStyle
             }
@@ -489,6 +513,10 @@ final class AllInOneAnnotationSession: ObservableObject {
         return RedactionMode(rawValue: value) ?? .pixelate
     }
 
+    private static func storedTextStrokeEnabled() -> Bool {
+        UserDefaults.standard.object(forKey: "annotationTextStrokeEnabled") as? Bool ?? true
+    }
+
     private static func storedTextFontSize() -> CGFloat {
         CGFloat(UserDefaults.standard.object(forKey: "annotationTextFontSize") as? Double ?? 48)
     }
@@ -520,6 +548,9 @@ private struct AllInOneAnnotationCanvasView: View {
             currentStyle: session.currentStyle,
             redactionMode: session.redactionMode,
             textFontSize: session.effectiveTextFontSize,
+            textFillColor: session.textFillColor,
+            textOutlineColor: session.textOutlineColor,
+            textGlyphStrokeColor: session.textGlyphStrokeColor,
             zoomScale: session.displayScale,
             refreshTrigger: session.refreshTrigger,
             textRegions: session.textRegions,
@@ -529,8 +560,11 @@ private struct AllInOneAnnotationCanvasView: View {
                 session.document.clearSelection()
                 session.switchTool(.select)
             },
-            onTextEditingStarted: { fontSize in
+            onTextEditingStarted: { fontSize, hasFill, hasOutline, hasStroke in
                 session.isEditingText = true
+                session.textFillEnabled = hasFill
+                session.textOutlineEnabled = hasOutline
+                session.textStrokeEnabled = hasStroke
                 if session.lineWidth != fontSize {
                     session.lineWidth = fontSize
                 }
@@ -545,7 +579,13 @@ private struct AllInOneAnnotationCanvasView: View {
 }
 
 private struct AllInOneAnnotationToolbarView: View {
+    private enum TextEffectAction: Hashable {
+        case fill, outline, trace
+    }
+
     @ObservedObject var session: AllInOneAnnotationSession
+    @State private var hoveredTool: AnnotationTool?
+    @State private var hoveredTextEffect: TextEffectAction?
 
     private var isFontSizeMode: Bool {
         session.currentTool == .text || session.isEditingText
@@ -621,6 +661,10 @@ private struct AllInOneAnnotationToolbarView: View {
                 }
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
+
+            if isFontSizeMode && session.usesCompactToolbar {
+                textEffectsRow
+            }
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
@@ -636,26 +680,32 @@ private struct AllInOneAnnotationToolbarView: View {
     }
 
     private var miniToolbar: some View {
-        HStack(spacing: 9) {
-            currentToolGlyph
-                .frame(width: 30, height: 28)
-                .background(Color.accentColor.opacity(0.45), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        VStack(spacing: 8) {
+            HStack(spacing: 9) {
+                currentToolGlyph
+                    .frame(width: 30, height: 28)
+                    .background(Color.accentColor.opacity(0.45), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
 
-            Circle()
-                .fill(Color(cgColor: session.currentColor.cgColor))
-                .frame(width: 18, height: 18)
-                .overlay(Circle().stroke(Color.white.opacity(0.62), lineWidth: 1.5))
+                Circle()
+                    .fill(Color(cgColor: session.currentColor.cgColor))
+                    .frame(width: 18, height: 18)
+                    .overlay(Circle().stroke(Color.white.opacity(0.62), lineWidth: 1.5))
 
-            Text(compactValueLabel)
-                .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                .foregroundStyle(.white.opacity(0.86))
-                .frame(minWidth: 34)
+                Text(compactValueLabel)
+                    .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(.white.opacity(0.86))
+                    .frame(minWidth: 34)
 
-            iconButton(
-                systemName: "ellipsis",
-                help: "More tools",
-                action: { session.toggleOverflow() }
-            )
+                iconButton(
+                    systemName: "ellipsis",
+                    help: "More tools",
+                    action: { session.toggleOverflow() }
+                )
+            }
+
+            if isFontSizeMode {
+                textEffectsRow
+            }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
@@ -722,6 +772,10 @@ private struct AllInOneAnnotationToolbarView: View {
                 strokePatternControl
             }
 
+            if isFontSizeMode && !session.usesCompactToolbar {
+                textEffectsInlineControls
+            }
+
             if session.currentTool != .counter
                 && session.currentTool != .arrow
                 && session.currentTool != .line
@@ -740,6 +794,172 @@ private struct AllInOneAnnotationToolbarView: View {
                 )
             }
         }
+    }
+
+    private var textEffectsInlineControls: some View {
+        HStack(spacing: 4) {
+            textEffectIconButton(
+                .fill,
+                systemName: "square.fill",
+                label: String(localized: "Fill"),
+                help: "Text Fill",
+                isActive: session.textFillEnabled,
+                defaultsKey: "annotationTextFillEnabled"
+            ) {
+                session.textFillEnabled.toggle()
+                return session.textFillEnabled
+            }
+            textEffectIconButton(
+                .outline,
+                systemName: "square",
+                label: String(localized: "Box"),
+                help: "Text Box Outline",
+                isActive: session.textOutlineEnabled,
+                defaultsKey: "annotationTextOutlineEnabled"
+            ) {
+                session.textOutlineEnabled.toggle()
+                return session.textOutlineEnabled
+            }
+            textEffectGlyphButton(
+                .trace,
+                glyph: "Aa",
+                label: String(localized: "Trace"),
+                help: "Text Trace",
+                isActive: session.textStrokeEnabled,
+                defaultsKey: "annotationTextStrokeEnabled"
+            ) {
+                session.textStrokeEnabled.toggle()
+                return session.textStrokeEnabled
+            }
+        }
+    }
+
+    private var textEffectsRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                textEffectButton(
+                    title: "Fill",
+                    isActive: session.textFillEnabled,
+                    defaultsKey: "annotationTextFillEnabled"
+                ) {
+                    session.textFillEnabled.toggle()
+                    return session.textFillEnabled
+                }
+                textEffectButton(
+                    title: "Outline",
+                    isActive: session.textOutlineEnabled,
+                    defaultsKey: "annotationTextOutlineEnabled"
+                ) {
+                    session.textOutlineEnabled.toggle()
+                    return session.textOutlineEnabled
+                }
+                textEffectButton(
+                    title: "Trace",
+                    isActive: session.textStrokeEnabled,
+                    defaultsKey: "annotationTextStrokeEnabled"
+                ) {
+                    session.textStrokeEnabled.toggle()
+                    return session.textStrokeEnabled
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private func textEffectIconButton(
+        _ kind: TextEffectAction,
+        systemName: String,
+        label: String,
+        help: LocalizedStringKey,
+        isActive: Bool,
+        defaultsKey: String,
+        toggle: @escaping () -> Bool
+    ) -> some View {
+        Button {
+            let newValue = toggle()
+            UserDefaults.standard.set(newValue, forKey: defaultsKey)
+            session.updateSelectedStyle()
+        } label: {
+            VStack(spacing: hoveredTextEffect == kind ? 1 : 0) {
+                Image(systemName: systemName)
+                    .font(.system(size: 13, weight: .semibold))
+                    .frame(height: hoveredTextEffect == kind ? 17 : 38)
+
+                if hoveredTextEffect == kind {
+                    Text(label)
+                        .font(.system(size: 8.5, weight: .semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.68)
+                        .transition(.opacity)
+                }
+            }
+            .foregroundStyle(.white)
+            .frame(width: 32, height: 38)
+            .background(buttonBackground(isActive: isActive, isEnabled: true))
+            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .onHover { hoveredTextEffect = $0 ? kind : nil }
+        .help(help)
+    }
+
+    private func textEffectGlyphButton(
+        _ kind: TextEffectAction,
+        glyph: String,
+        label: String,
+        help: LocalizedStringKey,
+        isActive: Bool,
+        defaultsKey: String,
+        toggle: @escaping () -> Bool
+    ) -> some View {
+        Button {
+            let newValue = toggle()
+            UserDefaults.standard.set(newValue, forKey: defaultsKey)
+            session.updateSelectedStyle()
+        } label: {
+            VStack(spacing: hoveredTextEffect == kind ? 1 : 0) {
+                Text(verbatim: glyph)
+                    .font(.system(size: 12, weight: .semibold))
+                    .frame(height: hoveredTextEffect == kind ? 17 : 38)
+
+                if hoveredTextEffect == kind {
+                    Text(label)
+                        .font(.system(size: 8.5, weight: .semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.68)
+                        .transition(.opacity)
+                }
+            }
+            .foregroundStyle(.white)
+            .frame(width: 32, height: 38)
+            .background(buttonBackground(isActive: isActive, isEnabled: true))
+            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .onHover { hoveredTextEffect = $0 ? kind : nil }
+        .help(help)
+    }
+
+    private func textEffectButton(
+        title: LocalizedStringKey,
+        isActive: Bool,
+        defaultsKey: String,
+        toggle: @escaping () -> Bool
+    ) -> some View {
+        Button {
+            let newValue = toggle()
+            UserDefaults.standard.set(newValue, forKey: defaultsKey)
+            session.updateSelectedStyle()
+        } label: {
+            Text(title)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(minWidth: 54, minHeight: 26)
+                .background(optionBackground(isActive: isActive))
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .help(title)
     }
 
     private var undoRedoControls: some View {
@@ -892,21 +1112,33 @@ private struct AllInOneAnnotationToolbarView: View {
     @ViewBuilder
     private func toolButton(_ tool: AnnotationTool) -> some View {
         Button(action: { session.switchTool(tool) }) {
-            Group {
-                if tool == .text {
-                    Text(verbatim: "Aa")
-                        .font(.system(size: 13, weight: .semibold))
-                } else {
-                    Image(systemName: iconName(for: tool))
-                        .font(.system(size: 14, weight: .medium))
+            VStack(spacing: hoveredTool == tool ? 1 : 0) {
+                Group {
+                    if tool == .text {
+                        Text(verbatim: "Aa")
+                            .font(.system(size: 13, weight: .semibold))
+                    } else {
+                        Image(systemName: iconName(for: tool))
+                            .font(.system(size: 14, weight: .medium))
+                    }
+                }
+                .frame(height: hoveredTool == tool ? 17 : 38)
+
+                if hoveredTool == tool {
+                    Text(toolHoverLabel(for: tool))
+                        .font(.system(size: 8.5, weight: .semibold))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.68)
+                        .transition(.opacity)
                 }
             }
             .foregroundStyle(.white)
-            .frame(width: 29, height: 28)
+            .frame(width: 29, height: 38)
             .background(session.currentTool == tool ? Color.accentColor.opacity(0.45) : Color.white.opacity(0.001))
             .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
         }
         .buttonStyle(.plain)
+        .onHover { hoveredTool = $0 ? tool : nil }
         .help(helpText(for: tool))
     }
 
@@ -964,6 +1196,21 @@ private struct AllInOneAnnotationToolbarView: View {
         case .pixelate: return "Pixelate / Blur"
         case .counter: return "Counter"
         case .highlighter: return "Highlighter"
+        }
+    }
+
+    private func toolHoverLabel(for tool: AnnotationTool) -> String {
+        switch tool {
+        case .select: return String(localized: "Select")
+        case .arrow: return String(localized: "Arrow")
+        case .line: return String(localized: "Line")
+        case .rectangle: return String(localized: "Rect")
+        case .ellipse: return String(localized: "Oval")
+        case .text: return String(localized: "Text")
+        case .freehand: return String(localized: "Draw")
+        case .pixelate: return String(localized: "Pixel")
+        case .counter: return String(localized: "Count")
+        case .highlighter: return String(localized: "Mark")
         }
     }
 }

--- a/Packages/AnnotationKit/Sources/AnnotationKit/Helpers/TextResizeGeometry.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/Helpers/TextResizeGeometry.swift
@@ -1,0 +1,117 @@
+import CoreGraphics
+
+public enum TextResizeHandle: Sendable {
+    case topLeft
+    case topRight
+    case bottomLeft
+    case bottomRight
+}
+
+public enum TextResizeGeometry {
+    public static func rect(
+        originalBounds: CGRect,
+        handle: TextResizeHandle,
+        dragDelta: CGSize,
+        minSize: CGSize
+    ) -> CGRect {
+        var rect = targetRect(
+            originalBounds: originalBounds,
+            handle: handle,
+            dragDelta: dragDelta
+        )
+
+        switch handle {
+        case .topLeft, .bottomLeft:
+            let maxX = originalBounds.maxX
+            rect.origin.x = min(rect.origin.x, maxX - minSize.width)
+            rect.size.width = maxX - rect.origin.x
+        case .topRight, .bottomRight:
+            rect.size.width = max(minSize.width, rect.width)
+        }
+
+        switch handle {
+        case .topLeft, .topRight:
+            let maxY = originalBounds.maxY
+            rect.origin.y = min(rect.origin.y, maxY - minSize.height)
+            rect.size.height = maxY - rect.origin.y
+        case .bottomLeft, .bottomRight:
+            rect.size.height = max(minSize.height, rect.height)
+        }
+
+        return rect
+    }
+
+    public static func fontSize(
+        originalBounds: CGRect,
+        originalFontSize: CGFloat,
+        handle: TextResizeHandle,
+        dragDelta: CGSize,
+        minFontSize: CGFloat = 6
+    ) -> CGFloat {
+        guard originalBounds.width > 0, originalBounds.height > 0 else {
+            return max(minFontSize, originalFontSize)
+        }
+
+        let target = targetRect(
+            originalBounds: originalBounds,
+            handle: handle,
+            dragDelta: dragDelta
+        )
+        let scaleX = max(10, target.width) / originalBounds.width
+        let scaleY = max(10, target.height) / originalBounds.height
+        return max(minFontSize, originalFontSize * max(scaleX, scaleY))
+    }
+
+    public static func origin(
+        originalBounds: CGRect,
+        resizedSize: CGSize,
+        handle: TextResizeHandle
+    ) -> CGPoint {
+        switch handle {
+        case .topLeft:
+            CGPoint(
+                x: originalBounds.maxX - resizedSize.width,
+                y: originalBounds.maxY - resizedSize.height
+            )
+        case .topRight:
+            CGPoint(
+                x: originalBounds.minX,
+                y: originalBounds.maxY - resizedSize.height
+            )
+        case .bottomLeft:
+            CGPoint(
+                x: originalBounds.maxX - resizedSize.width,
+                y: originalBounds.minY
+            )
+        case .bottomRight:
+            originalBounds.origin
+        }
+    }
+
+    private static func targetRect(
+        originalBounds: CGRect,
+        handle: TextResizeHandle,
+        dragDelta: CGSize
+    ) -> CGRect {
+        var rect = originalBounds
+        switch handle {
+        case .topLeft:
+            rect.origin.x = originalBounds.minX + dragDelta.width
+            rect.origin.y = originalBounds.minY + dragDelta.height
+            rect.size.width = originalBounds.width - dragDelta.width
+            rect.size.height = originalBounds.height - dragDelta.height
+        case .topRight:
+            rect.origin.y = originalBounds.minY + dragDelta.height
+            rect.size.width = originalBounds.width + dragDelta.width
+            rect.size.height = originalBounds.height - dragDelta.height
+        case .bottomLeft:
+            rect.origin.x = originalBounds.minX + dragDelta.width
+            rect.size.width = originalBounds.width - dragDelta.width
+            rect.size.height = originalBounds.height + dragDelta.height
+        case .bottomRight:
+            rect.size.width = originalBounds.width + dragDelta.width
+            rect.size.height = originalBounds.height + dragDelta.height
+        }
+        return rect
+    }
+}

--- a/Packages/AnnotationKit/Sources/AnnotationKit/Objects/TextObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/Objects/TextObject.swift
@@ -3,22 +3,42 @@ import CoreGraphics
 import AppKit
 
 public final class TextObject: AnnotationObject, @unchecked Sendable {
+    private static let glyphTraceStrokeWidth: CGFloat = 3.0
+
     public let id = ObjectID()
     public var style: StrokeStyle
     public var text: String
     public var origin: CGPoint
+    public var boxSize: CGSize?
     public var fontSize: CGFloat
     public var fontName: String
+    public var fillColor: AnnotationColor?
+    public var outlineColor: AnnotationColor?
+    public var glyphStrokeColor: AnnotationColor?
 
-    public init(text: String, origin: CGPoint, fontSize: CGFloat = 48, fontName: String = ".AppleSystemUIFont", style: StrokeStyle = StrokeStyle()) {
+    public init(
+        text: String,
+        origin: CGPoint,
+        boxSize: CGSize? = nil,
+        fontSize: CGFloat = 48,
+        fontName: String = ".AppleSystemUIFont",
+        fillColor: AnnotationColor? = nil,
+        outlineColor: AnnotationColor? = nil,
+        glyphStrokeColor: AnnotationColor? = nil,
+        style: StrokeStyle = StrokeStyle()
+    ) {
         self.text = text
         self.origin = origin
+        self.boxSize = boxSize
         self.fontSize = fontSize
         self.fontName = fontName
+        self.fillColor = fillColor
+        self.outlineColor = outlineColor
+        self.glyphStrokeColor = glyphStrokeColor
         self.style = style
     }
 
-    private var attributes: [NSAttributedString.Key: Any] {
+    private var fillAttributes: [NSAttributedString.Key: Any] {
         let font = NSFont(name: fontName, size: fontSize) ?? NSFont.systemFont(ofSize: fontSize, weight: .medium)
         return [
             .font: font,
@@ -26,9 +46,40 @@ public final class TextObject: AnnotationObject, @unchecked Sendable {
         ]
     }
 
-    public var bounds: CGRect {
-        let size = (text as NSString).size(withAttributes: attributes)
+    private var traceAttributes: [NSAttributedString.Key: Any]? {
+        guard let glyphStrokeColor else { return nil }
+        var attrs = fillAttributes
+        attrs[.strokeColor] = glyphStrokeColor.nsColor
+        attrs[.strokeWidth] = Self.glyphTraceStrokeWidth
+        return attrs
+    }
+
+    private var textBounds: CGRect {
+        if let boxSize {
+            return CGRect(origin: origin, size: boxSize)
+        }
+        let size = (text as NSString).size(withAttributes: fillAttributes)
         return CGRect(origin: origin, size: size)
+    }
+
+    private var boxPadding: CGFloat { 4 }
+
+    private var effectPadding: CGFloat {
+        let boxEffectPadding = (fillColor != nil || outlineColor != nil) ? boxPadding : 0
+        let glyphStrokePadding = glyphStrokeColor == nil ? 0 : max(boxPadding, ceil(fontSize * 0.03))
+        return max(boxEffectPadding, glyphStrokePadding)
+    }
+
+    private var effectBounds: CGRect {
+        textBounds.insetBy(dx: -effectPadding, dy: -effectPadding)
+    }
+
+    private var boxedTextRect: CGRect {
+        textBounds.insetBy(dx: boxPadding, dy: boxPadding)
+    }
+
+    public var bounds: CGRect {
+        (fillColor != nil || outlineColor != nil || glyphStrokeColor != nil) ? effectBounds : textBounds
     }
 
     public func hitTest(point: CGPoint, threshold: CGFloat) -> Bool {
@@ -39,8 +90,35 @@ public final class TextObject: AnnotationObject, @unchecked Sendable {
         let nsCtx = NSGraphicsContext(cgContext: ctx, flipped: true)
         NSGraphicsContext.saveGraphicsState()
         NSGraphicsContext.current = nsCtx
-        (text as NSString).draw(at: origin, withAttributes: attributes)
+        if fillColor != nil || outlineColor != nil {
+            let path = NSBezierPath(roundedRect: effectBounds, xRadius: 4, yRadius: 4)
+            if let fillColor {
+                fillColor.nsColor.withAlphaComponent(0.5).setFill()
+                path.fill()
+            }
+            if let outlineColor {
+                outlineColor.nsColor.setStroke()
+                path.lineWidth = 2
+                path.stroke()
+            }
+        }
+        if let traceAttributes {
+            drawText(with: traceAttributes)
+        }
+        drawText(with: fillAttributes)
         NSGraphicsContext.restoreGraphicsState()
+    }
+
+    private func drawText(with attributes: [NSAttributedString.Key: Any]) {
+        if boxSize != nil {
+            (text as NSString).draw(
+                with: boxedTextRect,
+                options: [.usesLineFragmentOrigin, .usesFontLeading],
+                attributes: attributes
+            )
+        } else {
+            (text as NSString).draw(at: origin, withAttributes: attributes)
+        }
     }
 
     public func move(by delta: CGSize) {
@@ -49,6 +127,16 @@ public final class TextObject: AnnotationObject, @unchecked Sendable {
     }
 
     public func copy() -> any AnnotationObject {
-        TextObject(text: text, origin: origin, fontSize: fontSize, fontName: fontName, style: style)
+        TextObject(
+            text: text,
+            origin: origin,
+            boxSize: boxSize,
+            fontSize: fontSize,
+            fontName: fontName,
+            fillColor: fillColor,
+            outlineColor: outlineColor,
+            glyphStrokeColor: glyphStrokeColor,
+            style: style
+        )
     }
 }

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationObjectTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationObjectTests.swift
@@ -2,6 +2,7 @@
 import Testing
 import Foundation
 import CoreGraphics
+import AppKit
 @testable import AnnotationKit
 
 @Suite("AnnotationObject")
@@ -56,6 +57,150 @@ struct AnnotationObjectTests {
         let id1 = ObjectID()
         let id2 = ObjectID()
         #expect(id1 != id2)
+    }
+}
+
+@Suite("TextObject")
+struct TextObjectTests {
+    @Test("Text copy preserves text effect colors")
+    func copyPreservesTextEffectColors() {
+        let text = TextObject(
+            text: "Hello",
+            origin: CGPoint(x: 10, y: 20),
+            boxSize: CGSize(width: 120, height: 40),
+            fillColor: .black,
+            outlineColor: .white,
+            glyphStrokeColor: .white
+        )
+
+        let copy = text.copy() as? TextObject
+
+        #expect(copy?.text == text.text)
+        #expect(copy?.origin == text.origin)
+        #expect(copy?.boxSize == CGSize(width: 120, height: 40))
+        #expect(copy?.fillColor == .black)
+        #expect(copy?.outlineColor == .white)
+        #expect(copy?.glyphStrokeColor == .white)
+    }
+
+    @Test("Text trace expands bounds enough for large glyph stroke")
+    func traceExpandsBoundsEnoughForLargeGlyphStroke() {
+        let text = TextObject(
+            text: "Trace",
+            origin: CGPoint(x: 20, y: 30),
+            boxSize: CGSize(width: 100, height: 40),
+            fontSize: 200,
+            glyphStrokeColor: .white
+        )
+
+        #expect(text.bounds == CGRect(x: 14, y: 24, width: 112, height: 52))
+    }
+
+    @Test("Text trace preserves the foreground color")
+    func tracePreservesForegroundColor() {
+        let text = TextObject(
+            text: "傅师大发生的",
+            origin: CGPoint(x: 20, y: 20),
+            boxSize: CGSize(width: 380, height: 96),
+            fontSize: 72,
+            glyphStrokeColor: .white,
+            style: StrokeStyle(color: .yellow)
+        )
+
+        let counts = renderColorCounts(text)
+
+        #expect(counts.yellow > counts.white)
+    }
+
+    @Test("Resize geometry scales text from bottom right while anchoring top left")
+    func resizeGeometryScalesFromBottomRight() {
+        let originalBounds = CGRect(x: 10, y: 20, width: 100, height: 50)
+
+        let fontSize = TextResizeGeometry.fontSize(
+            originalBounds: originalBounds,
+            originalFontSize: 20,
+            handle: .bottomRight,
+            dragDelta: CGSize(width: 50, height: 10)
+        )
+        let origin = TextResizeGeometry.origin(
+            originalBounds: originalBounds,
+            resizedSize: CGSize(width: 150, height: 75),
+            handle: .bottomRight
+        )
+
+        #expect(fontSize == 30)
+        #expect(origin == CGPoint(x: 10, y: 20))
+    }
+
+    @Test("Resize geometry keeps the opposite corner anchored")
+    func resizeGeometryKeepsOppositeCornerAnchored() {
+        let originalBounds = CGRect(x: 10, y: 20, width: 100, height: 50)
+
+        let origin = TextResizeGeometry.origin(
+            originalBounds: originalBounds,
+            resizedSize: CGSize(width: 150, height: 75),
+            handle: .topLeft
+        )
+
+        #expect(origin == CGPoint(x: -40, y: -5))
+    }
+
+    @Test("Resize geometry changes text box while preserving opposite edge")
+    func resizeGeometryChangesTextBox() {
+        let originalBounds = CGRect(x: 10, y: 20, width: 100, height: 50)
+
+        let rect = TextResizeGeometry.rect(
+            originalBounds: originalBounds,
+            handle: .topLeft,
+            dragDelta: CGSize(width: 20, height: 10),
+            minSize: CGSize(width: 60, height: 30)
+        )
+
+        #expect(rect == CGRect(x: 30, y: 30, width: 80, height: 40))
+    }
+
+    private func renderColorCounts(_ text: TextObject) -> (yellow: Int, white: Int) {
+        let width = 420
+        let height = 140
+        let bytesPerPixel = 4
+        var pixels = [UInt8](repeating: 0, count: width * height * bytesPerPixel)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+
+        guard let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * bytesPerPixel,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo
+        ) else {
+            Issue.record("Could not create bitmap context")
+            return (0, 0)
+        }
+
+        context.setFillColor(CGColor(gray: 0, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        text.render(in: context)
+
+        var yellow = 0
+        var white = 0
+        for index in stride(from: 0, to: pixels.count, by: bytesPerPixel) {
+            let r = pixels[index]
+            let g = pixels[index + 1]
+            let b = pixels[index + 2]
+            let a = pixels[index + 3]
+            guard a > 0 else { continue }
+
+            if r > 180, g > 140, b < 80 {
+                yellow += 1
+            } else if r > 180, g > 180, b > 180 {
+                white += 1
+            }
+        }
+
+        return (yellow, white)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add text annotation fill, box outline, and glyph trace support, with trace enabled by default for readability.
- Fix live text editing so trace is drawn behind foreground text instead of washing out the typed characters.
- Improve all-in-one annotation toolbar text controls, compact layout, and hover labels for bottom tool icons/effect buttons.

## Root Cause
Text annotations only rendered the foreground glyphs, so low-contrast backgrounds made them hard to read. The first trace implementation also relied on AppKit stroke attributes in the live editor, which could make the foreground text appear white or visually offset while editing.

## Validation
- `swift test --package-path Packages/AnnotationKit` passed: 55 tests, 0 failures.
- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passed.

Note: Xcode still prints the existing CoreSimulator out-of-date warning, but the macOS build succeeds.

Fixes #107
