### PR TITLE
feat: improve screenshot output workflow

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -6579,6 +6579,1238 @@
         "ko" : { "stringUnit" : { "state" : "translated", "value" : "흰색" } },
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "白色" } }
       }
+    },
+    "Customizable Shortcuts" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタマイズ可能なショートカット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용자 지정 단축키"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自定义快捷键"
+          }
+        }
+      }
+    },
+    "Contextual Shortcuts" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コンテキストショートカット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상황별 단축키"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "上下文快捷键"
+          }
+        }
+      }
+    },
+    "Click a customizable shortcut to record a new combination. Press Esc to cancel or Delete to remove. Contextual shortcuts are fixed and work only while that panel is active." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カスタマイズ可能なショートカットをクリックして新しい組み合わせを記録します。Escでキャンセル、Deleteで削除します。コンテキストショートカットは固定で、そのパネルがアクティブな間だけ機能します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용자 지정 가능한 단축키를 클릭해 새 조합을 기록하세요. Esc로 취소하고 Delete로 제거합니다. 상황별 단축키는 고정되어 있으며 해당 패널이 활성화된 동안에만 작동합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击可自定义快捷键以录制新的组合。按 Esc 取消，按 Delete 移除。上下文快捷键是固定的，仅在对应面板处于活动状态时生效。"
+          }
+        }
+      }
+    },
+    "Save selected area" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択範囲を保存"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택 영역 저장"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存所选区域"
+          }
+        }
+      }
+    },
+    "Pin selected area" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択範囲をピン留め"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택 영역 고정"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "固定所选区域"
+          }
+        }
+      }
+    },
+    "Copy selected area (%@)" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択範囲をコピー（%@）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택 영역 복사(%@)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "复制所选区域（%@）"
+          }
+        }
+      }
+    },
+    "Save selected area (%@)" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択範囲を保存（%@）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택 영역 저장(%@)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存所选区域（%@）"
+          }
+        }
+      }
+    },
+    "Pin selected area (%@)" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択範囲をピン留め（%@）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택 영역 고정(%@)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "固定所选区域（%@）"
+          }
+        }
+      }
+    },
+    "Cancel (%@)" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル（%@）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "취소(%@)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消（%@）"
+          }
+        }
+      }
+    },
+    "Screenshot Quality" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクリーンショット品質"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스크린샷 품질"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截图品质"
+          }
+        }
+      }
+    },
+    "Applies to screenshot files" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクリーンショットファイルに適用"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스크린샷 파일에 적용"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "适用于截图文件"
+          }
+        }
+      }
+    },
+    "Monthly Screenshot Folders" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "月別スクリーンショットフォルダ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "월별 스크린샷 폴더"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按月保存截图文件夹"
+          }
+        }
+      }
+    },
+    "Save screenshots into yyyy-MM subfolders" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクリーンショットを yyyy-MM サブフォルダに保存"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스크린샷을 yyyy-MM 하위 폴더에 저장"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将截图保存到 yyyy-MM 子文件夹"
+          }
+        }
+      }
+    },
+    "JPEG 85%" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JPEG 85%"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JPEG 85%"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JPEG 85%"
+          }
+        }
+      }
+    },
+    "JPEG 70%" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JPEG 70%"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JPEG 70%"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "JPEG 70%"
+          }
+        }
+      }
+    },
+    "Cloud Share" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クラウド共有"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클라우드 공유"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "云端分享"
+          }
+        }
+      }
+    },
+    "Status" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ステータス"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상태"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "状态"
+          }
+        }
+      }
+    },
+    "Provider" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プロバイダ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "제공업체"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "服务商"
+          }
+        }
+      }
+    },
+    "Public URL Prefix" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公開URLプレフィックス"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "공개 URL 접두사"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "公共 URL 前缀"
+          }
+        }
+      }
+    },
+    "Bucket" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バケット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버킷"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存储桶"
+          }
+        }
+      }
+    },
+    "Actions" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作"
+          }
+        }
+      }
+    },
+    "Verify the bucket is reachable" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バケットに到達できるか確認"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버킷에 접근할 수 있는지 확인"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "验证存储桶是否可访问"
+          }
+        }
+      }
+    },
+    "Reset Configuration" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定をリセット"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "구성 재설정"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重置配置"
+          }
+        }
+      }
+    },
+    "Remove all Cloud Share credentials" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのクラウド共有認証情報を削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "모든 클라우드 공유 자격 증명 제거"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除所有云端分享凭据"
+          }
+        }
+      }
+    },
+    "Remember Last Recording Area" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最後の録画範囲を記憶"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마지막 녹화 영역 기억"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "记住上次录屏区域"
+          }
+        }
+      }
+    },
+    "Automatically Install Updates" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデートを自動インストール"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "업데이트 자동 설치"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动安装更新"
+          }
+        }
+      }
+    },
+    "Install updates in the background when available" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "利用可能なアップデートをバックグラウンドでインストール"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용 가능한 업데이트를 백그라운드에서 설치"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有可用更新时在后台安装"
+          }
+        }
+      }
+    },
+    "1 Week" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1週間"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1주"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 周"
+          }
+        }
+      }
+    },
+    "2 Weeks" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2週間"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2주"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2 周"
+          }
+        }
+      }
+    },
+    "1 Month" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1か月"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1개월"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 个月"
+          }
+        }
+      }
+    },
+    "Diagnostic Logging" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "診断ログ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "진단 로그"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "诊断日志"
+          }
+        }
+      }
+    },
+    "Write local troubleshooting logs when enabled" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "有効にするとローカルのトラブルシューティングログを書き込みます"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "활성화하면 로컬 문제 해결 로그를 기록합니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用后写入本地故障排查日志"
+          }
+        }
+      }
+    },
+    "Diagnostic Logs" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "診断ログ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "진단 로그"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "诊断日志"
+          }
+        }
+      }
+    },
+    "Open Capso's local log folder" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capsoのローカルログフォルダを開く"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Capso 로컬 로그 폴더 열기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开 Capso 的本地日志文件夹"
+          }
+        }
+      }
+    },
+    "Crash Reports" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クラッシュレポート"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "충돌 보고서"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "崩溃报告"
+          }
+        }
+      }
+    },
+    "Open macOS DiagnosticReports" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "macOS DiagnosticReportsを開く"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "macOS DiagnosticReports 열기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开 macOS DiagnosticReports"
+          }
+        }
+      }
+    },
+    "Include the mouse pointer in screenshots" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクリーンショットにマウスポインタを含める"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스크린샷에 마우스 포인터 포함"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在截图中包含鼠标指针"
+          }
+        }
+      }
+    },
+    "Default Duration" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デフォルト時間"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기본 시간"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "默认时长"
+          }
+        }
+      }
+    },
+    "Delay before the screenshot fires" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "スクリーンショット撮影までの遅延"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "스크린샷 촬영 전 지연 시간"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "截图触发前的延迟"
+          }
+        }
+      }
+    },
+    "Tick Sound" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カウント音"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "틱 소리"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "倒计时提示音"
+          }
+        }
+      }
+    },
+    "Play a sound on each second of the countdown" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カウントダウンの各秒で音を鳴らす"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카운트다운 매초 소리 재생"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "倒计时每秒播放提示音"
+          }
+        }
+      }
+    },
+    "Useful for capturing menus, hover states, and other UI that disappears the moment you move the mouse." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メニュー、ホバー状態、マウスを動かすと消えるUIの撮影に便利です。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메뉴, 호버 상태, 마우스를 움직이면 사라지는 UI를 캡처할 때 유용합니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "适合捕捉菜单、悬停状态，以及鼠标一移动就会消失的界面。"
+          }
+        }
+      }
+    },
+    "Auto-detect if unset" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未設定の場合は自動検出"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정하지 않으면 자동 감지"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未设置时自动检测"
+          }
+        }
+      }
+    },
+    "Primary Language" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主言語"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기본 언어"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主要语言"
+          }
+        }
+      }
+    },
+    "Default Recording Format" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "デフォルト録画形式"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기본 녹화 형식"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "默认录屏格式"
+          }
+        }
+      }
+    },
+    "Dim Screen While Recording" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録画中に画面を暗くする"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "녹화 중 화면 어둡게 하기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "录屏时调暗屏幕"
+          }
+        }
+      }
+    },
+    "Cursor Smoothing" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カーソルの平滑化"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "커서 부드럽게 처리"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "光标平滑"
+          }
+        }
+      }
+    },
+    "Bézier interpolation to reduce jitter" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ベジェ補間で揺れを軽減"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "베지어 보간으로 흔들림 감소"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用贝塞尔插值减少抖动"
+          }
+        }
+      }
+    },
+    "Checking…" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確認中…"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확인 중…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在检查…"
+          }
+        }
+      }
+    },
+    "e.g. 16" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "例: 16"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "예: 16"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "例如 16"
+          }
+        }
+      }
+    },
+    "e.g. 9" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "例: 9"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "예: 9"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "例如 9"
+          }
+        }
+      }
+    },
+    "e.g. Widescreen" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "例: ワイドスクリーン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "예: 와이드스크린"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "例如 宽屏"
+          }
+        }
+      }
+    },
+    "In `R2 → Overview`, click `Create bucket`. Name it something memorable like `capso-shares`." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`R2 → Overview` で `Create bucket` をクリックします。`capso-shares` のような覚えやすい名前を付けます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`R2 → Overview`에서 `Create bucket`을 클릭하세요. `capso-shares`처럼 기억하기 쉬운 이름을 지정하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 `R2 → Overview` 中点击 `Create bucket`。取一个容易记住的名称，比如 `capso-shares`。"
+          }
+        }
+      }
+    },
+    "`R2 → Manage API Tokens` → `Create API Token`. Choose **Object Read & Write**, scoped to this bucket." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`R2 → Manage API Tokens` → `Create API Token`。**Object Read & Write** を選び、このバケットにスコープします。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`R2 → Manage API Tokens` → `Create API Token`으로 이동하세요. **Object Read & Write**를 선택하고 이 버킷으로 범위를 제한하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`R2 → Manage API Tokens` → `Create API Token`。选择 **Object Read & Write**，并限定到这个存储桶。"
+          }
+        }
+      }
+    },
+    "In the bucket's `Settings` tab: click `Enable` next to **Public Development URL** for a free `pub-…r2.dev` link, OR click `+ Add` next to **Custom Domains** to use your own domain." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バケットの `Settings` タブで、**Public Development URL** の横にある `Enable` をクリックして無料の `pub-…r2.dev` リンクを取得するか、**Custom Domains** の横にある `+ Add` をクリックして独自ドメインを使用します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버킷의 `Settings` 탭에서 **Public Development URL** 옆의 `Enable`을 클릭해 무료 `pub-…r2.dev` 링크를 받거나, **Custom Domains** 옆의 `+ Add`를 클릭해 자체 도메인을 사용하세요."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在存储桶的 `Settings` 标签页中：点击 **Public Development URL** 旁边的 `Enable` 获取免费的 `pub-…r2.dev` 链接，或者点击 **Custom Domains** 旁边的 `+ Add` 使用你自己的域名。"
+          }
+        }
+      }
+    },
+    "You'll get `Account ID`, `Access Key ID`, and `Secret Access Key`. Note your bucket name too. The secret won't be shown again." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`Account ID`、`Access Key ID`、`Secret Access Key` が表示されます。バケット名も控えてください。シークレットは再表示されません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "`Account ID`, `Access Key ID`, `Secret Access Key`를 받게 됩니다. 버킷 이름도 기록해 두세요. 비밀 키는 다시 표시되지 않습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你会得到 `Account ID`、`Access Key ID` 和 `Secret Access Key`。也请记下存储桶名称。密钥不会再次显示。"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -37,6 +37,8 @@ final class CaptureAllInOneToolbarWindow {
     var onAnnotate: ((CGRect) -> Void)?
     var onCopy: ((CGRect) -> Void)?
     var onCopyRendered: ((CGImage, CGRect) -> Void)?
+    var onSave: ((CGRect) -> Void)?
+    var onSaveRendered: ((CGImage, CGRect) -> Void)?
     var onPin: ((CGRect) -> Void)?
     var onPinRendered: ((CGImage, CGRect) -> Void)?
     var onOCRRendered: ((CGImage, CGRect) -> Void)?
@@ -73,11 +75,11 @@ final class CaptureAllInOneToolbarWindow {
         showSelectionOverlay()
         showToolbar()
         showAnnotationOverlayIfPossible()
-        installEscMonitor()
+        installKeyboardMonitor()
     }
 
     func close() {
-        removeEscMonitor()
+        removeKeyboardMonitor()
         annotationOverlay?.close()
         annotationOverlay = nil
         removeSelectionMouseMonitor()
@@ -203,36 +205,9 @@ final class CaptureAllInOneToolbarWindow {
                 guard let self else { return }
                 self.onAnnotate?(self.screenLocalSelectionRect)
             },
-            onCopy: { [weak self] in
-                guard let self else { return }
-                if let annotationOverlay = self.annotationOverlay {
-                    annotationOverlay.renderImage(afterCommit: { [weak self] rendered in
-                        guard let self else { return }
-                        if let rendered {
-                            self.onCopyRendered?(rendered, self.screenLocalSelectionRect)
-                        } else {
-                            self.onCopy?(self.screenLocalSelectionRect)
-                        }
-                    })
-                } else {
-                    self.onCopy?(self.screenLocalSelectionRect)
-                }
-            },
-            onPin: { [weak self] in
-                guard let self else { return }
-                if let annotationOverlay = self.annotationOverlay {
-                    annotationOverlay.renderImage(afterCommit: { [weak self] rendered in
-                        guard let self else { return }
-                        if let rendered {
-                            self.onPinRendered?(rendered, self.screenLocalSelectionRect)
-                        } else {
-                            self.onPin?(self.screenLocalSelectionRect)
-                        }
-                    })
-                } else {
-                    self.onPin?(self.screenLocalSelectionRect)
-                }
-            },
+            onCopy: { [weak self] in self?.performCopyAction() },
+            onSave: { [weak self] in self?.performSaveAction() },
+            onPin: { [weak self] in self?.performPinAction() },
             onPresetSelected: { [weak self] preset in
                 self?.applyPreset(preset)
             },
@@ -442,19 +417,62 @@ final class CaptureAllInOneToolbarWindow {
         )
     }
 
-    private func installEscMonitor() {
+    private func performCopyAction() {
+        if let annotationOverlay {
+            annotationOverlay.renderImage(afterCommit: { [weak self] rendered in
+                guard let self else { return }
+                if let rendered {
+                    self.onCopyRendered?(rendered, self.screenLocalSelectionRect)
+                } else {
+                    self.onCopy?(self.screenLocalSelectionRect)
+                }
+            })
+        } else {
+            onCopy?(screenLocalSelectionRect)
+        }
+    }
+
+    private func performSaveAction() {
+        if let annotationOverlay {
+            annotationOverlay.renderImage(afterCommit: { [weak self] rendered in
+                guard let self else { return }
+                if let rendered {
+                    self.onSaveRendered?(rendered, self.screenLocalSelectionRect)
+                } else {
+                    self.onSave?(self.screenLocalSelectionRect)
+                }
+            })
+        } else {
+            onSave?(screenLocalSelectionRect)
+        }
+    }
+
+    private func performPinAction() {
+        if let annotationOverlay {
+            annotationOverlay.renderImage(afterCommit: { [weak self] rendered in
+                guard let self else { return }
+                if let rendered {
+                    self.onPinRendered?(rendered, self.screenLocalSelectionRect)
+                } else {
+                    self.onPin?(self.screenLocalSelectionRect)
+                }
+            })
+        } else {
+            onPin?(screenLocalSelectionRect)
+        }
+    }
+
+    private func installKeyboardMonitor() {
         globalEscMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard event.keyCode == 53 else { return }
             Task { @MainActor in self?.onCancel?() }
         }
         localEscMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            guard event.keyCode == 53 else { return event }
-            self?.onCancel?()
-            return nil
+            self?.handleKeyboardEvent(event)
         }
     }
 
-    private func removeEscMonitor() {
+    private func removeKeyboardMonitor() {
         if let globalEscMonitor {
             NSEvent.removeMonitor(globalEscMonitor)
             self.globalEscMonitor = nil
@@ -462,6 +480,30 @@ final class CaptureAllInOneToolbarWindow {
         if let localEscMonitor {
             NSEvent.removeMonitor(localEscMonitor)
             self.localEscMonitor = nil
+        }
+    }
+
+    private func handleKeyboardEvent(_ event: NSEvent) -> NSEvent? {
+        if event.keyCode == 53 {
+            onCancel?()
+            return nil
+        }
+
+        let modifiers = event.modifierFlags.intersection([.command, .shift, .option, .control])
+        guard modifiers == .command else { return event }
+
+        switch event.charactersIgnoringModifiers?.lowercased() {
+        case "c":
+            performCopyAction()
+            return nil
+        case "s":
+            performSaveAction()
+            return nil
+        case "p":
+            performPinAction()
+            return nil
+        default:
+            return event
         }
     }
 
@@ -590,7 +632,7 @@ private struct CaptureAllInOneToolbarView: View {
     }
 
     private enum UtilityAction: Hashable {
-        case annotate, copy, pin, cancel, overflow
+        case annotate, copy, save, pin, cancel, overflow
     }
 
     let state: CaptureAllInOneToolbarState
@@ -605,6 +647,7 @@ private struct CaptureAllInOneToolbarView: View {
     let onRecording: () -> Void
     let onAnnotate: () -> Void
     let onCopy: () -> Void
+    let onSave: () -> Void
     let onPin: () -> Void
     let onPresetSelected: (CapturePreset) -> Void
     let onCancel: () -> Void
@@ -638,6 +681,7 @@ private struct CaptureAllInOneToolbarView: View {
                 dimensionPill
                 presetMenu
                 iconButton("doc.on.doc", kind: .copy, help: "Copy selected area", action: onCopy)
+                iconButton("square.and.arrow.down", kind: .save, help: "Save selected area", action: onSave)
                 iconButton("pin", kind: .pin, help: "Pin selected area", action: onPin)
                 iconButton("xmark", kind: .cancel, help: "Cancel", action: onCancel)
             }
@@ -680,6 +724,7 @@ private struct CaptureAllInOneToolbarView: View {
             }
 
             railIconButton("doc.on.doc", kind: .copy, help: "Copy selected area", label: String(localized: "Copy"), action: onCopy)
+            railIconButton("square.and.arrow.down", kind: .save, help: "Save selected area", label: String(localized: "Save"), action: onSave)
             railIconButton("pin", kind: .pin, help: "Pin selected area", label: String(localized: "Pin"), action: onPin)
             railIconButton("xmark", kind: .cancel, help: "Cancel", label: String(localized: "Close"), action: onCancel)
 
@@ -994,10 +1039,17 @@ private struct CaptureAllInOneToolbarView: View {
                     RoundedRectangle(cornerRadius: 8, style: .continuous)
                         .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
                 )
+                .overlay(alignment: .topTrailing) {
+                    if hoveredUtility == kind, let shortcut = utilityShortcut(for: kind) {
+                        UtilityShortcutBadge(text: shortcut)
+                            .offset(x: 5, y: -5)
+                            .transition(.opacity)
+                    }
+                }
         }
         .buttonStyle(.plain)
         .onHover { hoveredUtility = $0 ? kind : nil }
-        .help(help)
+        .help(utilityHelp(for: kind, fallback: help))
     }
 
     private func railIconButton(
@@ -1028,20 +1080,77 @@ private struct CaptureAllInOneToolbarView: View {
                 RoundedRectangle(cornerRadius: 9, style: .continuous)
                     .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
             )
+            .overlay(alignment: .topTrailing) {
+                if hoveredUtility == kind, let shortcut = utilityShortcut(for: kind) {
+                    UtilityShortcutBadge(text: shortcut)
+                        .offset(x: 5, y: -5)
+                        .transition(.opacity)
+                }
+            }
         }
         .buttonStyle(.plain)
         .onHover { hoveredUtility = $0 ? kind : nil }
-        .help(help)
+        .help(utilityHelp(for: kind, fallback: help))
     }
 
     private func utilityBackground(_ kind: UtilityAction) -> Color {
         hoveredUtility == kind ? Color.white.opacity(0.18) : Color.white.opacity(0.11)
     }
 
+    private func utilityShortcut(for kind: UtilityAction) -> String? {
+        switch kind {
+        case .copy:
+            return "⌘C"
+        case .save:
+            return "⌘S"
+        case .pin:
+            return "⌘P"
+        case .cancel:
+            return "Esc"
+        case .annotate, .overflow:
+            return nil
+        }
+    }
+
+    private func utilityHelp(for kind: UtilityAction, fallback: LocalizedStringKey) -> Text {
+        guard let shortcut = utilityShortcut(for: kind) else {
+            return Text(fallback)
+        }
+
+        switch kind {
+        case .copy:
+            return Text(String(localized: "Copy selected area (\(shortcut))"))
+        case .save:
+            return Text(String(localized: "Save selected area (\(shortcut))"))
+        case .pin:
+            return Text(String(localized: "Pin selected area (\(shortcut))"))
+        case .cancel:
+            return Text(String(localized: "Cancel (\(shortcut))"))
+        case .annotate, .overflow:
+            return Text(fallback)
+        }
+    }
+
     private func toggleOverflow() {
         guard state.isCompact else { return }
         state.showsOverflow.toggle()
         onChromeStateChanged()
+    }
+}
+
+private struct UtilityShortcutBadge: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 8.5, weight: .bold, design: .monospaced))
+            .foregroundStyle(.white)
+            .lineLimit(1)
+            .padding(.horizontal, 4)
+            .frame(height: 14)
+            .background(Color.black.opacity(0.62), in: Capsule())
+            .overlay(Capsule().stroke(Color.white.opacity(0.22), lineWidth: 0.5))
+            .allowsHitTesting(false)
     }
 }
 

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -51,13 +51,14 @@ final class CaptureCoordinator {
         case inlineAnnotate // Open the All-in-One inline annotation editor
         case ocr          // Open visual OCR directly
         case pin          // Pin selected capture to screen
+        case save         // Save to file only, no preview
         case share        // Upload to cloud, skip Quick Access, save to history
 
         var playsShutterSound: Bool {
             switch self {
             case .annotate, .inlineAnnotate:
                 false
-            case .default, .clipboard, .ocr, .pin, .share:
+            case .default, .clipboard, .ocr, .pin, .save, .share:
                 true
             }
         }
@@ -66,7 +67,7 @@ final class CaptureCoordinator {
             switch self {
             case .annotate, .inlineAnnotate, .pin:
                 false
-            case .default, .clipboard, .ocr, .share:
+            case .default, .clipboard, .ocr, .save, .share:
                 true
             }
         }
@@ -433,6 +434,28 @@ final class CaptureCoordinator {
             self.dismissAllInOneToolbar()
             self.dismissFreezeWindows()
             self.copyRenderedImage(image)
+        }
+        toolbar.onSave = { [weak self] rect in
+            guard let self else { return }
+            if self.handleFrozenAllInOneAction(
+                rect: rect,
+                screen: screen,
+                frozenImage: frozenImage,
+                action: .save
+            ) {
+                return
+            }
+            self.dismissAllInOneToolbar()
+            self.dismissFreezeWindows()
+            self.settings.lastCaptureSelection = .area(rect: rect, screenID: screen.displayID)
+            self.pendingAction = .save
+            self.performAreaCapture(rect: rect, screen: screen)
+        }
+        toolbar.onSaveRendered = { [weak self] image, _ in
+            guard let self else { return }
+            self.dismissAllInOneToolbar()
+            self.dismissFreezeWindows()
+            self.saveRenderedImage(image)
         }
         toolbar.onPin = { [weak self] rect in
             guard let self else { return }
@@ -948,6 +971,8 @@ final class CaptureCoordinator {
             ocrCoordinator?.startVisualOCR(image: result.image, anchorScreen: screenFor(result: result))
         case .pin:
             pinToScreen(result, anchor: anchorRect(for: result))
+        case .save:
+            saveImageToFile(result.image)
         case .share:
             // Skip Quick Access, save to history, then upload in background.
             logDiagnostic("Cloud Share capture completed mode=\(result.mode) displayID=\(result.displayID)")
@@ -1261,18 +1286,31 @@ final class CaptureCoordinator {
     }
 
     private func saveImageToFile(_ image: CGImage) {
-        let format = settings.screenshotFormat
-        let fileFormat: FileFormat = format == .png ? .png : .jpeg
+        guard let encoded = screenshotData(from: image) else { return }
+        let directory = settings.screenshotMonthlyFolders
+            ? FileNaming.monthlyDirectory(in: settings.exportLocation)
+            : settings.exportLocation
         let url = FileNaming.generateFileURL(
-            in: settings.exportLocation,
+            in: directory,
             type: .screenshot,
-            format: fileFormat
+            format: encoded.format
         )
-        let data: Data? = switch format {
-        case .png: ImageUtilities.pngData(from: image)
-        case .jpeg: ImageUtilities.jpegData(from: image)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try? encoded.data.write(to: url)
+    }
+
+    private func screenshotData(from image: CGImage) -> (data: Data, format: FileFormat)? {
+        let preset = settings.screenshotOutputPreset
+        let data: Data? = switch preset.fileFormat {
+        case .png:
+            ImageUtilities.pngData(from: image)
+        case .jpeg:
+            ImageUtilities.jpegData(from: image, quality: preset.jpegQuality ?? 0.85)
+        case .mp4, .gif, .mov:
+            nil
         }
-        if let data { try? data.write(to: url) }
+        guard let data else { return nil }
+        return (data, preset.fileFormat)
     }
 
     private func saveRenderedImage(_ image: CGImage) {

--- a/App/Sources/Preferences/Components/CheckForUpdatesView.swift
+++ b/App/Sources/Preferences/Components/CheckForUpdatesView.swift
@@ -64,7 +64,7 @@ final class UpdateManager: NSObject, ObservableObject {
         clearStatusTask?.cancel()
         manualCheckState = .probing
         probeFoundValidUpdate = false
-        status = Status(message: "Checking…", kind: .checking)
+        status = Status(message: String(localized: "Checking…"), kind: .checking)
         updater.checkForUpdateInformation()
     }
 

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -82,14 +82,25 @@ final class PreferencesViewModel {
             }
         }
     }
-    var screenshotFormat: ScreenshotFormat {
+    var screenshotOutputPreset: ScreenshotOutputPreset {
         get {
-            access(keyPath: \.screenshotFormat)
-            return settings.screenshotFormat
+            access(keyPath: \.screenshotOutputPreset)
+            return settings.screenshotOutputPreset
         }
         set {
-            withMutation(keyPath: \.screenshotFormat) {
-                settings.screenshotFormat = newValue
+            withMutation(keyPath: \.screenshotOutputPreset) {
+                settings.screenshotOutputPreset = newValue
+            }
+        }
+    }
+    var screenshotMonthlyFolders: Bool {
+        get {
+            access(keyPath: \.screenshotMonthlyFolders)
+            return settings.screenshotMonthlyFolders
+        }
+        set {
+            withMutation(keyPath: \.screenshotMonthlyFolders) {
+                settings.screenshotMonthlyFolders = newValue
             }
         }
     }

--- a/App/Sources/Preferences/Tabs/CloudShareWizard/CloudShareWizardView.swift
+++ b/App/Sources/Preferences/Tabs/CloudShareWizard/CloudShareWizardView.swift
@@ -512,13 +512,13 @@ private struct GetKeysStep: View {
 
     private let steps: [(title: String, detail: AttributedString)] = [
         (String(localized: "Create a bucket"),
-         attributed("In `R2 → Overview`, click `Create bucket`. Name it something memorable like `capso-shares`.")),
+         attributed(String(localized: "In `R2 → Overview`, click `Create bucket`. Name it something memorable like `capso-shares`."))),
         (String(localized: "Enable public access"),
-         attributed("In the bucket's `Settings` tab: click `Enable` next to **Public Development URL** for a free `pub-…r2.dev` link, OR click `+ Add` next to **Custom Domains** to use your own domain.")),
+         attributed(String(localized: "In the bucket's `Settings` tab: click `Enable` next to **Public Development URL** for a free `pub-…r2.dev` link, OR click `+ Add` next to **Custom Domains** to use your own domain."))),
         (String(localized: "Create an API token"),
-         attributed("`R2 → Manage API Tokens` → `Create API Token`. Choose **Object Read & Write**, scoped to this bucket.")),
+         attributed(String(localized: "`R2 → Manage API Tokens` → `Create API Token`. Choose **Object Read & Write**, scoped to this bucket."))),
         (String(localized: "Copy the four values"),
-         attributed("You'll get `Account ID`, `Access Key ID`, and `Secret Access Key`. Note your bucket name too. The secret won't be shown again."))
+         attributed(String(localized: "You'll get `Account ID`, `Access Key ID`, and `Secret Access Key`. Note your bucket name too. The secret won't be shown again.")))
     ]
 
     var body: some View {

--- a/App/Sources/Preferences/Tabs/ExportSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ExportSettingsView.swift
@@ -25,6 +25,15 @@ struct ExportSettingsView: View {
                         .pickerStyle(.segmented)
                         .frame(width: 220)
                     }
+                    SettingRow(label: "Screenshot Quality", sublabel: "Applies to screenshot files", showDivider: true) {
+                        Picker("", selection: $viewModel.screenshotOutputPreset) {
+                            Text("PNG").tag(ScreenshotOutputPreset.losslessPNG)
+                            Text("JPEG 85%").tag(ScreenshotOutputPreset.standardJPEG)
+                            Text("JPEG 70%").tag(ScreenshotOutputPreset.compactJPEG)
+                        }
+                        .pickerStyle(.segmented)
+                        .frame(width: 240)
+                    }
                 }
             }
 
@@ -43,6 +52,11 @@ struct ExportSettingsView: View {
                             }
                             .controlSize(.small)
                         }
+                    }
+                    SettingRow(label: "Monthly Screenshot Folders", sublabel: "Save screenshots into yyyy-MM subfolders", showDivider: true) {
+                        Toggle("", isOn: $viewModel.screenshotMonthlyFolders)
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
                     }
                 }
             }

--- a/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
@@ -188,18 +188,6 @@ struct ScreenshotSettingsView: View {
                 } // if capturePresetsEnabled
             }
 
-            SettingGroup(title: "Format") {
-                SettingCard {
-                    SettingRow(label: "Screenshot Format") {
-                        Picker("", selection: $viewModel.screenshotFormat) {
-                            Text("PNG").tag(ScreenshotFormat.png)
-                            Text("JPEG").tag(ScreenshotFormat.jpeg)
-                        }
-                        .pickerStyle(.segmented)
-                        .frame(width: 140)
-                    }
-                }
-            }
         }
         .sheet(isPresented: $showingAddPreset) {
             addPresetSheet

--- a/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
@@ -25,6 +25,24 @@ extension KeyboardShortcuts.Name {
 }
 
 struct ShortcutSettingsView: View {
+    private struct ContextualShortcut: Identifiable {
+        let id: String
+        let scope: LocalizedStringKey
+        let action: LocalizedStringKey
+        let shortcut: String
+    }
+
+    private let contextualShortcuts: [ContextualShortcut] = [
+        ContextualShortcut(id: "all-in-one-copy", scope: "All-in-One", action: "Copy selected area", shortcut: "⌘C"),
+        ContextualShortcut(id: "all-in-one-save", scope: "All-in-One", action: "Save selected area", shortcut: "⌘S"),
+        ContextualShortcut(id: "all-in-one-pin", scope: "All-in-One", action: "Pin selected area", shortcut: "⌘P"),
+        ContextualShortcut(id: "all-in-one-cancel", scope: "All-in-One", action: "Cancel", shortcut: "Esc"),
+        ContextualShortcut(id: "quick-access-copy", scope: "Quick Access", action: "Copy", shortcut: "⌘C"),
+        ContextualShortcut(id: "quick-access-save", scope: "Quick Access", action: "Save", shortcut: "⌘S"),
+        ContextualShortcut(id: "quick-access-annotate", scope: "Quick Access", action: "Annotate", shortcut: "⌘E"),
+        ContextualShortcut(id: "quick-access-pin", scope: "Quick Access", action: "Pin", shortcut: "⌘P")
+    ]
+
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             Text("Shortcuts")
@@ -34,7 +52,7 @@ struct ShortcutSettingsView: View {
             HStack(spacing: 8) {
                 Image(systemName: "info.circle")
                     .foregroundStyle(.blue)
-                Text("Click a shortcut to record a new combination. Press **Esc** to cancel or **Delete** to remove.")
+                Text("Click a customizable shortcut to record a new combination. Press Esc to cancel or Delete to remove. Contextual shortcuts are fixed and work only while that panel is active.")
                     .font(.system(size: 12))
                     .foregroundStyle(.secondary)
             }
@@ -47,7 +65,7 @@ struct ShortcutSettingsView: View {
                     .stroke(Color.blue.opacity(0.2), lineWidth: 0.5)
             )
 
-            SettingGroup(title: "Capture") {
+            SettingGroup(title: "Customizable Shortcuts") {
                 SettingCard {
                     shortcutRow("All-in-One", name: .captureAllInOne)
                     shortcutRow("Capture Area", name: .captureArea, showDivider: true)
@@ -61,18 +79,16 @@ struct ShortcutSettingsView: View {
                     shortcutRow("Capture Area & Annotate", name: .captureAreaAndAnnotate, showDivider: true)
                     shortcutRow("Capture & Translate", name: .captureAndTranslate, showDivider: true)
                     shortcutRow("Capture Previous Area", name: .captureLastArea, showDivider: true)
-                }
-            }
-
-            SettingGroup(title: "Recording") {
-                SettingCard {
-                    shortcutRow("Start / Stop Recording", name: .recordScreen)
-                }
-            }
-
-            SettingGroup(title: "Other") {
-                SettingCard {
+                    shortcutRow("Start / Stop Recording", name: .recordScreen, showDivider: true)
                     shortcutRow("Screenshot History", name: .screenshotHistory)
+                }
+            }
+
+            SettingGroup(title: "Contextual Shortcuts") {
+                SettingCard {
+                    ForEach(Array(contextualShortcuts.enumerated()), id: \.element.id) { index, item in
+                        contextualShortcutRow(item, showDivider: index > 0)
+                    }
                 }
             }
         }
@@ -85,5 +101,26 @@ struct ShortcutSettingsView: View {
         }
     }
 
+    private func contextualShortcutRow(_ item: ContextualShortcut, showDivider: Bool = false) -> some View {
+        SettingRow(label: item.action, sublabel: item.scope, showDivider: showDivider) {
+            ShortcutKeycap(text: item.shortcut)
+        }
+    }
+}
 
+private struct ShortcutKeycap: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 8)
+            .frame(height: 24)
+            .background(Color.primary.opacity(0.08), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .stroke(Color.primary.opacity(0.10), lineWidth: 0.5)
+            )
+    }
 }

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -8,6 +8,32 @@ public enum ScreenshotFormat: String, CaseIterable, Sendable {
     case jpeg
 }
 
+public enum ScreenshotOutputPreset: String, CaseIterable, Sendable {
+    case losslessPNG
+    case standardJPEG
+    case compactJPEG
+
+    public var fileFormat: FileFormat {
+        switch self {
+        case .losslessPNG:
+            return .png
+        case .standardJPEG, .compactJPEG:
+            return .jpeg
+        }
+    }
+
+    public var jpegQuality: Double? {
+        switch self {
+        case .losslessPNG:
+            return nil
+        case .standardJPEG:
+            return 0.85
+        case .compactJPEG:
+            return 0.70
+        }
+    }
+}
+
 public enum QuickAccessPosition: String, CaseIterable, Sendable {
     case bottomLeft
     case bottomRight
@@ -132,6 +158,20 @@ public final class AppSettings: @unchecked Sendable {
             return value
         }
         set { defaults.set(newValue.rawValue, forKey: "screenshotFormat") }
+    }
+
+    public var screenshotOutputPreset: ScreenshotOutputPreset {
+        get {
+            if let raw = defaults.string(forKey: "screenshotOutputPreset"),
+               let value = ScreenshotOutputPreset(rawValue: raw) {
+                return value
+            }
+            return screenshotFormat == .jpeg ? .standardJPEG : .losslessPNG
+        }
+        set {
+            defaults.set(newValue.rawValue, forKey: "screenshotOutputPreset")
+            screenshotFormat = newValue.fileFormat == .png ? .png : .jpeg
+        }
     }
 
     public var recordingFormat: RecordingFormat {
@@ -273,6 +313,11 @@ public final class AppSettings: @unchecked Sendable {
     public var screenshotAutoSave: Bool {
         get { defaults.object(forKey: "screenshotAutoSave") as? Bool ?? false }
         set { defaults.set(newValue, forKey: "screenshotAutoSave") }
+    }
+
+    public var screenshotMonthlyFolders: Bool {
+        get { defaults.object(forKey: "screenshotMonthlyFolders") as? Bool ?? false }
+        set { defaults.set(newValue, forKey: "screenshotMonthlyFolders") }
     }
 
     public var screenshotShowsCursor: Bool {

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/FileNaming.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/FileNaming.swift
@@ -60,6 +60,12 @@ public enum FileNaming {
         return f
     }()
 
+    private static let monthFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM"
+        return f
+    }()
+
     public static func generateName(for type: CaptureType, date: Date = Date()) -> String {
         let prefix = switch type {
         case .screenshot: "Capso Screenshot"
@@ -80,5 +86,9 @@ public enum FileNaming {
 
     public static func generateFileURL(in directory: URL, type: CaptureType, format: FileFormat, date: Date = Date()) -> URL {
         directory.appendingPathComponent(generateFileName(for: type, format: format, date: date))
+    }
+
+    public static func monthlyDirectory(in baseDirectory: URL, date: Date = Date()) -> URL {
+        baseDirectory.appendingPathComponent(monthFormatter.string(from: date), isDirectory: true)
     }
 }

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -17,6 +17,48 @@ struct AppSettingsTests {
         #expect(settings.screenshotFormat == .png)
     }
 
+    @Test("Default screenshot output preset is lossless PNG")
+    func defaultScreenshotOutputPreset() {
+        let suite = "test.screenshotOutputPreset.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+
+        #expect(settings.screenshotOutputPreset == .losslessPNG)
+        #expect(settings.screenshotOutputPreset.fileFormat == .png)
+        #expect(settings.screenshotOutputPreset.jpegQuality == nil)
+    }
+
+    @Test("Screenshot output presets expose JPEG quality")
+    func screenshotOutputPresetJPEGQuality() {
+        #expect(ScreenshotOutputPreset.standardJPEG.fileFormat == .jpeg)
+        #expect(ScreenshotOutputPreset.standardJPEG.jpegQuality == 0.85)
+        #expect(ScreenshotOutputPreset.compactJPEG.fileFormat == .jpeg)
+        #expect(ScreenshotOutputPreset.compactJPEG.jpegQuality == 0.70)
+    }
+
+    @Test("Screenshot output preset falls back to legacy JPEG format")
+    func screenshotOutputPresetLegacyFormatFallback() {
+        let suite = "test.screenshotOutputPreset.legacy"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+
+        settings.screenshotFormat = .jpeg
+
+        #expect(settings.screenshotOutputPreset == .standardJPEG)
+    }
+
+    @Test("Monthly screenshot folders are disabled by default")
+    func defaultScreenshotMonthlyFolders() {
+        let suite = "test.screenshotMonthlyFolders.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+
+        #expect(settings.screenshotMonthlyFolders == false)
+    }
+
     @Test("Screenshot cursor capture is disabled by default")
     func defaultScreenshotShowsCursor() {
         let suite = "test.screenshotShowsCursor.default"

--- a/Packages/SharedKit/Tests/SharedKitTests/FileNamingTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/FileNamingTests.swift
@@ -41,4 +41,15 @@ struct FileNamingTests {
         let ext = FileNaming.fileExtension(for: .gif)
         #expect(ext == "gif")
     }
+
+    @Test("Monthly directory uses year and month")
+    func monthlyDirectoryUsesYearAndMonth() {
+        let base = URL(fileURLWithPath: "/tmp/capso-test", isDirectory: true)
+        let date = Date(timeIntervalSince1970: 1_705_348_800)
+
+        let directory = FileNaming.monthlyDirectory(in: base, date: date)
+
+        #expect(directory.lastPathComponent == "2024-01")
+        #expect(directory.deletingLastPathComponent() == base)
+    }
 }


### PR DESCRIPTION
## Summary
- add screenshot output presets and monthly screenshot folder support in Export settings
- add All-in-One save shortcut handling, contextual shortcut hints, and read-only shortcut guidance in Settings
- expand Settings localization coverage across the existing app languages: Simplified Chinese, Japanese, and Korean

## Why
- screenshot file output controls belong with export settings, while screenshot capture settings stay focused on capture behavior
- fixed contextual shortcuts need to be discoverable without pretending they are customizable
- Settings had incomplete localization coverage, causing mixed-language UI

## Validation
- `node -e "JSON.parse(require('fs').readFileSync('App/Resources/Localizable.xcstrings','utf8'))"`
- `git diff --check`
- `swift test --package-path Packages/SharedKit`
- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build`