### PR TITLE
feat: add cloud share storage providers

### DIFF
--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -209,7 +209,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let providerRaw = settings.cloudShareProvider,
             let provider = ShareProvider(rawValue: providerRaw),
             let urlPrefix = settings.cloudShareURLPrefix,
-            let accountID = settings.cloudShareAccountID,
             let bucket = settings.cloudShareBucket
         else {
             return nil
@@ -223,8 +222,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return nil
         }
 
-        let config = ShareConfig(provider: provider, urlPrefix: urlPrefix, accountID: accountID, bucket: bucket)
-        let destination = R2Destination(config: config, accessKey: access, secretKey: secret)
+        var fields: [String: String] = [:]
+        if let accountID = settings.cloudShareAccountID {
+            fields["accountID"] = accountID
+        }
+        if let region = settings.cloudShareRegion {
+            fields["region"] = region
+        }
+        if let endpoint = settings.cloudShareEndpoint {
+            fields["endpoint"] = endpoint
+        }
+        if let pathPrefix = settings.cloudSharePathPrefix {
+            fields["pathPrefix"] = pathPrefix
+        }
+
+        let config = ShareConfig(provider: provider, urlPrefix: urlPrefix, bucket: bucket, fields: fields)
+        guard let destination = try? ShareDestinationFactory.make(config: config, accessKey: access, secretKey: secret) else {
+            return nil
+        }
         return ShareCoordinator(destination: destination)
     }
 

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -645,6 +645,41 @@ final class PreferencesViewModel {
             }
         }
     }
+    var cloudShareRegion: String? {
+        get {
+            access(keyPath: \.cloudShareRegion)
+            return settings.cloudShareRegion
+        }
+        set {
+            withMutation(keyPath: \.cloudShareRegion) {
+                withMutation(keyPath: \.isCloudShareConfigured) {
+                    settings.cloudShareRegion = newValue
+                }
+            }
+        }
+    }
+    var cloudShareEndpoint: String? {
+        get {
+            access(keyPath: \.cloudShareEndpoint)
+            return settings.cloudShareEndpoint
+        }
+        set {
+            withMutation(keyPath: \.cloudShareEndpoint) {
+                settings.cloudShareEndpoint = newValue
+            }
+        }
+    }
+    var cloudSharePathPrefix: String? {
+        get {
+            access(keyPath: \.cloudSharePathPrefix)
+            return settings.cloudSharePathPrefix
+        }
+        set {
+            withMutation(keyPath: \.cloudSharePathPrefix) {
+                settings.cloudSharePathPrefix = newValue
+            }
+        }
+    }
 
     // MARK: Version
     // MARK: History

--- a/App/Sources/Preferences/Tabs/CloudShareSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/CloudShareSettingsView.swift
@@ -42,7 +42,7 @@ struct CloudShareSettingsView: View {
                 .foregroundStyle(.secondary)
             Text(String(localized: "Cloud Share is not set up yet"))
                 .font(.headline)
-            Text(String(localized: "Configure a Cloudflare R2 bucket to share captures with one click."))
+            Text(String(localized: "Connect your own cloud storage bucket to share captures with one click."))
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
             Button(String(localized: "Set up Cloud Share")) {
@@ -64,7 +64,7 @@ struct CloudShareSettingsView: View {
                             Image(systemName: "checkmark.circle.fill")
                                 .foregroundStyle(.green)
                                 .font(.system(size: 12))
-                            Text(viewModel.cloudShareProvider ?? "—")
+                            Text(currentProvider?.displayName ?? viewModel.cloudShareProvider ?? "—")
                                 .font(.system(size: 12))
                                 .foregroundStyle(.secondary)
                         }
@@ -81,12 +81,34 @@ struct CloudShareSettingsView: View {
                             .font(.system(size: 12))
                             .foregroundStyle(.secondary)
                     }
+                    if let region = viewModel.cloudShareRegion, !region.isEmpty {
+                        SettingRow(label: "Region / Endpoint", showDivider: true) {
+                            Text(region)
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    }
+                    if let pathPrefix = viewModel.cloudSharePathPrefix, !pathPrefix.isEmpty {
+                        SettingRow(label: "Path Prefix", showDivider: true) {
+                            Text(pathPrefix)
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
                 }
             }
 
             SettingGroup(title: "Actions") {
                 SettingCard {
-                    SettingRow(label: "Test Connection", sublabel: "Verify the bucket is reachable") {
+                    SettingRow(label: "Change Provider", sublabel: "Update storage provider or credentials") {
+                        Button(String(localized: "Configure")) {
+                            showWizard = true
+                        }
+                        .controlSize(.small)
+                    }
+                    SettingRow(label: "Test Connection", sublabel: "Verify the bucket is reachable", showDivider: true) {
                         Button {
                             Task { await testConnection() }
                         } label: {
@@ -113,12 +135,16 @@ struct CloudShareSettingsView: View {
         }
     }
 
+    private var currentProvider: ShareProvider? {
+        guard let raw = viewModel.cloudShareProvider else { return nil }
+        return ShareProvider(rawValue: raw)
+    }
+
     private func testConnection() async {
         guard
             let providerRaw = viewModel.cloudShareProvider,
             let provider = ShareProvider(rawValue: providerRaw),
             let urlPrefix = viewModel.cloudShareURLPrefix,
-            let accountID = viewModel.cloudShareAccountID,
             let bucket = viewModel.cloudShareBucket
         else {
             testResult = TestResultAlert(
@@ -141,11 +167,24 @@ struct CloudShareSettingsView: View {
         }
 
         testing = true
+        var fields: [String: String] = [:]
+        if let accountID = viewModel.cloudShareAccountID {
+            fields["accountID"] = accountID
+        }
+        if let region = viewModel.cloudShareRegion {
+            fields["region"] = region
+        }
+        if let endpoint = viewModel.cloudShareEndpoint {
+            fields["endpoint"] = endpoint
+        }
+        if let pathPrefix = viewModel.cloudSharePathPrefix {
+            fields["pathPrefix"] = pathPrefix
+        }
         let result = await CloudShareTester.runTest(
             provider: provider,
             urlPrefix: urlPrefix,
-            accountID: accountID,
             bucket: bucket,
+            fields: fields,
             accessKey: accessKey,
             secretKey: secretKey
         )
@@ -170,15 +209,15 @@ struct CloudShareSettingsView: View {
         case .notConfigured:
             return String(localized: "Configuration is incomplete. Re-run the wizard.")
         case .invalidCredentials:
-            return String(localized: "Cloudflare rejected the credentials. Verify the Access Key and Secret have Object Read & Write on this bucket.")
+            return String(localized: "The storage provider rejected the credentials. Verify the access key, secret, and bucket permissions.")
         case .invalidURLPrefix(let reason):
             return String(format: String(localized: "Invalid public URL prefix: %@"), reason)
         case .network(let underlying):
             return String(format: String(localized: "Network error: %@"), underlying)
         case .quotaExceeded:
-            return String(localized: "Storage quota exceeded — free up space in the Cloudflare dashboard.")
+            return String(localized: "Storage quota exceeded — free up space in your provider dashboard.")
         case .publicAccessUnreachable:
-            return String(localized: "Upload worked, but the file isn't publicly reachable. Enable Public access on the bucket in Cloudflare.")
+            return String(localized: "Upload worked, but the file isn't publicly reachable. Enable public access or use a public custom domain.")
         case .unknown(let s):
             return s
         }
@@ -189,21 +228,25 @@ struct CloudShareSettingsView: View {
         viewModel.cloudShareProvider = nil
         viewModel.cloudShareURLPrefix = nil
         viewModel.cloudShareAccountID = nil
+        viewModel.cloudShareRegion = nil
+        viewModel.cloudShareEndpoint = nil
+        viewModel.cloudSharePathPrefix = nil
         viewModel.cloudShareBucket = nil
 
         // 2. Delete Keychain entries — surface failures instead of silently swallowing.
-        // r2 is the only provider in v1; when B2/S3 land, derive this string from cloudShareProvider.
-        let keychain = KeychainHelper(service: "com.awesomemacapps.capso.share.r2")
         var keychainErrors: [String] = []
-        do {
-            try keychain.delete(account: "accessKey")
-        } catch {
-            keychainErrors.append("Access Key (\(error.localizedDescription))")
-        }
-        do {
-            try keychain.delete(account: "secretKey")
-        } catch {
-            keychainErrors.append("Secret Access Key (\(error.localizedDescription))")
+        for provider in ShareProvider.allCases {
+            let keychain = KeychainHelper(service: "com.awesomemacapps.capso.share.\(provider.rawValue)")
+            do {
+                try keychain.delete(account: "accessKey")
+            } catch {
+                keychainErrors.append("\(provider.displayName) Access Key (\(error.localizedDescription))")
+            }
+            do {
+                try keychain.delete(account: "secretKey")
+            } catch {
+                keychainErrors.append("\(provider.displayName) Secret Access Key (\(error.localizedDescription))")
+            }
         }
 
         // 3. Tear down the live coordinator so subsequent shares fail closed.

--- a/App/Sources/Preferences/Tabs/CloudShareWizard/CloudShareWizardView.swift
+++ b/App/Sources/Preferences/Tabs/CloudShareWizard/CloudShareWizardView.swift
@@ -184,7 +184,10 @@ struct CloudShareWizardView: View {
         // notConfiguredView → configuredView transition in CloudShareSettingsView).
         viewModel.cloudShareProvider = model.provider.rawValue
         viewModel.cloudShareURLPrefix = ShareConfig.normalizePrefix(model.urlPrefix)
-        viewModel.cloudShareAccountID = model.accountID
+        viewModel.cloudShareAccountID = model.provider == .r2 ? model.accountID : nil
+        viewModel.cloudShareRegion = model.provider == .r2 ? nil : model.region
+        viewModel.cloudShareEndpoint = model.endpoint.isEmpty ? nil : model.endpoint
+        viewModel.cloudSharePathPrefix = model.pathPrefix.isEmpty ? nil : model.pathPrefix
         viewModel.cloudShareBucket = model.bucket
 
         // Step 3: Rebuild the live ShareCoordinator with the new credentials.
@@ -206,6 +209,9 @@ final class CloudShareWizardModel {
     // Form state
     var provider: ShareProvider = .r2
     var accountID: String = ""
+    var region: String = ""
+    var endpoint: String = ""
+    var pathPrefix: String = ""
     var bucket: String = ""
     var accessKey: String = ""
     var secretKey: String = ""
@@ -244,7 +250,7 @@ final class CloudShareWizardModel {
     var canAdvance: Bool {
         switch step {
         case .welcome:     return true
-        case .provider:    return provider == .r2  // only r2 selectable in v1
+        case .provider:    return true
         case .getKeys:     return true
         case .credentials: return credentialsValid
         case .urlPrefix:
@@ -255,13 +261,102 @@ final class CloudShareWizardModel {
     }
 
     var credentialsValid: Bool {
-        accountIDError == nil
+        providerSpecificFieldsValid
+            && accountIDError == nil
             && bucketError == nil
             && accessKeyError == nil
-            && !accountID.isEmpty
             && !bucket.isEmpty
             && !accessKey.isEmpty
             && !secretKey.isEmpty
+    }
+
+    var providerSpecificFieldsValid: Bool {
+        switch provider {
+        case .r2:
+            return !accountID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .s3, .tencentCOS, .aliyunOSS:
+            return !region.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
+    var providerDisplayName: String {
+        provider.displayName
+    }
+
+    var regionLabel: String {
+        switch provider {
+        case .r2:
+            return String(localized: "Account ID")
+        case .s3:
+            return String(localized: "Region")
+        case .tencentCOS:
+            return String(localized: "Region")
+        case .aliyunOSS:
+            return String(localized: "Endpoint / Region")
+        }
+    }
+
+    var regionPlaceholder: String {
+        switch provider {
+        case .r2:
+            return String(localized: "32-character hex")
+        case .s3:
+            return "us-east-1"
+        case .tencentCOS:
+            return "ap-guangzhou"
+        case .aliyunOSS:
+            return "oss-cn-hangzhou"
+        }
+    }
+
+    var accessKeyLabel: String {
+        switch provider {
+        case .tencentCOS:
+            return "SecretId"
+        case .aliyunOSS:
+            return String(localized: "AccessKey ID")
+        case .r2, .s3:
+            return String(localized: "Access Key ID")
+        }
+    }
+
+    var secretKeyLabel: String {
+        switch provider {
+        case .aliyunOSS:
+            return String(localized: "AccessKey Secret")
+        case .r2, .s3, .tencentCOS:
+            return String(localized: "Secret Access Key")
+        }
+    }
+
+    var endpointPlaceholder: String {
+        switch provider {
+        case .s3:
+            return String(localized: "Optional for S3-compatible services")
+        case .r2, .tencentCOS, .aliyunOSS:
+            return ""
+        }
+    }
+
+    var shouldShowEndpoint: Bool {
+        provider == .s3
+    }
+
+    var configFields: [String: String] {
+        var fields: [String: String] = [:]
+        if !accountID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            fields["accountID"] = accountID
+        }
+        if !region.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            fields["region"] = region
+        }
+        if !endpoint.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            fields["endpoint"] = endpoint
+        }
+        if !pathPrefix.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            fields["pathPrefix"] = pathPrefix
+        }
+        return fields
     }
 
     func goNext() {
@@ -356,8 +451,8 @@ final class CloudShareWizardModel {
         let result = await CloudShareTester.runTest(
             provider: provider,
             urlPrefix: urlPrefix,
-            accountID: accountID,
             bucket: bucket,
+            fields: configFields,
             accessKey: accessKey,
             secretKey: secretKey
         )
@@ -444,7 +539,7 @@ private struct ProviderStep: View {
             StepHeader(
                 stepLabel: String(localized: "Step 2 — Provider"),
                 title: String(localized: "Choose a storage provider"),
-                subtitle: String(localized: "Capso speaks the S3 protocol, so any S3-compatible bucket works. We recommend Cloudflare R2 — generous free tier and no egress fees.")
+                subtitle: String(localized: "Choose where Capso uploads screenshots. Files stay in your own storage account and Capso copies the public share link.")
             )
 
             VStack(spacing: 10) {
@@ -461,46 +556,44 @@ private struct ProviderStep: View {
                     model.provider = .r2
                 }
                 ProviderCard(
-                    badge: "B2",
-                    badgeColor: Color(red: 0.85, green: 0.18, blue: 0.18),
-                    name: String(localized: "Backblaze B2"),
-                    sub: String(localized: "10 GB free · pay-as-you-go after"),
-                    pillText: String(localized: "COMING SOON"),
-                    pillColor: Color.white.opacity(0.20),
-                    selected: false,
-                    enabled: false
-                ) {}
-                ProviderCard(
                     badge: "S3",
                     badgeColor: Color(red: 0.62, green: 0.40, blue: 0.20),
                     name: String(localized: "Amazon S3"),
-                    sub: String(localized: "The original. AWS account required."),
-                    pillText: String(localized: "COMING SOON"),
+                    sub: String(localized: "AWS buckets and S3-compatible endpoints"),
+                    pillText: nil,
                     pillColor: Color.white.opacity(0.20),
-                    selected: false,
-                    enabled: false
-                ) {}
+                    selected: model.provider == .s3,
+                    enabled: true
+                ) {
+                    model.provider = .s3
+                }
+                ProviderCard(
+                    badge: "COS",
+                    badgeColor: Color(red: 0.25, green: 0.55, blue: 0.95),
+                    name: String(localized: "Tencent COS"),
+                    sub: String(localized: "Tencent Cloud object storage"),
+                    pillText: nil,
+                    pillColor: Color.white.opacity(0.20),
+                    selected: model.provider == .tencentCOS,
+                    enabled: true
+                ) {
+                    model.provider = .tencentCOS
+                }
+                ProviderCard(
+                    badge: "OSS",
+                    badgeColor: Color(red: 0.95, green: 0.36, blue: 0.18),
+                    name: String(localized: "Aliyun OSS"),
+                    sub: String(localized: "Alibaba Cloud object storage"),
+                    pillText: nil,
+                    pillColor: Color.white.opacity(0.20),
+                    selected: model.provider == .aliyunOSS,
+                    enabled: true
+                ) {
+                    model.provider = .aliyunOSS
+                }
             }
 
             Spacer(minLength: 8)
-
-            HStack(spacing: 4) {
-                Image(systemName: "lightbulb")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.white.opacity(0.45))
-                Button {
-                    NSWorkspace.shared.open(URL(string: "https://github.com/lzhgus/Capso/issues/new?labels=enhancement&template=feature_request.yml")!)
-                } label: {
-                    HStack(spacing: 3) {
-                        Text(String(localized: "Want a provider added? Open an issue on GitHub"))
-                        Image(systemName: "arrow.up.right")
-                            .font(.system(size: 9, weight: .bold))
-                    }
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.55))
-                }
-                .buttonStyle(.plain)
-            }
         }
     }
 }
@@ -510,23 +603,25 @@ private struct ProviderStep: View {
 private struct GetKeysStep: View {
     @Bindable var model: CloudShareWizardModel
 
-    private let steps: [(title: String, detail: AttributedString)] = [
-        (String(localized: "Create a bucket"),
-         attributed(String(localized: "In `R2 → Overview`, click `Create bucket`. Name it something memorable like `capso-shares`."))),
-        (String(localized: "Enable public access"),
-         attributed(String(localized: "In the bucket's `Settings` tab: click `Enable` next to **Public Development URL** for a free `pub-…r2.dev` link, OR click `+ Add` next to **Custom Domains** to use your own domain."))),
-        (String(localized: "Create an API token"),
-         attributed(String(localized: "`R2 → Manage API Tokens` → `Create API Token`. Choose **Object Read & Write**, scoped to this bucket."))),
-        (String(localized: "Copy the four values"),
-         attributed(String(localized: "You'll get `Account ID`, `Access Key ID`, and `Secret Access Key`. Note your bucket name too. The secret won't be shown again.")))
-    ]
+    private var steps: [(title: String, detail: AttributedString)] {
+        [
+            (String(localized: "Create or choose a bucket"),
+             Self.attributed(String(format: String(localized: "Use a bucket in **%@** that Capso can write objects into."), model.providerDisplayName))),
+            (String(localized: "Make uploaded files publicly readable"),
+             Self.attributed(String(localized: "Use a public bucket URL or connect a custom domain/CDN. Capso needs a public HTTPS prefix so it can copy a share link."))),
+            (String(localized: "Create access credentials"),
+             Self.attributed(String(localized: "Create a key with object read/write permission scoped to this bucket when your provider supports scoped keys."))),
+            (String(localized: "Copy the required values"),
+             Self.attributed(String(localized: "Keep the bucket, region/endpoint, access key, and secret ready. The secret will be stored in macOS Keychain.")))
+        ]
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
             StepHeader(
-                stepLabel: String(localized: "Step 3 — Cloudflare"),
-                title: String(localized: "Get your R2 credentials"),
-                subtitle: String(localized: "Open the Cloudflare dashboard in your browser and follow these four steps. Keep this window open — you'll paste the keys on the next screen.")
+                stepLabel: String(localized: "Step 3 — Provider"),
+                title: String(format: String(localized: "Prepare %@ credentials"), model.providerDisplayName),
+                subtitle: String(localized: "Open your provider dashboard and keep this window nearby. You'll paste the values on the next screen.")
             )
 
             VStack(spacing: 0) {
@@ -547,12 +642,12 @@ private struct GetKeysStep: View {
             HStack {
                 Spacer()
                 Button {
-                    NSWorkspace.shared.open(URL(string: "https://dash.cloudflare.com/?to=/:account/r2/overview")!)
+                    NSWorkspace.shared.open(providerURL)
                 } label: {
                     HStack(spacing: 6) {
                         Image(systemName: "safari")
                             .font(.system(size: 12, weight: .semibold))
-                        Text(String(localized: "Open R2 Dashboard"))
+                        Text(String(localized: "Open Provider Dashboard"))
                             .font(.system(size: 13, weight: .semibold))
                         Image(systemName: "arrow.up.right")
                             .font(.system(size: 10, weight: .bold))
@@ -574,6 +669,19 @@ private struct GetKeysStep: View {
                 }
                 .buttonStyle(.plain)
             }
+        }
+    }
+
+    private var providerURL: URL {
+        switch model.provider {
+        case .r2:
+            return URL(string: "https://dash.cloudflare.com/?to=/:account/r2/overview")!
+        case .s3:
+            return URL(string: "https://s3.console.aws.amazon.com/s3/home")!
+        case .tencentCOS:
+            return URL(string: "https://console.cloud.tencent.com/cos")!
+        case .aliyunOSS:
+            return URL(string: "https://oss.console.aliyun.com/")!
         }
     }
 
@@ -607,7 +715,7 @@ private struct CredentialsStep: View {
     @FocusState private var focused: Field?
 
     enum Field: Hashable {
-        case accountID, bucket, accessKey, secretKey
+        case accountID, region, endpoint, pathPrefix, bucket, accessKey, secretKey
     }
 
     var body: some View {
@@ -619,26 +727,54 @@ private struct CredentialsStep: View {
             )
 
             VStack(alignment: .leading, spacing: 14) {
-                // Full-width: Account ID
-                FieldGroup(
-                    label: String(localized: "Account ID"),
-                    icon: nil,
-                    error: model.accountIDError
-                ) {
-                    MonoTextField(
-                        text: $model.accountID,
-                        placeholder: String(localized: "32-character hex"),
-                        secure: false
-                    )
-                    .focused($focused, equals: .accountID)
-                    .onChange(of: focused) { _, newValue in
-                        if newValue != .accountID && !model.accountID.isEmpty {
-                            model.blurredAccountID = true
+                if model.provider == .r2 {
+                    FieldGroup(
+                        label: model.regionLabel,
+                        icon: nil,
+                        error: model.accountIDError
+                    ) {
+                        MonoTextField(
+                            text: $model.accountID,
+                            placeholder: model.regionPlaceholder,
+                            secure: false
+                        )
+                        .focused($focused, equals: .accountID)
+                        .onChange(of: focused) { _, newValue in
+                            if newValue != .accountID && !model.accountID.isEmpty {
+                                model.blurredAccountID = true
+                            }
                         }
+                    }
+                } else {
+                    FieldGroup(
+                        label: model.regionLabel,
+                        icon: nil,
+                        error: nil
+                    ) {
+                        MonoTextField(
+                            text: $model.region,
+                            placeholder: model.regionPlaceholder,
+                            secure: false
+                        )
+                        .focused($focused, equals: .region)
                     }
                 }
 
-                // Full-width: Bucket name
+                if model.shouldShowEndpoint {
+                    FieldGroup(
+                        label: String(localized: "Endpoint"),
+                        icon: nil,
+                        error: nil
+                    ) {
+                        MonoTextField(
+                            text: $model.endpoint,
+                            placeholder: model.endpointPlaceholder,
+                            secure: false
+                        )
+                        .focused($focused, equals: .endpoint)
+                    }
+                }
+
                 FieldGroup(
                     label: String(localized: "Bucket name"),
                     icon: nil,
@@ -657,10 +793,9 @@ private struct CredentialsStep: View {
                     }
                 }
 
-                // Half-width row: Access Key + Secret Key
                 HStack(alignment: .top, spacing: 12) {
                     FieldGroup(
-                        label: String(localized: "Access Key ID"),
+                        label: model.accessKeyLabel,
                         icon: nil,
                         error: model.accessKeyError
                     ) {
@@ -677,7 +812,7 @@ private struct CredentialsStep: View {
                         }
                     }
                     FieldGroup(
-                        label: String(localized: "Secret Access Key"),
+                        label: model.secretKeyLabel,
                         icon: "lock.fill",
                         error: nil
                     ) {
@@ -688,6 +823,19 @@ private struct CredentialsStep: View {
                         )
                         .focused($focused, equals: .secretKey)
                     }
+                }
+
+                FieldGroup(
+                    label: String(localized: "Path prefix"),
+                    icon: nil,
+                    error: nil
+                ) {
+                    MonoTextField(
+                        text: $model.pathPrefix,
+                        placeholder: String(localized: "Optional, e.g. screenshots"),
+                        secure: false
+                    )
+                    .focused($focused, equals: .pathPrefix)
                 }
             }
 
@@ -720,7 +868,7 @@ private struct URLPrefixStep: View {
             StepHeader(
                 stepLabel: String(localized: "Step 5 — Public URL"),
                 title: String(localized: "Public URL & test"),
-                subtitle: String(localized: "Capso prepends this to every uploaded filename to build the share link. Use your custom domain if you connected one, otherwise use the pub-…r2.dev URL from the Public Development URL section.")
+                subtitle: String(localized: "Capso uses this HTTPS prefix to build the share link after upload. Use your public bucket URL, custom domain, or CDN URL.")
             )
 
             FieldGroup(
@@ -730,7 +878,7 @@ private struct URLPrefixStep: View {
             ) {
                 MonoTextField(
                     text: $model.urlPrefix,
-                    placeholder: "https://pub-xxxxx.r2.dev",
+                    placeholder: "https://cdn.example.com",
                     secure: false
                 )
                 .onChange(of: model.urlPrefix) { _, _ in
@@ -779,7 +927,8 @@ private struct URLPrefixStep: View {
 
     private var previewLink: String {
         let prefix = model.urlPrefix.isEmpty ? "https://<your-prefix>" : ShareConfig.normalizePrefix(model.urlPrefix)
-        return "\(prefix)/2026-04-25-screenshot.png"
+        let key = ShareConfig.normalizePathPrefix(model.pathPrefix) + "2026-04-25-screenshot.png"
+        return "\(prefix)/\(key)"
     }
 
     /// Cancel any in-flight test before launching a new one, and store the new
@@ -908,19 +1057,19 @@ private struct URLPrefixStep: View {
                     String(localized: "One or more required values are missing. Go back and double-check the previous step."))
         case .invalidCredentials:
             return (String(localized: "Those credentials were rejected."),
-                    String(localized: "Cloudflare returned an authentication error. Verify the Access Key ID and Secret Access Key, and that the token has Object Read & Write permission on this bucket."))
+                    String(localized: "The storage provider returned an authentication error. Verify the access key, secret, and bucket permissions."))
         case .invalidURLPrefix(let reason):
             return (String(localized: "That URL prefix doesn't look right."),
                     reason)
         case .network(let underlying):
-            return (String(localized: "Network error reaching Cloudflare."),
+            return (String(localized: "Network error reaching storage."),
                     underlying)
         case .quotaExceeded:
             return (String(localized: "Storage quota exceeded."),
-                    String(localized: "Your R2 account is at its storage limit. Free up space in the Cloudflare dashboard or upgrade your plan."))
+                    String(localized: "Your storage account is at its limit. Free up space or upgrade your provider plan."))
         case .publicAccessUnreachable:
             return (String(localized: "The upload worked, but the file isn't publicly reachable."),
-                    String(localized: "The bucket isn't publicly readable. Open the Cloudflare dashboard → your bucket → Settings, then enable Public Development URL or add a Custom Domain. Then re-test."))
+                    String(localized: "The bucket URL is not publicly readable. Enable public access or use a public custom domain, then re-test."))
         case .unknown(let s):
             return (String(localized: "Something went wrong."),
                     s)
@@ -1117,7 +1266,7 @@ private struct ProviderCard: View {
     let badgeColor: Color
     let name: String
     let sub: String
-    let pillText: String
+    let pillText: String?
     let pillColor: Color
     let selected: Bool
     let enabled: Bool
@@ -1147,7 +1296,9 @@ private struct ProviderCard: View {
                         Text(name)
                             .font(.system(size: 14, weight: .semibold))
                             .foregroundStyle(.white.opacity(0.95))
-                        StatusPill(text: pillText, color: pillColor)
+                        if let pillText {
+                            StatusPill(text: pillText, color: pillColor)
+                        }
                     }
                     Text(sub)
                         .font(.system(size: 11))
@@ -1457,8 +1608,8 @@ enum CloudShareTester {
     static func runTest(
         provider: ShareProvider,
         urlPrefix: String,
-        accountID: String,
         bucket: String,
+        fields: [String: String],
         accessKey: String,
         secretKey: String
     ) async -> Result<TimeInterval, ShareError> {
@@ -1475,10 +1626,17 @@ enum CloudShareTester {
         let config = ShareConfig(
             provider: provider,
             urlPrefix: urlPrefix,
-            accountID: accountID,
-            bucket: bucket
+            bucket: bucket,
+            fields: fields
         )
-        let dest = R2Destination(config: config, accessKey: accessKey, secretKey: secretKey)
+        let dest: any ShareDestination
+        do {
+            dest = try ShareDestinationFactory.make(config: config, accessKey: accessKey, secretKey: secretKey)
+        } catch let err as ShareError {
+            return .failure(err)
+        } catch {
+            return .failure(.unknown(error.localizedDescription))
+        }
 
         let start = Date()
         do {

--- a/Packages/ShareKit/Sources/ShareKit/AliyunOSSDestination.swift
+++ b/Packages/ShareKit/Sources/ShareKit/AliyunOSSDestination.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+public actor AliyunOSSDestination: ShareDestination {
+    private let config: ShareConfig
+    private let accessKeyID: String
+    private let accessKeySecret: String
+
+    public init(config: ShareConfig, accessKeyID: String, accessKeySecret: String) {
+        self.config = config
+        self.accessKeyID = accessKeyID
+        self.accessKeySecret = accessKeySecret
+    }
+
+    public func upload(file: URL, key: String, contentType: String) async throws -> URL {
+        let objectKey = config.objectKey(for: key)
+        let request = try signedRequest(method: "PUT", objectKey: objectKey, contentType: contentType)
+        try await ShareHTTP.upload(request: request, file: file)
+        return config.publicURL(forObjectKey: objectKey)
+    }
+
+    public func delete(key: String) async throws {
+        let objectKey = config.objectKey(for: key)
+        let request = try signedRequest(method: "DELETE", objectKey: objectKey, contentType: nil)
+        try await ShareHTTP.data(request: request)
+    }
+
+    private func signedRequest(method: String, objectKey: String, contentType: String?) throws -> URLRequest {
+        let host = "\(config.bucket).\(normalizedEndpoint(config.region))"
+        let encodedKey = ShareConfig.encodeObjectKey(objectKey)
+        guard let url = URL(string: "https://\(host)/\(encodedKey)") else {
+            throw ShareError.notConfigured
+        }
+
+        let date = ShareSigning.rfc1123Date()
+        let contentTypeForSignature = contentType ?? ""
+        let resource = "/\(config.bucket)/\(objectKey)"
+        let aclHeader = method == "PUT" ? "x-oss-object-acl:public-read\n" : ""
+        let stringToSign = "\(method)\n\n\(contentTypeForSignature)\n\(date)\n\(aclHeader)\(resource)"
+        let signature = ShareSigning.base64(
+            ShareSigning.hmacSHA1(key: accessKeySecret, message: stringToSign)
+        )
+
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue(host, forHTTPHeaderField: "Host")
+        request.setValue(date, forHTTPHeaderField: "Date")
+        request.setValue("OSS \(accessKeyID):\(signature)", forHTTPHeaderField: "Authorization")
+        if let contentType {
+            request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+            request.setValue("public-read", forHTTPHeaderField: "x-oss-object-acl")
+        }
+        return request
+    }
+
+    private func normalizedEndpoint(_ raw: String) -> String {
+        var value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.hasPrefix("https://") {
+            value.removeFirst("https://".count)
+        }
+        if value.hasPrefix("http://") {
+            value.removeFirst("http://".count)
+        }
+        while value.hasSuffix("/") {
+            value.removeLast()
+        }
+        if !value.contains(".") {
+            value += ".aliyuncs.com"
+        }
+        return value
+    }
+}

--- a/Packages/ShareKit/Sources/ShareKit/S3Destination.swift
+++ b/Packages/ShareKit/Sources/ShareKit/S3Destination.swift
@@ -1,9 +1,7 @@
-// Packages/ShareKit/Sources/ShareKit/R2Destination.swift
-
 import Foundation
 import SotoS3
 
-public actor R2Destination: ShareDestination {
+public actor S3Destination: ShareDestination {
     private let config: ShareConfig
     private let accessKey: String
     private let secretKey: String
@@ -23,14 +21,11 @@ public actor R2Destination: ShareDestination {
     private func makeS3(_ client: AWSClient) -> S3 {
         S3(
             client: client,
-            region: .useast1,  // R2 ignores region; placeholder required
-            endpoint: "https://\(config.accountID).r2.cloudflarestorage.com"
+            region: .init(rawValue: config.region),
+            endpoint: config.endpoint
         )
     }
 
-    /// Run `body` with a fresh AWSClient + S3, awaiting client.shutdown()
-    /// before returning. Awaited shutdown avoids the AWSClient.deinit assertion
-    /// that fires when a deferred Task runs after the client goes out of scope.
     private func withClient<T: Sendable>(_ body: @Sendable (S3) async throws -> T) async throws -> T {
         let client = makeClient()
         let s3 = makeS3(client)
@@ -46,9 +41,6 @@ public actor R2Destination: ShareDestination {
 
     public func upload(file: URL, key: String, contentType: String) async throws -> URL {
         let objectKey = config.objectKey(for: key)
-        // TODO(v2): stream large files via AWSPayload.stream — current path loads the
-        // entire file into memory, which is fine for screenshots (~500KB) but pins
-        // RAM proportional to file size for screen recordings (10MB–1GB+).
         let data = try Data(contentsOf: file)
 
         return try await withClient { s3 in
@@ -67,7 +59,6 @@ public actor R2Destination: ShareDestination {
                 throw ShareError.network(underlying: error.localizedDescription)
             }
 
-            // The public URL is constructed from the user-configured prefix, not from S3 response.
             return self.config.publicURL(forObjectKey: objectKey)
         }
     }
@@ -87,42 +78,12 @@ public actor R2Destination: ShareDestination {
         }
     }
 
-    public func validateConfig() async throws {
-        let testID = IDGenerator.shortID()
-        let testKey = "_capso_test_\(testID).txt"
-        let tmpFile = FileManager.default.temporaryDirectory.appendingPathComponent(testKey)
-        try "ok".write(to: tmpFile, atomically: true, encoding: .utf8)
-        defer { try? FileManager.default.removeItem(at: tmpFile) }
-
-        let publicURL = try await upload(file: tmpFile, key: testKey, contentType: "text/plain")
-
-        // Round-trip: fetch via public URL to confirm public access is enabled
-        var request = URLRequest(url: publicURL)
-        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-        let (data, response) = try await URLSession.shared.data(for: request)
-        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
-            try? await delete(key: testKey)
-            throw ShareError.publicAccessUnreachable
-        }
-        guard String(data: data, encoding: .utf8) == "ok" else {
-            try? await delete(key: testKey)
-            throw ShareError.publicAccessUnreachable
-        }
-
-        try await delete(key: testKey)
-    }
-
-    // MARK: - Error mapping
-
     nonisolated private func map(_ error: S3ErrorType) -> ShareError {
-        // S3ErrorType only covers S3-specific typed errors (bucket/key not found, etc.)
         .unknown("\(error.errorCode): \(error.message ?? "")")
     }
 
     nonisolated private func mapResponse(_ error: AWSResponseError) -> ShareError {
-        // Auth and quota errors arrive as untyped AWSResponseError from R2/S3.
-        let code = error.errorCode
-        switch code {
+        switch error.errorCode {
         case "InvalidAccessKeyId", "SignatureDoesNotMatch", "AccessDenied":
             return .invalidCredentials
         case "QuotaExceeded", "EntityTooLarge":
@@ -130,7 +91,7 @@ public actor R2Destination: ShareDestination {
         case "NoSuchBucket":
             return .unknown("Bucket not found — verify the bucket name in Cloud Share settings")
         default:
-            return .unknown("\(code): \(error.message ?? "")")
+            return .unknown("\(error.errorCode): \(error.message ?? "")")
         }
     }
 }

--- a/Packages/ShareKit/Sources/ShareKit/ShareConfig.swift
+++ b/Packages/ShareKit/Sources/ShareKit/ShareConfig.swift
@@ -4,19 +4,90 @@ import Foundation
 
 public enum ShareProvider: String, CaseIterable, Sendable {
     case r2 = "r2"
+    case s3 = "s3"
+    case tencentCOS = "tencentCOS"
+    case aliyunOSS = "aliyunOSS"
+
+    public var displayName: String {
+        switch self {
+        case .r2:
+            return "Cloudflare R2"
+        case .s3:
+            return "Amazon S3"
+        case .tencentCOS:
+            return "Tencent COS"
+        case .aliyunOSS:
+            return "Aliyun OSS"
+        }
+    }
 }
 
 public struct ShareConfig: Sendable {
     public let provider: ShareProvider
     public let urlPrefix: String  // normalized: no trailing slash
-    public let accountID: String  // R2 account ID
     public let bucket: String
+    public let fields: [String: String]
 
     public init(provider: ShareProvider, urlPrefix: String, accountID: String, bucket: String) {
+        self.init(
+            provider: provider,
+            urlPrefix: urlPrefix,
+            bucket: bucket,
+            fields: ["accountID": accountID]
+        )
+    }
+
+    public init(provider: ShareProvider, urlPrefix: String, bucket: String, fields: [String: String]) {
         self.provider = provider
         self.urlPrefix = ShareConfig.normalizePrefix(urlPrefix)
-        self.accountID = accountID
         self.bucket = bucket
+        self.fields = fields.mapValues { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+    }
+
+    public var accountID: String {
+        value("accountID")
+    }
+
+    public var region: String {
+        value("region")
+    }
+
+    public var endpoint: String? {
+        nonEmpty("endpoint")
+    }
+
+    public var pathPrefix: String? {
+        nonEmpty("pathPrefix")
+    }
+
+    public func value(_ key: String) -> String {
+        fields[key] ?? ""
+    }
+
+    public func nonEmpty(_ key: String) -> String? {
+        let raw = value(key).trimmingCharacters(in: .whitespacesAndNewlines)
+        return raw.isEmpty ? nil : raw
+    }
+
+    public func validateForUpload() throws {
+        try ShareConfig.validatePrefix(urlPrefix)
+        guard !bucket.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ShareError.notConfigured
+        }
+        for key in provider.requiredFields {
+            guard nonEmpty(key) != nil else {
+                throw ShareError.notConfigured
+            }
+        }
+    }
+
+    public func objectKey(for key: String) -> String {
+        ShareConfig.normalizePathPrefix(pathPrefix) + key
+    }
+
+    public func publicURL(forObjectKey key: String) -> URL {
+        let encoded = ShareConfig.encodeObjectKey(key)
+        return URL(string: "\(urlPrefix)/\(encoded)")!
     }
 
     /// Compose a public URL from a prefix, ID, and file extension.
@@ -45,5 +116,43 @@ public struct ShareConfig: Sendable {
         guard url.query == nil, url.fragment == nil else {
             throw ShareError.invalidURLPrefix(reason: "Must not contain query string or fragment")
         }
+    }
+
+    public static func normalizePathPrefix(_ raw: String?) -> String {
+        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return ""
+        }
+        while value.hasPrefix("/") {
+            value.removeFirst()
+        }
+        while value.hasSuffix("/") {
+            value.removeLast()
+        }
+        return value.isEmpty ? "" : "\(value)/"
+    }
+
+    public static func encodeObjectKey(_ key: String) -> String {
+        key.split(separator: "/", omittingEmptySubsequences: false)
+            .map { String($0).sharePercentEncoded() }
+            .joined(separator: "/")
+    }
+}
+
+private extension ShareProvider {
+    var requiredFields: [String] {
+        switch self {
+        case .r2:
+            return ["accountID"]
+        case .s3, .tencentCOS, .aliyunOSS:
+            return ["region"]
+        }
+    }
+}
+
+extension String {
+    func sharePercentEncoded() -> String {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return addingPercentEncoding(withAllowedCharacters: allowed) ?? self
     }
 }

--- a/Packages/ShareKit/Sources/ShareKit/ShareDestinationFactory.swift
+++ b/Packages/ShareKit/Sources/ShareKit/ShareDestinationFactory.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+public enum ShareDestinationFactory {
+    public static func make(config: ShareConfig, accessKey: String, secretKey: String) throws -> any ShareDestination {
+        try config.validateForUpload()
+        guard !accessKey.isEmpty, !secretKey.isEmpty else {
+            throw ShareError.notConfigured
+        }
+
+        switch config.provider {
+        case .r2:
+            return R2Destination(config: config, accessKey: accessKey, secretKey: secretKey)
+        case .s3:
+            return S3Destination(config: config, accessKey: accessKey, secretKey: secretKey)
+        case .tencentCOS:
+            return TencentCOSDestination(config: config, secretID: accessKey, secretKey: secretKey)
+        case .aliyunOSS:
+            return AliyunOSSDestination(config: config, accessKeyID: accessKey, accessKeySecret: secretKey)
+        }
+    }
+}
+
+public extension ShareDestination {
+    func validateConfig() async throws {
+        let testID = IDGenerator.shortID()
+        let testKey = "_capso_test_\(testID).txt"
+        let tmpFile = FileManager.default.temporaryDirectory.appendingPathComponent(testKey)
+        try "ok".write(to: tmpFile, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tmpFile) }
+
+        let publicURL = try await upload(file: tmpFile, key: testKey, contentType: "text/plain")
+
+        var request = URLRequest(url: publicURL)
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            try? await delete(key: testKey)
+            throw ShareError.publicAccessUnreachable
+        }
+        guard String(data: data, encoding: .utf8) == "ok" else {
+            try? await delete(key: testKey)
+            throw ShareError.publicAccessUnreachable
+        }
+
+        try await delete(key: testKey)
+    }
+}

--- a/Packages/ShareKit/Sources/ShareKit/ShareSigning.swift
+++ b/Packages/ShareKit/Sources/ShareKit/ShareSigning.swift
@@ -1,0 +1,60 @@
+import CryptoKit
+import Foundation
+
+enum ShareSigning {
+    static func hmacSHA1(key: String, message: String) -> Data {
+        let signature = HMAC<Insecure.SHA1>.authenticationCode(
+            for: Data(message.utf8),
+            using: SymmetricKey(data: Data(key.utf8))
+        )
+        return Data(signature)
+    }
+
+    static func sha1Hex(_ text: String) -> String {
+        hex(Data(Insecure.SHA1.hash(data: Data(text.utf8))))
+    }
+
+    static func hex(_ data: Data) -> String {
+        data.map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func base64(_ data: Data) -> String {
+        data.base64EncodedString()
+    }
+
+    static func rfc1123Date(_ date: Date = Date()) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "GMT")
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss 'GMT'"
+        return formatter.string(from: date)
+    }
+}
+
+enum ShareHTTP {
+    static func upload(request: URLRequest, file: URL) async throws {
+        let (_, response) = try await URLSession.shared.upload(for: request, fromFile: file)
+        try validate(response: response)
+    }
+
+    static func data(request: URLRequest) async throws {
+        let (_, response) = try await URLSession.shared.data(for: request)
+        try validate(response: response)
+    }
+
+    private static func validate(response: URLResponse) throws {
+        guard let http = response as? HTTPURLResponse else {
+            throw ShareError.network(underlying: "Missing HTTP response")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            switch http.statusCode {
+            case 401, 403:
+                throw ShareError.invalidCredentials
+            case 413, 507:
+                throw ShareError.quotaExceeded
+            default:
+                throw ShareError.unknown("HTTP \(http.statusCode)")
+            }
+        }
+    }
+}

--- a/Packages/ShareKit/Sources/ShareKit/TencentCOSDestination.swift
+++ b/Packages/ShareKit/Sources/ShareKit/TencentCOSDestination.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+public actor TencentCOSDestination: ShareDestination {
+    private let config: ShareConfig
+    private let secretID: String
+    private let secretKey: String
+
+    public init(config: ShareConfig, secretID: String, secretKey: String) {
+        self.config = config
+        self.secretID = secretID
+        self.secretKey = secretKey
+    }
+
+    public func upload(file: URL, key: String, contentType: String) async throws -> URL {
+        let objectKey = config.objectKey(for: key)
+        let request = try signedRequest(method: "PUT", objectKey: objectKey, contentType: contentType)
+        try await ShareHTTP.upload(request: request, file: file)
+        return config.publicURL(forObjectKey: objectKey)
+    }
+
+    public func delete(key: String) async throws {
+        let objectKey = config.objectKey(for: key)
+        let request = try signedRequest(method: "DELETE", objectKey: objectKey, contentType: nil)
+        try await ShareHTTP.data(request: request)
+    }
+
+    private func signedRequest(method: String, objectKey: String, contentType: String?) throws -> URLRequest {
+        let host = "\(config.bucket).cos.\(config.region).myqcloud.com"
+        let encodedKey = ShareConfig.encodeObjectKey(objectKey)
+        guard let url = URL(string: "https://\(host)/\(encodedKey)") else {
+            throw ShareError.notConfigured
+        }
+
+        let now = Int(Date().timeIntervalSince1970)
+        let keyTime = "\(now);\(now + 3600)"
+        let signKey = ShareSigning.hex(ShareSigning.hmacSHA1(key: secretKey, message: keyTime))
+        let httpString = "\(method.lowercased())\n/\(encodedKey)\n\n\n"
+        let stringToSign = "sha1\n\(keyTime)\n\(ShareSigning.sha1Hex(httpString))\n"
+        let signature = ShareSigning.hex(ShareSigning.hmacSHA1(key: signKey, message: stringToSign))
+        let authorization = "q-sign-algorithm=sha1"
+            + "&q-ak=\(secretID)"
+            + "&q-sign-time=\(keyTime)"
+            + "&q-key-time=\(keyTime)"
+            + "&q-header-list="
+            + "&q-url-param-list="
+            + "&q-signature=\(signature)"
+
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue(host, forHTTPHeaderField: "Host")
+        request.setValue(authorization, forHTTPHeaderField: "Authorization")
+        if let contentType {
+            request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        }
+        return request
+    }
+}

--- a/Packages/ShareKit/Tests/ShareKitTests/ShareProviderTests.swift
+++ b/Packages/ShareKit/Tests/ShareKitTests/ShareProviderTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import ShareKit
+
+@Suite("Share providers")
+struct ShareProviderTests {
+    @Test("supported providers include R2, S3, Tencent COS, and Aliyun OSS")
+    func supportedProviders() {
+        #expect(ShareProvider.allCases == [.r2, .s3, .tencentCOS, .aliyunOSS])
+        #expect(ShareProvider.s3.displayName == "Amazon S3")
+        #expect(ShareProvider.tencentCOS.displayName == "Tencent COS")
+        #expect(ShareProvider.aliyunOSS.displayName == "Aliyun OSS")
+    }
+
+    @Test("R2 compatibility initializer stores account ID in provider fields")
+    func r2CompatibilityInitializer() {
+        let config = ShareConfig(
+            provider: .r2,
+            urlPrefix: "https://pub.example.com/",
+            accountID: "abc123",
+            bucket: "capso"
+        )
+
+        #expect(config.urlPrefix == "https://pub.example.com")
+        #expect(config.bucket == "capso")
+        #expect(config.accountID == "abc123")
+        #expect(config.value("accountID") == "abc123")
+    }
+
+    @Test("object keys support optional path prefixes")
+    func objectKeysSupportPathPrefixes() {
+        let config = ShareConfig(
+            provider: .s3,
+            urlPrefix: "https://cdn.example.com",
+            bucket: "capso",
+            fields: ["region": "us-east-1", "pathPrefix": "/screenshots/"]
+        )
+
+        #expect(config.objectKey(for: "capture one.png") == "screenshots/capture one.png")
+        #expect(config.publicURL(forObjectKey: config.objectKey(for: "capture one.png")).absoluteString == "https://cdn.example.com/screenshots/capture%20one.png")
+    }
+
+    @Test("destination factory creates provider-specific destinations")
+    func destinationFactory() throws {
+        let r2 = ShareConfig(provider: .r2, urlPrefix: "https://cdn.example.com", bucket: "capso", fields: ["accountID": "abc123"])
+        let s3 = ShareConfig(provider: .s3, urlPrefix: "https://cdn.example.com", bucket: "capso", fields: ["region": "us-east-1"])
+        let cos = ShareConfig(provider: .tencentCOS, urlPrefix: "https://cdn.example.com", bucket: "capso-123456", fields: ["region": "ap-guangzhou"])
+        let oss = ShareConfig(provider: .aliyunOSS, urlPrefix: "https://cdn.example.com", bucket: "capso", fields: ["region": "oss-cn-hangzhou"])
+
+        #expect(try ShareDestinationFactory.make(config: r2, accessKey: "id", secretKey: "secret") is R2Destination)
+        #expect(try ShareDestinationFactory.make(config: s3, accessKey: "id", secretKey: "secret") is S3Destination)
+        #expect(try ShareDestinationFactory.make(config: cos, accessKey: "id", secretKey: "secret") is TencentCOSDestination)
+        #expect(try ShareDestinationFactory.make(config: oss, accessKey: "id", secretKey: "secret") is AliyunOSSDestination)
+    }
+}

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -702,11 +702,38 @@ public final class AppSettings: @unchecked Sendable {
         set { defaults.set(newValue, forKey: "cloudShareBucket") }
     }
 
+    public var cloudShareRegion: String? {
+        get { defaults.string(forKey: "cloudShareRegion") }
+        set { defaults.set(newValue, forKey: "cloudShareRegion") }
+    }
+
+    public var cloudShareEndpoint: String? {
+        get { defaults.string(forKey: "cloudShareEndpoint") }
+        set { defaults.set(newValue, forKey: "cloudShareEndpoint") }
+    }
+
+    public var cloudSharePathPrefix: String? {
+        get { defaults.string(forKey: "cloudSharePathPrefix") }
+        set { defaults.set(newValue, forKey: "cloudSharePathPrefix") }
+    }
+
     public var isCloudShareConfigured: Bool {
-        cloudShareProvider != nil
-            && cloudShareURLPrefix != nil
-            && cloudShareAccountID != nil
-            && cloudShareBucket != nil
+        guard
+            let provider = cloudShareProvider,
+            cloudShareURLPrefix != nil,
+            cloudShareBucket != nil
+        else {
+            return false
+        }
+
+        switch provider {
+        case "r2":
+            return cloudShareAccountID != nil
+        case "s3", "tencentCOS", "aliyunOSS":
+            return cloudShareRegion != nil
+        default:
+            return false
+        }
     }
 
     // MARK: Computed

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -266,6 +266,43 @@ struct AppSettingsTests {
         #expect(settings.translationAutoDismissDelay == 10)
     }
 
+    @Test("Cloud Share configuration supports provider-specific fields")
+    func cloudShareProviderFieldsPersist() {
+        let suite = "test.cloudShare.providerFields"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let first = AppSettings(defaults: defaults)
+
+        first.cloudShareProvider = "s3"
+        first.cloudShareURLPrefix = "https://cdn.example.com"
+        first.cloudShareBucket = "capso"
+        first.cloudShareRegion = "us-east-1"
+        first.cloudShareEndpoint = "https://s3.us-east-1.amazonaws.com"
+        first.cloudSharePathPrefix = "screenshots"
+
+        let second = AppSettings(defaults: defaults)
+        #expect(second.isCloudShareConfigured == true)
+        #expect(second.cloudShareRegion == "us-east-1")
+        #expect(second.cloudShareEndpoint == "https://s3.us-east-1.amazonaws.com")
+        #expect(second.cloudSharePathPrefix == "screenshots")
+    }
+
+    @Test("Cloud Share R2 configuration remains compatible with account ID")
+    func cloudShareR2Compatibility() {
+        let suite = "test.cloudShare.r2Compatibility"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+
+        settings.cloudShareProvider = "r2"
+        settings.cloudShareURLPrefix = "https://pub.example.com"
+        settings.cloudShareBucket = "capso"
+        settings.cloudShareAccountID = "abc123"
+
+        #expect(settings.isCloudShareConfigured == true)
+        #expect(settings.cloudShareAccountID == "abc123")
+    }
+
     // MARK: Self-Timer
 
     @Test("Default self-timer duration is 5 seconds")


### PR DESCRIPTION
## Summary
- Add Cloud Share support for Amazon S3, Tencent COS, and Aliyun OSS alongside Cloudflare R2
- Add provider-specific ShareKit destinations and a destination factory
- Redesign Cloud Share setup/settings to select and configure supported providers
- Preserve existing R2 configuration compatibility

## Verification
- swift test --package-path Packages/ShareKit
- swift test --package-path Packages/SharedKit
- xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build
- git diff --check