### PR TITLE
feat: add translation providers and selected text translation

### DIFF
--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -47,7 +47,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         captureCoordinator!.shareCoordinator = shareCoordinator
         historyCoordinator!.shareCoordinator = shareCoordinator
         recordingCoordinator!.historyCoordinator = historyCoordinator
-        preferencesWindow = PreferencesWindow(settings: settings, updateManager: updateManager)
+        preferencesWindow = PreferencesWindow(settings: settings, permissionManager: permissionManager, updateManager: updateManager)
         if settings.diagnosticLoggingEnabled {
             DiagnosticLogger.append(
                 "App launched version=\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown") build=\(Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown")",
@@ -82,6 +82,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let tabRaw = (notification.object as? PreferencesTab)?.rawValue
             MainActor.assumeIsolated {
                 let tab = tabRaw.flatMap(PreferencesTab.init(rawValue:)) ?? .screenshots
+                self?.preferencesWindow?.show(tab: tab)
+            }
+        }
+        NotificationCenter.default.addObserver(
+            forName: .openPreferencesTab,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            let tabRaw = (notification.object as? PreferencesTab)?.rawValue
+            MainActor.assumeIsolated {
+                let tab = tabRaw.flatMap(PreferencesTab.init(rawValue:)) ?? .general
                 self?.preferencesWindow?.show(tab: tab)
             }
         }
@@ -158,6 +169,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 return
             }
             self.translationCoordinator?.startCaptureAndTranslate()
+        }
+        KeyboardShortcuts.onKeyDown(for: .translateSelectedText) { [weak self] in
+            self?.translationCoordinator?.translateSelectedText()
         }
     }
 

--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -6,6 +6,7 @@ import SharedKit
 // MARK: - Notification extensions
 
 extension Notification.Name {
+    static let openPreferencesTab = Notification.Name("openPreferencesTab")
     static let openScreenshotSettings = Notification.Name("openScreenshotSettings")
     static let capturePresetChanged = Notification.Name("capturePresetChanged")
     /// Posted by PreferencesWindow when the window is already open and the

--- a/App/Sources/MenuBar/MenuBarController.swift
+++ b/App/Sources/MenuBar/MenuBarController.swift
@@ -99,6 +99,10 @@ final class MenuBarController: NSObject {
         captureAndTranslate.setShortcut(for: .captureAndTranslate)
         menu.addItem(captureAndTranslate)
 
+        let translateSelectedText = menuItem(String(localized: "Translate Selected Text"), action: #selector(self.translateSelectedText))
+        translateSelectedText.setShortcut(for: .translateSelectedText)
+        menu.addItem(translateSelectedText)
+
         let captureScrolling = menuItem(String(localized: "Scrolling Capture"), action: #selector(captureScrolling))
         captureScrolling.setShortcut(for: .captureScrolling)
         menu.addItem(captureScrolling)
@@ -186,6 +190,10 @@ final class MenuBarController: NSObject {
         translationCoordinator.startCaptureAndTranslate()
     }
 
+    @objc private func translateSelectedText() {
+        translationCoordinator.translateSelectedText()
+    }
+
     @objc private func captureScrolling() {
         captureCoordinator.captureScrolling()
     }
@@ -229,6 +237,7 @@ extension MenuBarController: NSMenuDelegate {
             case #selector(captureWindow): item.setShortcut(for: .captureWindow)
             case #selector(captureText): item.setShortcut(for: .captureText)
             case #selector(captureAndTranslate): item.setShortcut(for: .captureAndTranslate)
+            case #selector(translateSelectedText): item.setShortcut(for: .translateSelectedText)
             case #selector(recordScreen): item.setShortcut(for: .recordScreen)
             case #selector(captureScrolling): item.setShortcut(for: .captureScrolling)
             case #selector(captureSelfTimer):

--- a/App/Sources/Preferences/PreferencesView.swift
+++ b/App/Sources/Preferences/PreferencesView.swift
@@ -2,8 +2,9 @@
 import Combine
 import SwiftUI
 
-enum PreferencesTab: String, CaseIterable {
+enum PreferencesTab: String, CaseIterable, Sendable {
     case general
+    case permissions
     case screenshots
     case recording
     case quickAccess
@@ -15,6 +16,7 @@ enum PreferencesTab: String, CaseIterable {
     var title: LocalizedStringKey {
         switch self {
         case .general: "General"
+        case .permissions: "Permissions"
         case .screenshots: "Screenshots"
         case .recording: "Recording"
         case .quickAccess: "Quick Access"
@@ -28,6 +30,7 @@ enum PreferencesTab: String, CaseIterable {
     var icon: String {
         switch self {
         case .general: "gearshape"
+        case .permissions: "lock.shield"
         case .screenshots: "camera"
         case .recording: "record.circle"
         case .quickAccess: "bolt"
@@ -94,6 +97,8 @@ struct PreferencesView: View {
                 switch selectedTab {
                 case .general:
                     GeneralSettingsView(viewModel: viewModel, updateManager: updateManager)
+                case .permissions:
+                    PermissionSettingsView(viewModel: viewModel)
                 case .screenshots:
                     ScreenshotSettingsView(viewModel: viewModel)
                 case .recording:

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -2,14 +2,22 @@
 import Foundation
 import Observation
 import SharedKit
+import TranslationKit
 
 @MainActor
 @Observable
 final class PreferencesViewModel {
     private let settings: AppSettings
+    private let permissionManager: PermissionManager
 
-    init(settings: AppSettings) {
+    private(set) var screenRecordingGranted: Bool = false
+    private(set) var accessibilityGranted: Bool = false
+    private(set) var cameraGranted: Bool = false
+    private(set) var microphoneGranted: Bool = false
+
+    init(settings: AppSettings, permissionManager: PermissionManager) {
         self.settings = settings
+        self.permissionManager = permissionManager
     }
 
     // MARK: General
@@ -458,6 +466,62 @@ final class PreferencesViewModel {
             }
         }
     }
+    var translationProvider: TranslationProviderKind {
+        get {
+            access(keyPath: \.translationProvider)
+            return settings.translationProvider
+        }
+        set {
+            withMutation(keyPath: \.translationProvider) {
+                settings.translationProvider = newValue
+            }
+        }
+    }
+    var translationProviderModel: String {
+        get {
+            access(keyPath: \.translationProviderModel)
+            return settings.translationProviderModel
+        }
+        set {
+            withMutation(keyPath: \.translationProviderModel) {
+                settings.translationProviderModel = newValue
+            }
+        }
+    }
+    var translationProviderEndpoint: String {
+        get {
+            access(keyPath: \.translationProviderEndpoint)
+            return settings.translationProviderEndpoint
+        }
+        set {
+            withMutation(keyPath: \.translationProviderEndpoint) {
+                settings.translationProviderEndpoint = newValue
+            }
+        }
+    }
+    func translationAPIKey() -> String {
+        settings.translationAPIKey() ?? ""
+    }
+    func setTranslationAPIKey(_ value: String) throws {
+        try settings.setTranslationAPIKey(value)
+    }
+    func testTranslationProviderConnection() async throws {
+        let provider = settings.translationProvider
+        guard provider != .apple else { return }
+        let result = try await ProviderTranslationService.translate(
+            text: "hello",
+            target: settings.translationTargetLanguage,
+            provider: provider,
+            config: TranslationProviderConfiguration(
+                apiKey: settings.translationAPIKey() ?? "",
+                endpoint: settings.translationProviderEndpoint,
+                model: settings.translationProviderModel
+            )
+        )
+        if result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw ProviderTranslationError.badResponse
+        }
+    }
     var translationAutoCopy: Bool {
         get {
             access(keyPath: \.translationAutoCopy)
@@ -490,6 +554,38 @@ final class PreferencesViewModel {
                 settings.translationAutoDismiss = newValue
             }
         }
+    }
+
+    // MARK: Permissions
+    func refreshPermissions() async {
+        await permissionManager.refreshAll()
+        updatePermissionSnapshot()
+    }
+
+    func requestPermission(_ kind: PermissionKind) async {
+        switch kind {
+        case .screenRecording:
+            permissionManager.openSettings(for: kind)
+        case .accessibility:
+            permissionManager.requestAccessibilityPermission()
+            permissionManager.openSettings(for: kind)
+        case .camera:
+            await permissionManager.requestCameraPermission()
+        case .microphone:
+            await permissionManager.requestMicrophonePermission()
+        }
+        updatePermissionSnapshot()
+    }
+
+    func openPermissionSettings(_ kind: PermissionKind) {
+        permissionManager.openSettings(for: kind)
+    }
+
+    private func updatePermissionSnapshot() {
+        screenRecordingGranted = permissionManager.screenRecordingGranted
+        accessibilityGranted = permissionManager.accessibilityGranted
+        cameraGranted = permissionManager.cameraGranted
+        microphoneGranted = permissionManager.microphoneGranted
     }
 
     // MARK: Cloud Share

--- a/App/Sources/Preferences/PreferencesWindow.swift
+++ b/App/Sources/Preferences/PreferencesWindow.swift
@@ -7,10 +7,12 @@ import SharedKit
 final class PreferencesWindow {
     private var window: NSWindow?
     private let settings: AppSettings
+    private let permissionManager: PermissionManager
     private let updateManager: UpdateManager?
 
-    init(settings: AppSettings, updateManager: UpdateManager? = nil) {
+    init(settings: AppSettings, permissionManager: PermissionManager, updateManager: UpdateManager? = nil) {
         self.settings = settings
+        self.permissionManager = permissionManager
         self.updateManager = updateManager
     }
 
@@ -46,7 +48,7 @@ final class PreferencesWindow {
         visualEffect.state = .active
         window.contentView = visualEffect
 
-        let viewModel = PreferencesViewModel(settings: settings)
+        let viewModel = PreferencesViewModel(settings: settings, permissionManager: permissionManager)
         let hostingView = NSHostingView(rootView: PreferencesView(viewModel: viewModel, updateManager: updateManager, initialTab: tab))
         hostingView.translatesAutoresizingMaskIntoConstraints = false
         visualEffect.addSubview(hostingView)

--- a/App/Sources/Preferences/Tabs/OCRSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/OCRSettingsView.swift
@@ -6,6 +6,9 @@ import SharedKit
 struct TextAndTranslationSettingsView: View {
     @Bindable var viewModel: PreferencesViewModel
     @State private var supportedLanguages: [(code: String, name: String)] = []
+    @State private var providerAPIKey: String = ""
+    @State private var providerStatusMessage: String?
+    @State private var isTestingProvider = false
 
     private let translationLanguages: [(code: String, name: String)] = [
         ("en",      "English"),
@@ -58,6 +61,66 @@ struct TextAndTranslationSettingsView: View {
                         }
                         .frame(width: 180)
                     }
+                    SettingRow(label: "Provider", sublabel: "Engine used for screenshot and selected text translation", showDivider: true) {
+                        Picker("", selection: $viewModel.translationProvider) {
+                            ForEach(TranslationProviderKind.allCases, id: \.rawValue) { provider in
+                                Text(provider.displayName).tag(provider)
+                            }
+                        }
+                        .frame(width: 180)
+                        .onChange(of: viewModel.translationProvider) { _, provider in
+                            viewModel.translationProviderEndpoint = provider.defaultEndpoint
+                            viewModel.translationProviderModel = provider.defaultModel
+                            loadProviderAPIKey()
+                        }
+                    }
+                    if viewModel.translationProvider.requiresAPIKey {
+                        SettingRow(label: "API Key", sublabel: "Stored in Keychain", showDivider: true) {
+                            HStack(spacing: 8) {
+                                SecureField("API Key", text: $providerAPIKey)
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(width: 180)
+                                    .onSubmit(saveProviderAPIKey)
+                                Button(action: saveProviderAPIKey) {
+                                    Image(systemName: "checkmark")
+                                }
+                                .buttonStyle(.borderless)
+                                .help("Save API key")
+                            }
+                        }
+                        if viewModel.translationProvider.supportsEndpoint {
+                            SettingRow(label: "Endpoint", sublabel: "Leave empty to use the provider default", showDivider: true) {
+                                TextField("", text: $viewModel.translationProviderEndpoint)
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(width: 260)
+                            }
+                        }
+                        if viewModel.translationProvider.supportsModel {
+                            SettingRow(label: "Model", sublabel: "Leave empty to use the provider default", showDivider: true) {
+                                TextField("", text: $viewModel.translationProviderModel)
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(width: 180)
+                            }
+                        }
+                        SettingRow(label: "Connection", sublabel: "Verify the current provider settings", showDivider: true) {
+                            HStack(spacing: 8) {
+                                if isTestingProvider {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                }
+                                Button(action: testProviderConnection) {
+                                    Label("Test Connection", systemImage: "network")
+                                }
+                                .controlSize(.small)
+                                .disabled(isTestingProvider)
+                            }
+                        }
+                    }
+                    if let providerStatusMessage {
+                        SettingRow(label: LocalizedStringKey(providerStatusMessage), showDivider: true) {
+                            EmptyView()
+                        }
+                    }
                     SettingRow(label: "Auto-Copy Translation", sublabel: "Copy result to clipboard automatically") {
                         Toggle("", isOn: $viewModel.translationAutoCopy)
                             .toggleStyle(.switch)
@@ -102,9 +165,46 @@ struct TextAndTranslationSettingsView: View {
             //     }
             // }
         }
-        // .onAppear {
-        //     loadSupportedLanguages()
-        // }
+        .onAppear {
+            loadProviderAPIKey()
+            // loadSupportedLanguages()
+        }
+    }
+
+    private func loadProviderAPIKey() {
+        providerAPIKey = viewModel.translationAPIKey()
+        providerStatusMessage = nil
+    }
+
+    private func saveProviderAPIKey() {
+        do {
+            try viewModel.setTranslationAPIKey(providerAPIKey)
+            providerStatusMessage = providerAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? "API key cleared"
+                : "API key saved"
+        } catch {
+            providerStatusMessage = "API key could not be saved"
+        }
+    }
+
+    private func testProviderConnection() {
+        isTestingProvider = true
+        providerStatusMessage = nil
+        Task {
+            do {
+                try viewModel.setTranslationAPIKey(providerAPIKey)
+                try await viewModel.testTranslationProviderConnection()
+                await MainActor.run {
+                    providerStatusMessage = "Connection succeeded"
+                    isTestingProvider = false
+                }
+            } catch {
+                await MainActor.run {
+                    providerStatusMessage = "Connection failed: \(error.localizedDescription)"
+                    isTestingProvider = false
+                }
+            }
+        }
     }
 
     private func loadSupportedLanguages() {

--- a/App/Sources/Preferences/Tabs/PermissionSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/PermissionSettingsView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+import SharedKit
+
+struct PermissionSettingsView: View {
+    @Bindable var viewModel: PreferencesViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            HStack {
+                Text("Permissions")
+                    .font(.system(size: 20, weight: .bold))
+                Spacer()
+                Button(action: refresh) {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                .controlSize(.small)
+            }
+
+            SettingGroup(title: "Privacy & Security") {
+                SettingCard {
+                    permissionRow(
+                        kind: .screenRecording,
+                        title: "Screen Recording",
+                        subtitle: "Required for screenshots and recording",
+                        isGranted: viewModel.screenRecordingGranted
+                    )
+                    permissionRow(
+                        kind: .accessibility,
+                        title: "Accessibility",
+                        subtitle: "Required for selected text translation",
+                        isGranted: viewModel.accessibilityGranted,
+                        showDivider: true
+                    )
+                    permissionRow(
+                        kind: .camera,
+                        title: "Camera",
+                        subtitle: "Required for camera overlay",
+                        isGranted: viewModel.cameraGranted,
+                        showDivider: true
+                    )
+                    permissionRow(
+                        kind: .microphone,
+                        title: "Microphone",
+                        subtitle: "Required for microphone recording",
+                        isGranted: viewModel.microphoneGranted,
+                        showDivider: true
+                    )
+                }
+            }
+        }
+        .task {
+            await viewModel.refreshPermissions()
+        }
+    }
+
+    private func permissionRow(
+        kind: PermissionKind,
+        title: LocalizedStringKey,
+        subtitle: LocalizedStringKey,
+        isGranted: Bool,
+        showDivider: Bool = false
+    ) -> some View {
+        SettingRow(label: title, sublabel: subtitle, showDivider: showDivider) {
+            HStack(spacing: 10) {
+                statusBadge(isGranted)
+                Button(action: { request(kind) }) {
+                    Label(actionTitle(for: kind, isGranted: isGranted), systemImage: actionIcon(for: kind, isGranted: isGranted))
+                }
+                .controlSize(.small)
+                Button(action: { viewModel.openPermissionSettings(kind) }) {
+                    Image(systemName: "arrow.up.forward.app")
+                }
+                .buttonStyle(.borderless)
+                .help("Open System Settings")
+            }
+        }
+    }
+
+    private func statusBadge(_ isGranted: Bool) -> some View {
+        HStack(spacing: 5) {
+            Circle()
+                .fill(isGranted ? Color.green : Color.orange)
+                .frame(width: 7, height: 7)
+            Text(isGranted ? "Allowed" : "Needs Access")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(isGranted ? .secondary : .primary)
+        }
+        .frame(width: 96, alignment: .leading)
+    }
+
+    private func actionTitle(for kind: PermissionKind, isGranted: Bool) -> LocalizedStringKey {
+        if isGranted { return "Open" }
+        switch kind {
+        case .camera, .microphone:
+            return "Request"
+        case .screenRecording, .accessibility:
+            return "Open"
+        }
+    }
+
+    private func actionIcon(for kind: PermissionKind, isGranted: Bool) -> String {
+        if isGranted { return "gearshape" }
+        switch kind {
+        case .camera, .microphone:
+            return "hand.tap"
+        case .screenRecording, .accessibility:
+            return "gearshape"
+        }
+    }
+
+    private func request(_ kind: PermissionKind) {
+        Task { await viewModel.requestPermission(kind) }
+    }
+
+    private func refresh() {
+        Task { await viewModel.refreshPermissions() }
+    }
+}

--- a/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
@@ -15,6 +15,7 @@ extension KeyboardShortcuts.Name {
     static let captureAreaAndAnnotate = Self("captureAreaAndAnnotate", default: .init(.eight, modifiers: [.option, .shift]))
     static let screenshotHistory = Self("screenshotHistory", default: .init(.nine, modifiers: [.option, .shift]))
     static let captureAndTranslate = Self("captureAndTranslate", default: .init(.t, modifiers: [.option, .shift]))
+    static let translateSelectedText = Self("translateSelectedText", default: .init(.y, modifiers: [.option, .shift]))
     /// No default binding — opt-in. Self-Timer is discoverable from the
     /// menu bar; shipping a default risks colliding with whatever the user
     /// has already bound in macOS or third-party apps.
@@ -78,6 +79,7 @@ struct ShortcutSettingsView: View {
                     shortcutRow("Capture and Share to Cloud", name: .captureAreaAndShare, showDivider: true)
                     shortcutRow("Capture Area & Annotate", name: .captureAreaAndAnnotate, showDivider: true)
                     shortcutRow("Capture & Translate", name: .captureAndTranslate, showDivider: true)
+                    shortcutRow("Translate Selected Text", name: .translateSelectedText, showDivider: true)
                     shortcutRow("Capture Previous Area", name: .captureLastArea, showDivider: true)
                     shortcutRow("Start / Stop Recording", name: .recordScreen, showDivider: true)
                     shortcutRow("Screenshot History", name: .screenshotHistory)

--- a/App/Sources/Translation/SelectedTextReader.swift
+++ b/App/Sources/Translation/SelectedTextReader.swift
@@ -1,0 +1,76 @@
+import AppKit
+
+enum SelectedTextReader {
+    @MainActor
+    static func readSelectedText() async -> String? {
+        if let text = accessibilitySelectedText() {
+            return text
+        }
+        return await copySelectedText()
+    }
+
+    @MainActor
+    private static func accessibilitySelectedText() -> String? {
+        let system = AXUIElementCreateSystemWide()
+        var focusedValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            system,
+            kAXFocusedUIElementAttribute as CFString,
+            &focusedValue
+        ) == .success else {
+            return nil
+        }
+        guard let focusedValue else { return nil }
+        let focused = focusedValue as! AXUIElement
+
+        var selectedValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            focused,
+            kAXSelectedTextAttribute as CFString,
+            &selectedValue
+        ) == .success else {
+            return nil
+        }
+        return cleaned(selectedValue as? String)
+    }
+
+    @MainActor
+    private static func copySelectedText() async -> String? {
+        let pasteboard = NSPasteboard.general
+        let savedItems = (pasteboard.pasteboardItems ?? []).map { item -> NSPasteboardItem in
+            let copy = NSPasteboardItem()
+            for type in item.types {
+                if let data = item.data(forType: type) {
+                    copy.setData(data, forType: type)
+                }
+            }
+            return copy
+        }
+
+        pasteboard.clearContents()
+        postCopyShortcut()
+        try? await Task.sleep(nanoseconds: 120_000_000)
+        let copied = cleaned(pasteboard.string(forType: .string))
+
+        pasteboard.clearContents()
+        if !savedItems.isEmpty {
+            pasteboard.writeObjects(savedItems)
+        }
+        return copied
+    }
+
+    private static func postCopyShortcut() {
+        let source = CGEventSource(stateID: .hidSystemState)
+        let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 8, keyDown: true)
+        let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 8, keyDown: false)
+        keyDown?.flags = .maskCommand
+        keyUp?.flags = .maskCommand
+        keyDown?.post(tap: .cghidEventTap)
+        keyUp?.post(tap: .cghidEventTap)
+    }
+
+    private static func cleaned(_ text: String?) -> String? {
+        let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/App/Sources/Translation/TranslationCoordinator.swift
+++ b/App/Sources/Translation/TranslationCoordinator.swift
@@ -35,6 +35,14 @@ final class TranslationCoordinator {
         }
     }
 
+    func translateSelectedText() {
+        if !settings.translationOnboardingShown {
+            showOnboarding { [weak self] in self?.beginSelectedTextFlow() }
+        } else {
+            beginSelectedTextFlow()
+        }
+    }
+
     /// - Parameter anchorScreen: The screen where the capture came from.
     ///   Used to place the result card on the correct display — without this,
     ///   translating a screenshot taken on a secondary screen would bounce the
@@ -126,6 +134,8 @@ final class TranslationCoordinator {
         let window = TranslationResultWindow(
             regions: regions,
             target: target,
+            provider: settings.translationProvider,
+            providerConfig: providerConfig(),
             settings: settings,
             anchor: anchor,
             anchorScreen: anchorScreen
@@ -139,6 +149,7 @@ final class TranslationCoordinator {
             // `.screenSaver` floats above everything — including other apps'
             // windows — making the translation card genuinely always-on-top
             // when pinned. Unpinning returns to regular floating level.
+            window.setPinned(isPinned)
             window.level = isPinned ? .screenSaver : .floating
         }
         window.onChangeLanguage = { [weak self] in
@@ -177,6 +188,48 @@ final class TranslationCoordinator {
         }
         resultWindow = window
         window.show()
+    }
+
+    private func beginSelectedTextFlow() {
+        Task {
+            guard AXIsProcessTrusted() else {
+                let options = ["AXTrustedCheckOptionPrompt": true] as CFDictionary
+                _ = AXIsProcessTrustedWithOptions(options)
+                NotificationCenter.default.post(name: .openPreferencesTab, object: PreferencesTab.permissions)
+                NSWorkspace.shared.open(PermissionKind.accessibility.settingsURL)
+                showToast("Allow Accessibility to translate selected text", icon: "lock.fill", iconColor: .systemYellow)
+                return
+            }
+
+            guard let text = await SelectedTextReader.readSelectedText(),
+                  !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                showToast("No selected text found", icon: "text.cursor", iconColor: .systemYellow)
+                return
+            }
+
+            let region = TextRegion(text: text, boundingBox: .zero, confidence: 1)
+            let (anchor, screen) = Self.mouseAnchor()
+            showLoadingResult(
+                regions: [region],
+                target: settings.translationTargetLanguage,
+                anchor: anchor,
+                anchorScreen: screen
+            )
+        }
+    }
+
+    private func providerConfig() -> TranslationProviderConfiguration {
+        TranslationProviderConfiguration(
+            apiKey: settings.translationAPIKey() ?? "",
+            endpoint: settings.translationProviderEndpoint,
+            model: settings.translationProviderModel
+        )
+    }
+
+    private static func mouseAnchor() -> (NSRect, NSScreen?) {
+        let point = NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { NSMouseInRect(point, $0.frame, false) }
+        return (NSRect(x: point.x, y: point.y, width: 1, height: 1), screen)
     }
 
     /// Fetches the authoritative list of target language BCP-47 codes from

--- a/App/Sources/Translation/TranslationResultView.swift
+++ b/App/Sources/Translation/TranslationResultView.swift
@@ -4,12 +4,16 @@ import Translation
 import NaturalLanguage
 import AppKit
 import OCRKit
+import SharedKit
 import TranslationKit
 
 struct TranslationResultView: View {
     let regions: [TextRegion]
     let target: String
+    let provider: TranslationProviderKind
+    let providerConfig: TranslationProviderConfiguration
     let autoCopy: Bool
+    let showOriginal: Bool
     let onClose: () -> Void
     let onPinChanged: (Bool) -> Void
     let onChangeLanguage: () -> Void
@@ -129,7 +133,7 @@ struct TranslationResultView: View {
             RoundedRectangle(cornerRadius: 14)
                 .stroke(Color.primary.opacity(0.08), lineWidth: 0.5)
         )
-        .onAppear { buildConfig() }
+        .onAppear { startTranslation() }
         .translationTask(runConfig) { session in
             await runTranslation(using: session)
         }
@@ -183,35 +187,37 @@ struct TranslationResultView: View {
 
                 Divider().padding(.horizontal, 12)
 
-                // ORIGINAL (collapsible)
-                Button(action: toggleOriginal) {
-                    HStack(spacing: 8) {
-                        Text("ORIGINAL")
-                            .font(.system(size: 10, weight: .semibold))
-                            .foregroundStyle(.tertiary)
-                            .tracking(1.0)
-                        Spacer()
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 9, weight: .semibold))
-                            .foregroundStyle(.tertiary)
-                            .rotationEffect(.degrees(originalExpanded ? 90 : 0))
+                if showOriginal {
+                    // ORIGINAL (collapsible)
+                    Button(action: toggleOriginal) {
+                        HStack(spacing: 8) {
+                            Text("ORIGINAL")
+                                .font(.system(size: 10, weight: .semibold))
+                                .foregroundStyle(.tertiary)
+                                .tracking(1.0)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 9, weight: .semibold))
+                                .foregroundStyle(.tertiary)
+                                .rotationEffect(.degrees(originalExpanded ? 90 : 0))
+                        }
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .contentShape(Rectangle())
                     }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 10)
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
+                    .buttonStyle(.plain)
 
-                if originalExpanded {
-                    renderedText(
-                        region.original.text,
-                        bodyFont: .system(size: 13),
-                        bodyColor: .secondary,
-                        markerColor: .tertiary
-                    )
-                    .padding(.horizontal, 16)
-                    .padding(.bottom, 14)
-                    .transition(.opacity)
+                    if originalExpanded {
+                        renderedText(
+                            region.original.text,
+                            bodyFont: .system(size: 13),
+                            bodyColor: .secondary,
+                            markerColor: .tertiary
+                        )
+                        .padding(.horizontal, 16)
+                        .padding(.bottom, 14)
+                        .transition(.opacity)
+                    }
                 }
             }
         }
@@ -307,7 +313,7 @@ struct TranslationResultView: View {
 
     private func footer(copiedMessage: String?) -> some View {
         HStack {
-            Text("Apple Translation")
+            Text(provider.displayName)
                 .font(.system(size: 10))
                 .foregroundStyle(.tertiary)
             if let copiedMessage {
@@ -409,6 +415,16 @@ struct TranslationResultView: View {
         )
     }
 
+    private func startTranslation() {
+        originalExpanded = showOriginal
+        guard provider == .apple else {
+            runConfig = nil
+            Task { await runProviderTranslation() }
+            return
+        }
+        buildConfig()
+    }
+
     /// Normalizes codes for comparison (e.g. NLLanguageRecognizer returns
     /// "zh-Hans" / "zh-Hant"; our target stores the same form). Makes matching
     /// robust to minor casing/encoding differences.
@@ -459,6 +475,50 @@ struct TranslationResultView: View {
                 original: merged,
                 translation: response.targetText,
                 detectedSource: Locale.Language(identifier: detectedSource.isEmpty ? "en" : detectedSource)
+            )
+            phase = .done([result])
+        } catch {
+            phase = .failed(error.localizedDescription)
+        }
+    }
+
+    private func runProviderTranslation() async {
+        let meaningful = regions.filter {
+            !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        guard !meaningful.isEmpty else {
+            phase = .failed("No text to translate")
+            return
+        }
+
+        let joinedOriginal = meaningful.map(\.text).joined(separator: "\n")
+        do {
+            let response = try await ProviderTranslationService.translate(
+                text: joinedOriginal,
+                target: target,
+                provider: provider,
+                config: providerConfig
+            )
+            guard !response.text.isEmpty else {
+                phase = .failed("Translation returned no results. Try changing the target language.")
+                return
+            }
+
+            if autoCopy {
+                let pb = NSPasteboard.general
+                pb.clearContents()
+                pb.setString(response.text, forType: .string)
+            }
+
+            let merged = TextRegion(
+                text: joinedOriginal,
+                boundingBox: meaningful.first?.boundingBox ?? .zero,
+                confidence: 1.0
+            )
+            let result = TranslatedRegion(
+                original: merged,
+                translation: response.text,
+                detectedSource: Locale.Language(identifier: response.detectedSource ?? "und")
             )
             phase = .done([result])
         } catch {

--- a/App/Sources/Translation/TranslationResultWindow.swift
+++ b/App/Sources/Translation/TranslationResultWindow.swift
@@ -10,7 +10,12 @@ final class TranslationResultWindow: NSPanel {
     private let settings: AppSettings
     private let regions: [TextRegion]
     private let target: String
+    private let provider: TranslationProviderKind
+    private let providerConfig: TranslationProviderConfiguration
     private var dismissTimer: Timer?
+    private var localClickMonitor: Any?
+    private var globalClickMonitor: Any?
+    private var isPinned = false
 
     var onClose: (() -> Void)?
     var onPinChanged: ((Bool) -> Void)?
@@ -21,12 +26,16 @@ final class TranslationResultWindow: NSPanel {
     init(
         regions: [TextRegion],
         target: String,
+        provider: TranslationProviderKind,
+        providerConfig: TranslationProviderConfiguration,
         settings: AppSettings,
         anchor: NSRect?,
         anchorScreen: NSScreen?
     ) {
         self.regions = regions
         self.target = target
+        self.provider = provider
+        self.providerConfig = providerConfig
         self.settings = settings
 
         // Fixed window size matching the SwiftUI view's `.frame(width: 360, height: 480)`.
@@ -58,7 +67,10 @@ final class TranslationResultWindow: NSPanel {
         let view = TranslationResultView(
             regions: regions,
             target: target,
+            provider: provider,
+            providerConfig: providerConfig,
             autoCopy: settings.translationAutoCopy,
+            showOriginal: settings.translationShowOriginal,
             onClose:          { [weak self] in self?.onClose?() },
             onPinChanged:     { [weak self] isPinned in self?.onPinChanged?(isPinned) },
             onChangeLanguage: { [weak self] in self?.onChangeLanguage?() }
@@ -77,12 +89,46 @@ final class TranslationResultWindow: NSPanel {
                 Task { @MainActor in self?.onClose?() }
             }
         }
+        if settings.translationAutoDismiss == .clickOutside {
+            installClickOutsideMonitors()
+        }
+    }
+
+    func setPinned(_ pinned: Bool) {
+        isPinned = pinned
     }
 
     override func close() {
         dismissTimer?.invalidate()
         dismissTimer = nil
+        removeClickOutsideMonitors()
         super.close()
+    }
+
+    private func installClickOutsideMonitors() {
+        removeClickOutsideMonitors()
+        localClickMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] event in
+            guard let self else { return event }
+            if !self.isPinned && event.window !== self {
+                self.onClose?()
+            }
+            return event
+        }
+        globalClickMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] _ in
+            guard let self, !self.isPinned else { return }
+            self.onClose?()
+        }
+    }
+
+    private func removeClickOutsideMonitors() {
+        if let localClickMonitor {
+            NSEvent.removeMonitor(localClickMonitor)
+            self.localClickMonitor = nil
+        }
+        if let globalClickMonitor {
+            NSEvent.removeMonitor(globalClickMonitor)
+            self.globalClickMonitor = nil
+        }
     }
 
     private static func positionedFrame(

--- a/Packages/SharedKit/Sources/SharedKit/Permissions/PermissionManager.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Permissions/PermissionManager.swift
@@ -3,6 +3,26 @@ import AVFoundation
 import Observation
 @preconcurrency import ScreenCaptureKit
 
+public enum PermissionKind: String, CaseIterable, Sendable {
+    case screenRecording
+    case accessibility
+    case camera
+    case microphone
+
+    public var settingsURL: URL {
+        switch self {
+        case .screenRecording:
+            return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!
+        case .accessibility:
+            return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
+        case .camera:
+            return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera")!
+        case .microphone:
+            return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")!
+        }
+    }
+}
+
 @Observable
 @MainActor
 public final class PermissionManager {
@@ -12,6 +32,13 @@ public final class PermissionManager {
     public private(set) var accessibilityGranted: Bool = false
 
     public init() {}
+
+    public func refreshAll() async {
+        await checkScreenRecordingPermission()
+        checkAccessibilityPermission()
+        checkCameraPermission()
+        checkMicrophonePermission()
+    }
 
     // MARK: - Screen Recording
 
@@ -26,6 +53,10 @@ public final class PermissionManager {
 
     // MARK: - Camera
 
+    public func checkCameraPermission() {
+        cameraGranted = AVCaptureDevice.authorizationStatus(for: .video) == .authorized
+    }
+
     public func requestCameraPermission() async {
         let status = AVCaptureDevice.authorizationStatus(for: .video)
         switch status {
@@ -39,6 +70,10 @@ public final class PermissionManager {
     }
 
     // MARK: - Microphone
+
+    public func checkMicrophonePermission() {
+        microphoneGranted = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+    }
 
     public func requestMicrophonePermission() async {
         let status = AVCaptureDevice.authorizationStatus(for: .audio)
@@ -69,22 +104,22 @@ public final class PermissionManager {
     // MARK: - Open System Settings
 
     public func openScreenRecordingSettings() {
-        let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!
-        NSWorkspace.shared.open(url)
+        openSettings(for: .screenRecording)
     }
 
     public func openCameraSettings() {
-        let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera")!
-        NSWorkspace.shared.open(url)
+        openSettings(for: .camera)
     }
 
     public func openMicrophoneSettings() {
-        let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")!
-        NSWorkspace.shared.open(url)
+        openSettings(for: .microphone)
     }
 
     public func openAccessibilitySettings() {
-        let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
-        NSWorkspace.shared.open(url)
+        openSettings(for: .accessibility)
+    }
+
+    public func openSettings(for kind: PermissionKind) {
+        NSWorkspace.shared.open(kind.settingsURL)
     }
 }

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -56,6 +56,64 @@ public enum TranslationAutoDismiss: String, CaseIterable, Sendable {
     case afterDelay
 }
 
+public enum TranslationProviderKind: String, CaseIterable, Sendable {
+    case apple
+    case openAICompatible
+    case deepL
+    case custom
+
+    public var displayName: String {
+        switch self {
+        case .apple: return "Apple Translation"
+        case .openAICompatible: return "OpenAI"
+        case .deepL: return "DeepL"
+        case .custom: return "Custom"
+        }
+    }
+
+    public var defaultEndpoint: String {
+        switch self {
+        case .apple:
+            return ""
+        case .openAICompatible:
+            return "https://api.openai.com/v1/chat/completions"
+        case .deepL:
+            return ""
+        case .custom:
+            return ""
+        }
+    }
+
+    public var defaultModel: String {
+        switch self {
+        case .apple, .deepL:
+            return ""
+        case .openAICompatible:
+            return "gpt-4o-mini"
+        case .custom:
+            return ""
+        }
+    }
+
+    public var requiresAPIKey: Bool {
+        self != .apple
+    }
+
+    public var supportsModel: Bool {
+        switch self {
+        case .apple, .deepL: return false
+        case .openAICompatible, .custom: return true
+        }
+    }
+
+    public var supportsEndpoint: Bool {
+        switch self {
+        case .apple: return false
+        case .openAICompatible, .deepL, .custom: return true
+        }
+    }
+}
+
 public enum ExportQuality: String, CaseIterable, Sendable {
     case maximum
     case social
@@ -504,6 +562,25 @@ public final class AppSettings: @unchecked Sendable {
         set { defaults.set(newValue, forKey: "translationTargetLanguage") }
     }
 
+    public var translationProvider: TranslationProviderKind {
+        get {
+            guard let raw = defaults.string(forKey: "translationProvider"),
+                  let provider = TranslationProviderKind(rawValue: raw) else { return .apple }
+            return provider
+        }
+        set { defaults.set(newValue.rawValue, forKey: "translationProvider") }
+    }
+
+    public var translationProviderModel: String {
+        get { defaults.string(forKey: "translationProviderModel") ?? translationProvider.defaultModel }
+        set { defaults.set(newValue, forKey: "translationProviderModel") }
+    }
+
+    public var translationProviderEndpoint: String {
+        get { defaults.string(forKey: "translationProviderEndpoint") ?? translationProvider.defaultEndpoint }
+        set { defaults.set(newValue, forKey: "translationProviderEndpoint") }
+    }
+
     public var translationAutoCopy: Bool {
         get { defaults.object(forKey: "translationAutoCopy") as? Bool ?? true }
         set { defaults.set(newValue, forKey: "translationAutoCopy") }
@@ -540,6 +617,22 @@ public final class AppSettings: @unchecked Sendable {
     public var translationOnboardingShown: Bool {
         get { defaults.object(forKey: "translationOnboardingShown") as? Bool ?? false }
         set { defaults.set(newValue, forKey: "translationOnboardingShown") }
+    }
+
+    public func translationAPIKey() -> String? {
+        try? KeychainHelper(service: "com.awesomemacapps.capso.translation")
+            .get(account: translationProvider.rawValue)
+    }
+
+    public func setTranslationAPIKey(_ value: String?) throws {
+        let keychain = KeychainHelper(service: "com.awesomemacapps.capso.translation")
+        let account = translationProvider.rawValue
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if trimmed.isEmpty {
+            try keychain.delete(account: account)
+        } else {
+            try keychain.set(trimmed, account: account)
+        }
     }
 
     /// Chosen at first launch; falls back to English for unsupported locales.

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -143,6 +143,43 @@ struct AppSettingsTests {
         #expect(settings.isProUnlocked == false)
     }
 
+    @Test("Translation provider defaults to Apple")
+    func translationProviderDefaultsToApple() {
+        let suite = "test.translationProvider.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+
+        #expect(settings.translationProvider == .apple)
+    }
+
+    @Test("Translation provider choices exclude DeepSeek")
+    func translationProviderChoicesExcludeDeepSeek() {
+        #expect(TranslationProviderKind.allCases.map(\.rawValue) == [
+            "apple",
+            "openAICompatible",
+            "deepL",
+            "custom",
+        ])
+    }
+
+    @Test("Translation provider settings persist across instances")
+    func translationProviderSettingsPersist() {
+        let suite = "test.translationProvider.persist"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let first = AppSettings(defaults: defaults)
+
+        first.translationProvider = .openAICompatible
+        first.translationProviderModel = "gpt-4o-mini"
+        first.translationProviderEndpoint = "https://example.com/chat/completions"
+
+        let second = AppSettings(defaults: defaults)
+        #expect(second.translationProvider == .openAICompatible)
+        #expect(second.translationProviderModel == "gpt-4o-mini")
+        #expect(second.translationProviderEndpoint == "https://example.com/chat/completions")
+    }
+
     @Test("File formats map common extensions")
     func fileFormatExtensionMapping() {
         #expect(FileFormat(pathExtension: "png") == .png)

--- a/Packages/SharedKit/Tests/SharedKitTests/PermissionKindTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/PermissionKindTests.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Testing
+@testable import SharedKit
+
+@Suite("PermissionKind")
+struct PermissionKindTests {
+    @Test("System Settings URLs point at the expected privacy panes")
+    func systemSettingsURLs() {
+        #expect(PermissionKind.screenRecording.settingsURL.absoluteString.contains("Privacy_ScreenCapture"))
+        #expect(PermissionKind.accessibility.settingsURL.absoluteString.contains("Privacy_Accessibility"))
+        #expect(PermissionKind.camera.settingsURL.absoluteString.contains("Privacy_Camera"))
+        #expect(PermissionKind.microphone.settingsURL.absoluteString.contains("Privacy_Microphone"))
+    }
+}

--- a/Packages/TranslationKit/Sources/TranslationKit/ProviderTranslationService.swift
+++ b/Packages/TranslationKit/Sources/TranslationKit/ProviderTranslationService.swift
@@ -1,0 +1,214 @@
+import Foundation
+import SharedKit
+
+public struct TranslationProviderConfiguration: Sendable {
+    public let apiKey: String
+    public let endpoint: String
+    public let model: String
+
+    public init(apiKey: String, endpoint: String, model: String) {
+        self.apiKey = apiKey
+        self.endpoint = endpoint
+        self.model = model
+    }
+}
+
+public struct ProviderTranslationResult: Sendable {
+    public let text: String
+    public let detectedSource: String?
+
+    public init(text: String, detectedSource: String?) {
+        self.text = text
+        self.detectedSource = detectedSource
+    }
+}
+
+public enum ProviderTranslationError: LocalizedError, Sendable {
+    case missingAPIKey
+    case badEndpoint
+    case badResponse
+    case httpStatus(Int, String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingAPIKey:
+            return "Translation provider API key is missing."
+        case .badEndpoint:
+            return "Translation provider endpoint is invalid."
+        case .badResponse:
+            return "Translation provider returned an unreadable response."
+        case .httpStatus(let code, let body):
+            return body.isEmpty ? "Translation provider returned HTTP \(code)." : "Translation provider returned HTTP \(code): \(body)"
+        }
+    }
+}
+
+public enum ProviderTranslationService {
+    public static func translate(
+        text: String,
+        target: String,
+        provider: TranslationProviderKind,
+        config: TranslationProviderConfiguration
+    ) async throws -> ProviderTranslationResult {
+        let request = try makeRequest(text: text, target: target, provider: provider, config: config)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw ProviderTranslationError.badResponse
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw ProviderTranslationError.httpStatus(http.statusCode, String(body.prefix(600)))
+        }
+
+        if provider == .deepL {
+            return try parseDeepLResponse(data)
+        }
+        return try parseChatCompletionResponse(data)
+    }
+
+    public static func makeRequest(
+        text: String,
+        target: String,
+        provider: TranslationProviderKind,
+        config: TranslationProviderConfiguration
+    ) throws -> URLRequest {
+        switch provider {
+        case .apple:
+            throw ProviderTranslationError.badEndpoint
+        case .deepL:
+            return try makeDeepLRequest(text: text, target: target, config: config)
+        case .openAICompatible, .custom:
+            return try makeChatCompletionRequest(
+                text: text,
+                target: target,
+                provider: provider,
+                config: config
+            )
+        }
+    }
+
+    private static func makeChatCompletionRequest(
+        text: String,
+        target: String,
+        provider: TranslationProviderKind,
+        config: TranslationProviderConfiguration
+    ) throws -> URLRequest {
+        let apiKey = config.apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        if provider != .custom && apiKey.isEmpty {
+            throw ProviderTranslationError.missingAPIKey
+        }
+
+        let endpoint = resolvedEndpoint(provider: provider, config: config)
+        guard let url = URL(string: endpoint), url.scheme != nil else {
+            throw ProviderTranslationError.badEndpoint
+        }
+
+        let model = resolvedModel(provider: provider, config: config)
+        var request = URLRequest(url: url, timeoutInterval: 60)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "model": model,
+            "temperature": 0.2,
+            "stream": false,
+            "messages": [
+                ["role": "system", "content": systemPrompt(target: target)],
+                ["role": "user", "content": text],
+            ],
+        ])
+        return request
+    }
+
+    private static func makeDeepLRequest(
+        text: String,
+        target: String,
+        config: TranslationProviderConfiguration
+    ) throws -> URLRequest {
+        let apiKey = config.apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !apiKey.isEmpty else { throw ProviderTranslationError.missingAPIKey }
+        guard let url = URL(string: resolvedDeepLEndpoint(config: config, apiKey: apiKey)) else {
+            throw ProviderTranslationError.badEndpoint
+        }
+
+        var request = URLRequest(url: url, timeoutInterval: 60)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("DeepL-Auth-Key \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "text": [text],
+            "target_lang": deepLTargetCode(target),
+            "preserve_formatting": true,
+        ])
+        return request
+    }
+
+    private static func parseChatCompletionResponse(_ data: Data) throws -> ProviderTranslationResult {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [[String: Any]],
+              let message = choices.first?["message"] as? [String: Any],
+              let content = message["content"] as? String else {
+            throw ProviderTranslationError.badResponse
+        }
+        return ProviderTranslationResult(
+            text: content.trimmingCharacters(in: .whitespacesAndNewlines),
+            detectedSource: nil
+        )
+    }
+
+    private static func parseDeepLResponse(_ data: Data) throws -> ProviderTranslationResult {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let translations = json["translations"] as? [[String: Any]],
+              let first = translations.first,
+              let text = first["text"] as? String else {
+            throw ProviderTranslationError.badResponse
+        }
+        return ProviderTranslationResult(
+            text: text.trimmingCharacters(in: .whitespacesAndNewlines),
+            detectedSource: first["detected_source_language"] as? String
+        )
+    }
+
+    private static func resolvedEndpoint(
+        provider: TranslationProviderKind,
+        config: TranslationProviderConfiguration
+    ) -> String {
+        let endpoint = config.endpoint.trimmingCharacters(in: .whitespacesAndNewlines)
+        return endpoint.isEmpty ? provider.defaultEndpoint : endpoint
+    }
+
+    private static func resolvedModel(
+        provider: TranslationProviderKind,
+        config: TranslationProviderConfiguration
+    ) -> String {
+        let model = config.model.trimmingCharacters(in: .whitespacesAndNewlines)
+        return model.isEmpty ? provider.defaultModel : model
+    }
+
+    private static func systemPrompt(target: String) -> String {
+        let targetName = Locale.current.localizedString(forIdentifier: target) ?? target
+        return """
+        Translate the user's text into \(targetName). If the text is already in \(targetName), translate it into English instead. Return only the final translation. Preserve line breaks.
+        """
+    }
+
+    private static func resolvedDeepLEndpoint(config: TranslationProviderConfiguration, apiKey: String) -> String {
+        let endpoint = config.endpoint.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !endpoint.isEmpty { return endpoint }
+        return apiKey.lowercased().hasSuffix(":fx")
+            ? "https://api-free.deepl.com/v2/translate"
+            : "https://api.deepl.com/v2/translate"
+    }
+
+    private static func deepLTargetCode(_ target: String) -> String {
+        switch target {
+        case "zh-Hans": return "ZH-HANS"
+        case "zh-Hant": return "ZH-HANT"
+        case "pt-BR": return "PT-BR"
+        default:
+            return target.uppercased()
+        }
+    }
+}

--- a/Packages/TranslationKit/Tests/TranslationKitTests/TranslationProviderRequestTests.swift
+++ b/Packages/TranslationKit/Tests/TranslationKitTests/TranslationProviderRequestTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+import SharedKit
+@testable import TranslationKit
+
+@Suite("Translation provider requests")
+struct TranslationProviderRequestTests {
+    @Test("OpenAI-compatible providers build chat completion requests")
+    func openAICompatibleRequest() throws {
+        let config = TranslationProviderConfiguration(
+            apiKey: "sk-test",
+            endpoint: "https://example.com/v1/chat/completions",
+            model: "test-model"
+        )
+
+        let request = try ProviderTranslationService.makeRequest(
+            text: "Hello",
+            target: "zh-Hans",
+            provider: .openAICompatible,
+            config: config
+        )
+
+        #expect(request.url?.absoluteString == "https://example.com/v1/chat/completions")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-test")
+        let body = try #require(request.httpBody)
+        let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect(json["model"] as? String == "test-model")
+        #expect(json["stream"] as? Bool == false)
+        #expect((json["messages"] as? [[String: String]])?.count == 2)
+    }
+
+    @Test("DeepL providers build translate requests")
+    func deepLRequest() throws {
+        let config = TranslationProviderConfiguration(
+            apiKey: "deepl-key:fx",
+            endpoint: "",
+            model: ""
+        )
+
+        let request = try ProviderTranslationService.makeRequest(
+            text: "Hello",
+            target: "zh-Hans",
+            provider: .deepL,
+            config: config
+        )
+
+        #expect(request.url?.absoluteString == "https://api-free.deepl.com/v2/translate")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "DeepL-Auth-Key deepl-key:fx")
+        let body = try #require(request.httpBody)
+        let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        #expect((json["text"] as? [String]) == ["Hello"])
+        #expect(json["target_lang"] as? String == "ZH-HANS")
+    }
+
+    @Test("Custom providers can omit API keys for local endpoints")
+    func customProviderAllowsMissingAPIKey() throws {
+        let config = TranslationProviderConfiguration(
+            apiKey: "",
+            endpoint: "http://localhost:8317/v1/chat/completions",
+            model: "gpt-5.4-mini"
+        )
+
+        let request = try ProviderTranslationService.makeRequest(
+            text: "Hello",
+            target: "zh-Hans",
+            provider: .custom,
+            config: config
+        )
+
+        #expect(request.url?.absoluteString == "http://localhost:8317/v1/chat/completions")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Add selectable translation providers with Keychain-backed API key storage and a test connection action in settings.
- Add selected text translation via Accessibility with pasteboard fallback.
- Add a Permissions settings tab with current permission status and direct System Settings navigation.
- Improve translation card behavior for provider display, original-text visibility, and click-outside dismissal.

## Validation
- `swift test --package-path Packages/SharedKit`
- `swift test --package-path Packages/TranslationKit`
- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build`
