### PR TITLE
fix: align recording output dimensions

### DIFF
--- a/App/Sources/Recording/RecordingToolbar.swift
+++ b/App/Sources/Recording/RecordingToolbar.swift
@@ -35,7 +35,7 @@ struct RecordingToolbarView: View {
                     Text("\(width)")
                         .font(.system(size: 13, weight: .medium, design: .monospaced))
                         .foregroundStyle(.white.opacity(0.9))
-                        .frame(minWidth: 40)
+                        .frame(minWidth: 48)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
                         .background(.white.opacity(0.1))
@@ -48,11 +48,15 @@ struct RecordingToolbarView: View {
                     Text("\(height)")
                         .font(.system(size: 13, weight: .medium, design: .monospaced))
                         .foregroundStyle(.white.opacity(0.9))
-                        .frame(minWidth: 40)
+                        .frame(minWidth: 48)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
                         .background(.white.opacity(0.1))
                         .clipShape(RoundedRectangle(cornerRadius: 4))
+
+                    Text("px")
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .foregroundStyle(.white.opacity(0.45))
                 }
 
                 // Controls row

--- a/App/Sources/Recording/RecordingToolbarWindow.swift
+++ b/App/Sources/Recording/RecordingToolbarWindow.swift
@@ -45,9 +45,10 @@ final class RecordingToolbarWindow: NSPanel {
         self.collectionBehavior = [.canJoinAllSpaces, .transient]
         self.isMovableByWindowBackground = true
 
+        let outputSize = Self.outputVideoSize(for: selectionRect, screen: screen)
         let view = RecordingToolbarWrapper(
-            width: Int(selectionRect.width),
-            height: Int(selectionRect.height),
+            width: outputSize.width,
+            height: outputSize.height,
             settings: settings,
             onRecord: onRecord,
             onCameraToggled: onCameraToggled,
@@ -56,6 +57,18 @@ final class RecordingToolbarWindow: NSPanel {
             onCameraSettingsChanged: onCameraSettingsChanged
         )
         self.contentView = NSHostingView(rootView: view)
+    }
+
+    private static func outputVideoSize(for selectionRect: CGRect, screen: NSScreen) -> (width: Int, height: Int) {
+        let scale = max(screen.backingScaleFactor, 1)
+        return (
+            width: ensureEven(max(1, Int(ceil(selectionRect.width * scale)))),
+            height: ensureEven(max(1, Int(ceil(selectionRect.height * scale))))
+        )
+    }
+
+    private static func ensureEven(_ value: Int) -> Int {
+        value % 2 == 0 ? value : value + 1
     }
 
     func show() {

--- a/Packages/RecordingKit/Sources/RecordingKit/ScreenRecorder.swift
+++ b/Packages/RecordingKit/Sources/RecordingKit/ScreenRecorder.swift
@@ -75,11 +75,8 @@ public final class ScreenRecorder {
                 .appendingPathComponent("capso_recording_\(UUID().uuidString).mov")
             outputFileURL = fileURL
 
-            // Calculate dimensions (same as stream config)
-            let dims = videoDims(for: config.captureRect)
-
             // Set up SCStream first (creates the dispatch queue)
-            try await setupStream(config: config, dims: dims, excludeWindowIDs: excludeWindowIDs)
+            let dims = try await setupStream(config: config, excludeWindowIDs: excludeWindowIDs)
 
             // Create writer ON the recording dispatch queue (thread affinity —
             // AVAssetWriter's AAC encoder must be created and used on same thread)
@@ -150,14 +147,7 @@ public final class ScreenRecorder {
 
     // MARK: - SCStream
 
-    private struct VideoDims { let w: Int; let h: Int }
-
-    private func videoDims(for rect: CGRect) -> VideoDims {
-        VideoDims(w: ensureEven(Int(ceil(rect.width)) * 2),
-                  h: ensureEven(Int(ceil(rect.height)) * 2))
-    }
-
-    private func setupStream(config: RecordingConfig, dims: VideoDims, excludeWindowIDs: [CGWindowID]) async throws {
+    private func setupStream(config: RecordingConfig, excludeWindowIDs: [CGWindowID]) async throws -> RecordingVideoDimensions {
         let excludeSet = Set(excludeWindowIDs)
         let content = try await shareableContent(excludingWindowIDs: excludeSet)
         guard let display = content.displays.first(where: { $0.displayID == config.displayID }) else {
@@ -183,6 +173,10 @@ public final class ScreenRecorder {
             capsoLog("Proceeding without excluding windows: \(missingIDs)")
         }
         let filter = SCContentFilter(display: display, excludingWindows: excludedWindows)
+        let dims = RecordingVideoGeometry.dimensions(
+            for: config.captureRect,
+            pointPixelScale: CGFloat(filter.pointPixelScale)
+        )
         let sc = SCStreamConfiguration()
 
         sc.width = dims.w
@@ -224,6 +218,7 @@ public final class ScreenRecorder {
         }
 
         self.stream = captureStream; self.streamOutput = output
+        return dims
     }
 
     private func shareableContent(excludingWindowIDs excludeSet: Set<CGWindowID>) async throws -> SCShareableContent {
@@ -273,7 +268,24 @@ public final class ScreenRecorder {
     }
 }
 
-private func ensureEven(_ v: Int) -> Int { v % 2 == 0 ? v : v + 1 }
+struct RecordingVideoDimensions: Sendable, Equatable {
+    let w: Int
+    let h: Int
+}
+
+enum RecordingVideoGeometry {
+    static func dimensions(for rect: CGRect, pointPixelScale: CGFloat) -> RecordingVideoDimensions {
+        let scale = max(pointPixelScale, 1)
+        return RecordingVideoDimensions(
+            w: ensureEven(max(1, Int(ceil(rect.width * scale)))),
+            h: ensureEven(max(1, Int(ceil(rect.height * scale))))
+        )
+    }
+
+    private static func ensureEven(_ v: Int) -> Int {
+        v % 2 == 0 ? v : v + 1
+    }
+}
 
 // MARK: - RecordingWriter
 

--- a/Packages/RecordingKit/Tests/RecordingKitTests/RecordingVideoGeometryTests.swift
+++ b/Packages/RecordingKit/Tests/RecordingKitTests/RecordingVideoGeometryTests.swift
@@ -1,0 +1,46 @@
+import CoreGraphics
+import Testing
+@testable import RecordingKit
+
+@Suite("RecordingVideoGeometry")
+struct RecordingVideoGeometryTests {
+    @Test("Uses actual 1x display scale without doubling")
+    func dimensionsForOneXDisplay() {
+        let dims = RecordingVideoGeometry.dimensions(
+            for: CGRect(x: 0, y: 0, width: 863, height: 604),
+            pointPixelScale: 1
+        )
+
+        #expect(dims == RecordingVideoDimensions(w: 864, h: 604))
+    }
+
+    @Test("Uses actual 2x display scale for Retina output")
+    func dimensionsForTwoXDisplay() {
+        let dims = RecordingVideoGeometry.dimensions(
+            for: CGRect(x: 0, y: 0, width: 863, height: 604),
+            pointPixelScale: 2
+        )
+
+        #expect(dims == RecordingVideoDimensions(w: 1726, h: 1208))
+    }
+
+    @Test("Rounds fractional scaled dimensions up to even encoder sizes")
+    func dimensionsRoundUpToEvenSizes() {
+        let dims = RecordingVideoGeometry.dimensions(
+            for: CGRect(x: 0, y: 0, width: 863.5, height: 604.5),
+            pointPixelScale: 2
+        )
+
+        #expect(dims == RecordingVideoDimensions(w: 1728, h: 1210))
+    }
+
+    @Test("Clamps invalid scale to 1x")
+    func dimensionsClampScale() {
+        let dims = RecordingVideoGeometry.dimensions(
+            for: CGRect(x: 0, y: 0, width: 320, height: 241),
+            pointPixelScale: 0
+        )
+
+        #expect(dims == RecordingVideoDimensions(w: 320, h: 242))
+    }
+}


### PR DESCRIPTION
## Summary
- Use the actual ScreenCaptureKit point-to-pixel scale for recording output dimensions instead of hardcoding 2x.
- Show the toolbar recording size as final output pixels with a px label.
- Add RecordingKit geometry tests for 1x, 2x, fractional, and even-dimension rounding.

## Test Plan
- swift test --package-path Packages/RecordingKit
- xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build

Closes #136