### PR TITLE
fix: change capture & translate default shortcut

### DIFF
--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -93,9 +93,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// One-time migration: clear stale KeyboardShortcuts UserDefaults so new defaults apply.
     private func migrateShortcutsIfNeeded() {
         let migrationKey = "shortcutsMigratedToOptionShift"
-        guard !UserDefaults.standard.bool(forKey: migrationKey) else { return }
-        KeyboardShortcuts.reset(.captureArea, .captureFullscreen, .captureWindow, .captureText, .recordScreen)
-        UserDefaults.standard.set(true, forKey: migrationKey)
+        if !UserDefaults.standard.bool(forKey: migrationKey) {
+            KeyboardShortcuts.reset(.captureArea, .captureFullscreen, .captureWindow, .captureText, .recordScreen)
+            UserDefaults.standard.set(true, forKey: migrationKey)
+        }
+
+        let translationMigrationKey = "captureAndTranslateShortcutMigratedToOptionShift"
+        guard !UserDefaults.standard.bool(forKey: translationMigrationKey) else { return }
+        let oldDefault = KeyboardShortcuts.Shortcut(.t, modifiers: [.command, .shift])
+        if KeyboardShortcuts.getShortcut(for: .captureAndTranslate) == oldDefault {
+            KeyboardShortcuts.reset(.captureAndTranslate)
+        }
+        UserDefaults.standard.set(true, forKey: translationMigrationKey)
     }
 
     private func registerGlobalShortcuts() {
@@ -140,7 +149,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         KeyboardShortcuts.onKeyDown(for: .captureAndTranslate) { [weak self] in
             guard let self else { return }
-            // If the user pressed ⌘⇧T while a Quick Access panel has focus
+            // If the user pressed the global Translate shortcut while a Quick
+            // Access panel has focus
             // (hovered / clicked), translate THAT capture rather than
             // starting a brand-new capture flow. The global hotkey otherwise
             // always wins over the panel's local `.keyboardShortcut`.

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -1240,11 +1240,12 @@ final class CaptureCoordinator {
     /// (a global shortcut handler) can fall through to its default behavior.
     ///
     /// This exists because the `KeyboardShortcuts` package registers a
-    /// SYSTEM-wide hotkey for `⌘⇧T`, which always wins over a SwiftUI
-    /// `.keyboardShortcut` attached to the Translate button in the Quick
-    /// Access panel. Without this fall-through, pressing ⌘⇧T while hovering
-    /// a Quick Access preview would trigger a fresh capture-and-translate
-    /// flow instead of translating the capture the user was already looking at.
+    /// SYSTEM-wide hotkey for the Capture & Translate shortcut, which always
+    /// wins over a SwiftUI `.keyboardShortcut` attached to the Translate button
+    /// in the Quick Access panel. Without this fall-through, pressing the
+    /// global shortcut while hovering a Quick Access preview would trigger a
+    /// fresh capture-and-translate flow instead of translating the capture the
+    /// user was already looking at.
     @discardableResult
     func invokeQuickAccessTranslateIfKey() -> Bool {
         guard let key = NSApp.keyWindow as? QuickAccessWindow,

--- a/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
@@ -14,7 +14,7 @@ extension KeyboardShortcuts.Name {
     static let captureAreaAndShare = Self("captureAreaAndShare", default: .init(.zero, modifiers: [.option, .shift]))
     static let captureAreaAndAnnotate = Self("captureAreaAndAnnotate", default: .init(.eight, modifiers: [.option, .shift]))
     static let screenshotHistory = Self("screenshotHistory", default: .init(.nine, modifiers: [.option, .shift]))
-    static let captureAndTranslate = Self("captureAndTranslate", default: .init(.t, modifiers: [.command, .shift]))
+    static let captureAndTranslate = Self("captureAndTranslate", default: .init(.t, modifiers: [.option, .shift]))
     /// No default binding — opt-in. Self-Timer is discoverable from the
     /// menu bar; shipping a default risks colliding with whatever the user
     /// has already bound in macOS or third-party apps.

--- a/App/Sources/Translation/TranslationOnboardingView.swift
+++ b/App/Sources/Translation/TranslationOnboardingView.swift
@@ -19,7 +19,7 @@ struct TranslationOnboardingView: View {
                 stepCard(
                     number: "01",
                     title: "Capture & Translate",
-                    description: "Press ⌘⇧T, drag to select text",
+                    description: "Press ⌥⇧T, drag to select text",
                     symbol: "rectangle.dashed.and.paperclip",
                     symbolColor: .orange
                 )


### PR DESCRIPTION
## Summary
- change the default Capture & Translate shortcut from `Cmd+Shift+T` to `Option+Shift+T`
- migrate existing users only when they are still on the old default shortcut
- update onboarding copy and comments to match the new global shortcut

## Root Cause
`Capture & Translate` was the only default capture shortcut still using `Cmd+Shift+T`, which conflicts with the common browser shortcut for reopening a closed tab.

## Validation
- `git diff --check`
- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build -quiet`

## Notes
- `xcodebuild test -project Capso.xcodeproj -scheme Capso -quiet` is not available because the `Capso` scheme is not configured for the test action.

Closes #126
