### PR TITLE
feat: include app names in screenshot filenames

### DIFF
--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -43,6 +43,12 @@ final class CaptureCoordinator {
 
     /// Post-capture action override. When set, ignores Settings toggles.
     private var pendingAction: PostCaptureAction = .default
+    private var pendingSourceApplication: SourceApplication?
+
+    private struct SourceApplication: Sendable {
+        let name: String?
+        let bundleIdentifier: String?
+    }
 
     enum PostCaptureAction {
         case `default`    // Use Settings (Show Preview / Copy / Auto Save)
@@ -75,6 +81,41 @@ final class CaptureCoordinator {
 
     init(settings: AppSettings) {
         self.settings = settings
+    }
+
+    private func rememberSourceApplication() {
+        pendingSourceApplication = currentSourceApplication()
+    }
+
+    private func currentSourceApplication() -> SourceApplication? {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return nil }
+        if app.bundleIdentifier == Bundle.main.bundleIdentifier {
+            return nil
+        }
+
+        let name = app.localizedName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let bundleIdentifier = app.bundleIdentifier
+        guard !(name?.isEmpty ?? true) || bundleIdentifier != nil else { return nil }
+        return SourceApplication(name: name, bundleIdentifier: bundleIdentifier)
+    }
+
+    private func captureResultWithPendingSource(_ result: CaptureResult) -> CaptureResult {
+        defer { pendingSourceApplication = nil }
+        guard let source = pendingSourceApplication,
+              result.appName == nil || result.appBundleIdentifier == nil else {
+            return result
+        }
+
+        return CaptureResult(
+            image: result.image,
+            mode: result.mode,
+            captureRect: result.captureRect,
+            windowName: result.windowName,
+            appName: result.appName ?? source.name,
+            appBundleIdentifier: result.appBundleIdentifier ?? source.bundleIdentifier,
+            timestamp: result.timestamp,
+            displayID: result.displayID
+        )
     }
 
     func captureArea() {
@@ -123,12 +164,14 @@ final class CaptureCoordinator {
 
     func captureAllInOne() {
         pendingAction = .default
+        rememberSourceApplication()
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
             self?.showFrozenAllInOneOverlay()
         }
     }
 
     private func startAreaCapture() {
+        rememberSourceApplication()
         if settings.freezeScreen && !settings.screenshotShowsCursor {
             showFrozenOverlay()
         } else {
@@ -139,6 +182,7 @@ final class CaptureCoordinator {
     }
 
     func captureFullscreen() {
+        rememberSourceApplication()
         // Capture the display the user is currently looking at (the one
         // containing the mouse cursor), not unconditionally the primary.
         // For keyboard-shortcut invocations this matches where attention is;
@@ -164,6 +208,7 @@ final class CaptureCoordinator {
     }
 
     func captureScrolling() {
+        rememberSourceApplication()
         // Use area selection overlay, then start scrolling capture on the selected region
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
             self?.showOverlay(mode: .area, isScrollingCapture: true)
@@ -174,6 +219,7 @@ final class CaptureCoordinator {
     /// Uses `settings.selfTimerDurationSeconds` as the delay.
     func captureAreaWithSelfTimer() {
         pendingAction = .default
+        rememberSourceApplication()
         let seconds = settings.selfTimerDurationSeconds
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
             self?.showOverlay(mode: .area, selfTimerSeconds: seconds)
@@ -181,6 +227,7 @@ final class CaptureCoordinator {
     }
 
     func captureWindow() {
+        pendingSourceApplication = nil
         // Enumerate windows first, then show overlay in window selection mode
         Task {
             do {
@@ -267,6 +314,7 @@ final class CaptureCoordinator {
                 self?.performWindowCapture(windowID: windowID)
             }
             overlay.onCancelled = { [weak self] in
+                self?.pendingSourceApplication = nil
                 self?.dismissOverlay()
             }
             overlay.activate(mode: mode)
@@ -305,6 +353,7 @@ final class CaptureCoordinator {
                 self?.performWindowCapture(windowID: windowID)
             }
             overlay.onCancelled = { [weak self] in
+                self?.pendingSourceApplication = nil
                 self?.dismissOverlay()
             }
             overlay.activate(mode: .area)
@@ -455,7 +504,8 @@ final class CaptureCoordinator {
             guard let self else { return }
             self.dismissAllInOneToolbar()
             self.dismissFreezeWindows()
-            self.saveRenderedImage(image)
+            self.saveRenderedImage(image, sourceAppName: self.pendingSourceApplication?.name)
+            self.pendingSourceApplication = nil
         }
         toolbar.onPin = { [weak self] rect in
             guard let self else { return }
@@ -477,9 +527,15 @@ final class CaptureCoordinator {
             guard let self else { return }
             self.dismissAllInOneToolbar()
             self.dismissFreezeWindows()
-            self.pinRenderedImage(image, anchor: self.globalRect(fromScreenLocalRect: rect, screen: screen))
+            self.pinRenderedImage(
+                image,
+                anchor: self.globalRect(fromScreenLocalRect: rect, screen: screen),
+                sourceAppName: self.pendingSourceApplication?.name
+            )
+            self.pendingSourceApplication = nil
         }
         toolbar.onCancel = { [weak self] in
+            self?.pendingSourceApplication = nil
             self?.dismissAllInOneToolbar()
             self?.dismissFreezeWindows()
         }
@@ -547,6 +603,7 @@ final class CaptureCoordinator {
                 }
             }
             overlay.onCancelled = { [weak self] in
+                self?.pendingSourceApplication = nil
                 self?.dismissOverlay()
             }
             overlay.activate(mode: .area)
@@ -944,7 +1001,8 @@ final class CaptureCoordinator {
         )
     }
 
-    private func handleCaptureResult(_ result: CaptureResult) {
+    private func handleCaptureResult(_ capturedResult: CaptureResult) {
+        let result = captureResultWithPendingSource(capturedResult)
         lastCaptureResult = result
 
         let action = pendingAction
@@ -972,7 +1030,7 @@ final class CaptureCoordinator {
         case .pin:
             pinToScreen(result, anchor: anchorRect(for: result))
         case .save:
-            saveImageToFile(result.image)
+            saveImageToFile(result)
         case .share:
             // Skip Quick Access, save to history, then upload in background.
             logDiagnostic("Cloud Share capture completed mode=\(result.mode) displayID=\(result.displayID)")
@@ -992,7 +1050,7 @@ final class CaptureCoordinator {
                 copyImageToClipboard(result.image)
             }
             if settings.screenshotAutoSave {
-                saveImageToFile(result.image)
+                saveImageToFile(result)
             }
             if settings.screenshotShowPreview {
                 showQuickAccess(for: result, entryID: entryID)
@@ -1044,7 +1102,7 @@ final class CaptureCoordinator {
         }
         window.onSave = { [weak self, weak window] in
             guard let self, let window else { return }
-            self.saveImageToFile(result.image)
+            self.saveImageToFile(result)
             self.dismissQuickAccessWindow(window)
         }
         window.onAnnotate = { [weak self, weak window] in
@@ -1139,7 +1197,7 @@ final class CaptureCoordinator {
             image: result.image,
             anchorScreen: screen,
             onSave: { [weak self] (rendered: CGImage) in
-                self?.saveRenderedImage(rendered)
+                self?.saveRenderedImage(rendered, sourceAppName: result.appName, date: result.timestamp)
                 self?.annotationWindow = nil
             },
             onCopy: { [weak self] (rendered: CGImage) in
@@ -1147,7 +1205,7 @@ final class CaptureCoordinator {
                 self?.annotationWindow = nil
             },
             onPin: { [weak self] (rendered: CGImage, anchor: CGRect?) in
-                self?.pinRenderedImage(rendered, anchor: anchor)
+                self?.pinRenderedImage(rendered, anchor: anchor, sourceAppName: result.appName, date: result.timestamp)
                 self?.annotationWindow = nil
             },
             onClose: { [weak self] in
@@ -1189,7 +1247,7 @@ final class CaptureCoordinator {
             screen: screen,
             screenLocalRect: screenLocalRect,
             onSave: { [weak self] rendered in
-                self?.saveRenderedImage(rendered)
+                self?.saveRenderedImage(rendered, sourceAppName: result.appName, date: result.timestamp)
                 self?.inlineAnnotationWindow = nil
             },
             onCopy: { [weak self] rendered in
@@ -1197,7 +1255,7 @@ final class CaptureCoordinator {
                 self?.inlineAnnotationWindow = nil
             },
             onPin: { [weak self] rendered, anchor in
-                self?.pinRenderedImage(rendered, anchor: anchor)
+                self?.pinRenderedImage(rendered, anchor: anchor, sourceAppName: result.appName, date: result.timestamp)
                 self?.inlineAnnotationWindow = nil
             },
             onClose: { [weak self] in
@@ -1258,10 +1316,15 @@ final class CaptureCoordinator {
     }
 
     private func pinToScreen(_ result: CaptureResult, anchor: CGRect) {
-        pinRenderedImage(result.image, anchor: anchor)
+        pinRenderedImage(result.image, anchor: anchor, sourceAppName: result.appName, date: result.timestamp)
     }
 
-    private func pinRenderedImage(_ image: CGImage, anchor: CGRect?) {
+    private func pinRenderedImage(
+        _ image: CGImage,
+        anchor: CGRect?,
+        sourceAppName: String? = nil,
+        date: Date = Date()
+    ) {
         let controller = PinnedScreenshotController(
             image: image,
             anchorRect: anchor,
@@ -1269,7 +1332,7 @@ final class CaptureCoordinator {
                 self?.copyImageToClipboard(image)
             },
             onSave: { [weak self] in
-                self?.saveImageToFile(image)
+                self?.saveImageToFile(image, sourceAppName: sourceAppName, date: date)
             },
             onDidClose: { [weak self] controllerID in
                 self?.pinnedControllers.removeAll { $0.id == controllerID }
@@ -1286,7 +1349,11 @@ final class CaptureCoordinator {
         pasteboard.writeObjects([nsImage])
     }
 
-    private func saveImageToFile(_ image: CGImage) {
+    private func saveImageToFile(_ result: CaptureResult) {
+        saveImageToFile(result.image, sourceAppName: result.appName, date: result.timestamp)
+    }
+
+    private func saveImageToFile(_ image: CGImage, sourceAppName: String? = nil, date: Date = Date()) {
         guard let encoded = screenshotData(from: image) else { return }
         let directory = settings.screenshotMonthlyFolders
             ? FileNaming.monthlyDirectory(in: settings.exportLocation)
@@ -1294,7 +1361,9 @@ final class CaptureCoordinator {
         let url = FileNaming.generateFileURL(
             in: directory,
             type: .screenshot,
-            format: encoded.format
+            format: encoded.format,
+            date: date,
+            sourceAppName: sourceAppName
         )
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         try? encoded.data.write(to: url)
@@ -1314,8 +1383,8 @@ final class CaptureCoordinator {
         return (data, preset.fileFormat)
     }
 
-    private func saveRenderedImage(_ image: CGImage) {
-        saveImageToFile(image)
+    private func saveRenderedImage(_ image: CGImage, sourceAppName: String? = nil, date: Date = Date()) {
+        saveImageToFile(image, sourceAppName: sourceAppName, date: date)
     }
 
     private func copyRenderedImage(_ image: CGImage) {

--- a/App/Sources/History/HistoryCoordinator.swift
+++ b/App/Sources/History/HistoryCoordinator.swift
@@ -351,12 +351,19 @@ final class HistoryCoordinator {
         guard let sourceURL = fullImageURL(for: entry) else { return }
         let fileFormat = preferredFileFormat(for: entry, sourceURL: sourceURL)
         let captureType = preferredCaptureType(for: entry)
+        let sourceAppName: String? = switch captureType {
+        case .screenshot:
+            entry.sourceAppName
+        case .recording:
+            nil
+        }
 
         let panel = NSSavePanel()
         panel.nameFieldStringValue = FileNaming.generateFileName(
             for: captureType,
             format: fileFormat,
-            date: entry.createdAt
+            date: entry.createdAt,
+            sourceAppName: sourceAppName
         )
         panel.allowedContentTypes = [fileFormat.contentType]
         panel.canCreateDirectories = true

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/FileNaming.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/FileNaming.swift
@@ -66,29 +66,56 @@ public enum FileNaming {
         return f
     }()
 
-    public static func generateName(for type: CaptureType, date: Date = Date()) -> String {
+    public static func generateName(for type: CaptureType, date: Date = Date(), sourceAppName: String? = nil) -> String {
         let prefix = switch type {
         case .screenshot: "Capso Screenshot"
         case .recording: "Capso Recording"
         }
+        let source = sanitizedSourceAppName(sourceAppName).map { " - \($0)" } ?? ""
         let dateString = dateFormatter.string(from: date)
         let timeString = timeFormatter.string(from: date)
-        return "\(prefix) \(dateString) at \(timeString)"
+        return "\(prefix)\(source) \(dateString) at \(timeString)"
     }
 
     public static func fileExtension(for format: FileFormat) -> String {
         format.rawValue
     }
 
-    public static func generateFileName(for type: CaptureType, format: FileFormat, date: Date = Date()) -> String {
-        "\(generateName(for: type, date: date)).\(fileExtension(for: format))"
+    public static func generateFileName(
+        for type: CaptureType,
+        format: FileFormat,
+        date: Date = Date(),
+        sourceAppName: String? = nil
+    ) -> String {
+        "\(generateName(for: type, date: date, sourceAppName: sourceAppName)).\(fileExtension(for: format))"
     }
 
-    public static func generateFileURL(in directory: URL, type: CaptureType, format: FileFormat, date: Date = Date()) -> URL {
-        directory.appendingPathComponent(generateFileName(for: type, format: format, date: date))
+    public static func generateFileURL(
+        in directory: URL,
+        type: CaptureType,
+        format: FileFormat,
+        date: Date = Date(),
+        sourceAppName: String? = nil
+    ) -> URL {
+        directory.appendingPathComponent(
+            generateFileName(for: type, format: format, date: date, sourceAppName: sourceAppName)
+        )
     }
 
     public static func monthlyDirectory(in baseDirectory: URL, date: Date = Date()) -> URL {
         baseDirectory.appendingPathComponent(monthFormatter.string(from: date), isDirectory: true)
+    }
+
+    private static func sanitizedSourceAppName(_ name: String?) -> String? {
+        guard let name else { return nil }
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let invalidCharacters = CharacterSet(charactersIn: "/:")
+        let sanitized = trimmed
+            .components(separatedBy: invalidCharacters)
+            .joined(separator: "-")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return sanitized.isEmpty ? nil : sanitized
     }
 }

--- a/Packages/SharedKit/Tests/SharedKitTests/FileNamingTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/FileNamingTests.swift
@@ -24,6 +24,28 @@ struct FileNamingTests {
         #expect(name.contains(String(year)))
     }
 
+    @Test("Screenshot name includes source app when provided")
+    func screenshotNameIncludesSourceApp() {
+        let date = Date(timeIntervalSince1970: 1_705_348_800)
+        let name = FileNaming.generateName(for: .screenshot, date: date, sourceAppName: "Safari")
+
+        #expect(name.hasPrefix("Capso Screenshot - Safari "))
+    }
+
+    @Test("Source app name is sanitized for filenames")
+    func sourceAppNameIsSanitized() {
+        let date = Date(timeIntervalSince1970: 1_705_348_800)
+        let fileName = FileNaming.generateFileName(
+            for: .screenshot,
+            format: .png,
+            date: date,
+            sourceAppName: "Foo/Bar:Beta"
+        )
+
+        #expect(fileName.hasPrefix("Capso Screenshot - Foo-Bar-Beta "))
+        #expect(fileName.hasSuffix(".png"))
+    }
+
     @Test("File extension for PNG")
     func fileExtensionPNG() {
         let ext = FileNaming.fileExtension(for: .png)


### PR DESCRIPTION
## Summary
- include the captured/source app name in screenshot filenames when available
- carry source-app metadata through auto-save, Quick Access save, annotation save, pin save, and history export flows
- sanitize app names before using them in generated file paths

## Verification
- swift test --package-path Packages/SharedKit
- xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build
