### PR TITLE
feat: adapt settings to liquid glass

### DIFF
--- a/App/Sources/Preferences/Components/PreferencesGlassStyle.swift
+++ b/App/Sources/Preferences/Components/PreferencesGlassStyle.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+extension View {
+    @ViewBuilder
+    func preferencesGlassCard(cornerRadius: CGFloat = 8) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+
+        if #available(macOS 26.0, *) {
+            self
+                .glassEffect(.regular.tint(Color.white.opacity(0.04)), in: shape)
+                .overlay(
+                    shape.stroke(Color.white.opacity(0.10), lineWidth: 0.5)
+                )
+        } else {
+            self
+                .background(Color.white.opacity(0.04), in: shape)
+                .overlay(
+                    shape.stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+                )
+        }
+    }
+
+    @ViewBuilder
+    func preferencesSidebarSelectionBackground(isSelected: Bool, isHovered: Bool) -> some View {
+        let shape = RoundedRectangle(cornerRadius: 6, style: .continuous)
+
+        if #available(macOS 26.0, *), isSelected || isHovered {
+            self
+                .background(
+                    shape.fill(Color.white.opacity(isSelected ? 0.06 : 0.03))
+                )
+                .glassEffect(
+                    .regular.tint(Color.white.opacity(isSelected ? 0.08 : 0.04)).interactive(),
+                    in: shape
+                )
+        } else {
+            self
+                .background(
+                    shape.fill(
+                        isSelected ? Color.white.opacity(0.12) :
+                        isHovered ? Color.white.opacity(0.08) : Color.clear
+                    )
+                )
+        }
+    }
+
+    @ViewBuilder
+    func preferencesGlassActionBackground(isHovered: Bool) -> some View {
+        let shape = RoundedRectangle(cornerRadius: 5, style: .continuous)
+
+        if #available(macOS 26.0, *) {
+            self
+                .background(
+                    shape.fill(Color.white.opacity(isHovered ? 0.05 : 0.025))
+                )
+                .glassEffect(.regular.tint(Color.white.opacity(0.05)).interactive(), in: shape)
+                .overlay(
+                    shape.stroke(Color.white.opacity(0.10), lineWidth: 0.5)
+                )
+        } else {
+            self
+                .background(
+                    shape.fill(isHovered ? Color.white.opacity(0.1) : Color.white.opacity(0.05))
+                )
+                .overlay(
+                    shape.stroke(Color.white.opacity(0.12), lineWidth: 0.5)
+                )
+        }
+    }
+}

--- a/App/Sources/Preferences/Components/PreferencesGlassStyle.swift
+++ b/App/Sources/Preferences/Components/PreferencesGlassStyle.swift
@@ -5,6 +5,7 @@ extension View {
     func preferencesGlassCard(cornerRadius: CGFloat = 8) -> some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
 
+#if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             self
                 .glassEffect(.regular.tint(Color.white.opacity(0.04)), in: shape)
@@ -18,12 +19,20 @@ extension View {
                     shape.stroke(Color.white.opacity(0.08), lineWidth: 0.5)
                 )
         }
+#else
+        self
+            .background(Color.white.opacity(0.04), in: shape)
+            .overlay(
+                shape.stroke(Color.white.opacity(0.08), lineWidth: 0.5)
+            )
+#endif
     }
 
     @ViewBuilder
     func preferencesSidebarSelectionBackground(isSelected: Bool, isHovered: Bool) -> some View {
         let shape = RoundedRectangle(cornerRadius: 6, style: .continuous)
 
+#if compiler(>=6.2)
         if #available(macOS 26.0, *), isSelected || isHovered {
             self
                 .background(
@@ -42,12 +51,22 @@ extension View {
                     )
                 )
         }
+#else
+        self
+            .background(
+                shape.fill(
+                    isSelected ? Color.white.opacity(0.12) :
+                    isHovered ? Color.white.opacity(0.08) : Color.clear
+                )
+            )
+#endif
     }
 
     @ViewBuilder
     func preferencesGlassActionBackground(isHovered: Bool) -> some View {
         let shape = RoundedRectangle(cornerRadius: 5, style: .continuous)
 
+#if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             self
                 .background(
@@ -66,5 +85,14 @@ extension View {
                     shape.stroke(Color.white.opacity(0.12), lineWidth: 0.5)
                 )
         }
+#else
+        self
+            .background(
+                shape.fill(isHovered ? Color.white.opacity(0.1) : Color.white.opacity(0.05))
+            )
+            .overlay(
+                shape.stroke(Color.white.opacity(0.12), lineWidth: 0.5)
+            )
+#endif
     }
 }

--- a/App/Sources/Preferences/Components/SettingCard.swift
+++ b/App/Sources/Preferences/Components/SettingCard.swift
@@ -7,12 +7,7 @@ struct SettingCard<Content: View>: View {
         VStack(spacing: 0) {
             content
         }
-        .background(Color.white.opacity(0.04))
-        .clipShape(RoundedRectangle(cornerRadius: 8))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
-        )
+        .preferencesGlassCard()
     }
 }
 

--- a/App/Sources/Preferences/PreferencesView.swift
+++ b/App/Sources/Preferences/PreferencesView.swift
@@ -75,7 +75,18 @@ struct PreferencesView: View {
         }
     }
 
+    @ViewBuilder
     private var sidebar: some View {
+        if #available(macOS 26.0, *) {
+            GlassEffectContainer(spacing: 8) {
+                sidebarContent
+            }
+        } else {
+            sidebarContent
+        }
+    }
+
+    private var sidebarContent: some View {
         VStack(spacing: 2) {
             ForEach(PreferencesTab.allCases, id: \.self) { tab in
                 SidebarButton(tab: tab, isSelected: selectedTab == tab) {
@@ -92,6 +103,16 @@ struct PreferencesView: View {
 
     @ViewBuilder
     private var content: some View {
+        if #available(macOS 26.0, *) {
+            GlassEffectContainer(spacing: 18) {
+                scrollContent
+            }
+        } else {
+            scrollContent
+        }
+    }
+
+    private var scrollContent: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 switch selectedTab {
@@ -141,13 +162,7 @@ private struct SidebarButton: View {
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 7)
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(
-                        isSelected ? Color.white.opacity(0.12) :
-                        isHovered ? Color.white.opacity(0.08) : Color.clear
-                    )
-            )
+            .preferencesSidebarSelectionBackground(isSelected: isSelected, isHovered: isHovered)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/App/Sources/Preferences/PreferencesView.swift
+++ b/App/Sources/Preferences/PreferencesView.swift
@@ -77,6 +77,7 @@ struct PreferencesView: View {
 
     @ViewBuilder
     private var sidebar: some View {
+#if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             GlassEffectContainer(spacing: 8) {
                 sidebarContent
@@ -84,6 +85,9 @@ struct PreferencesView: View {
         } else {
             sidebarContent
         }
+#else
+        sidebarContent
+#endif
     }
 
     private var sidebarContent: some View {
@@ -103,6 +107,7 @@ struct PreferencesView: View {
 
     @ViewBuilder
     private var content: some View {
+#if compiler(>=6.2)
         if #available(macOS 26.0, *) {
             GlassEffectContainer(spacing: 18) {
                 scrollContent
@@ -110,6 +115,9 @@ struct PreferencesView: View {
         } else {
             scrollContent
         }
+#else
+        scrollContent
+#endif
     }
 
     private var scrollContent: some View {

--- a/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
@@ -201,14 +201,7 @@ private struct ExternalLinkButton: View {
             }
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
-            .background(
-                RoundedRectangle(cornerRadius: 5)
-                    .fill(isHovered ? Color.white.opacity(0.1) : Color.white.opacity(0.05))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 5)
-                    .stroke(Color.white.opacity(0.12), lineWidth: 0.5)
-            )
+            .preferencesGlassActionBackground(isHovered: isHovered)
         }
         .buttonStyle(.plain)
         .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- add macOS 26-gated Liquid Glass styling helpers for the settings surface
- apply native glass effects to settings cards, selected/hovered sidebar items, and compact external-link buttons
- preserve the existing translucent material fallback for macOS 15+

Closes #137

## Validation
- xcodegen
- git diff HEAD --check
- xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build
