### PR TITLE
Fix/recording space window selection

### DIFF
--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -26,6 +26,7 @@ final class CaptureOverlayView: NSView {
     var onSelectionComplete: ((CGRect) -> Void)?
     var onWindowSelected: ((CGWindowID) -> Void)?
     var onCancel: (() -> Void)?
+    var onSpaceToggle: (() -> Void)?
 
     private let settings: AppSettings
     /// When true, preset features (badge, R-key, right-click menu, ratio lock) are disabled.
@@ -821,6 +822,9 @@ final class CaptureOverlayView: NSView {
     override func keyDown(with event: NSEvent) {
         if event.keyCode == 53 { // ESC
             cancelOverlay()
+        } else if event.keyCode == 49 { // Space
+            guard !isDragging, onSpaceToggle != nil else { return }
+            onSpaceToggle?()
         } else if event.keyCode == 15 { // R key
             guard case .area = mode, !isDragging, !presetsDisabled else { return }
             let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)

--- a/App/Sources/Capture/CaptureOverlayWindow.swift
+++ b/App/Sources/Capture/CaptureOverlayWindow.swift
@@ -8,6 +8,7 @@ final class CaptureOverlayWindow: NSPanel {
     var onAreaSelected: ((CGRect, NSScreen) -> Void)?
     var onWindowSelected: ((CGWindowID) -> Void)?
     var onCancelled: (() -> Void)?
+    var onSpaceToggle: (() -> Void)?
 
     private let settings: AppSettings
     private var overlayView: CaptureOverlayView!
@@ -49,6 +50,9 @@ final class CaptureOverlayWindow: NSPanel {
         }
         overlayView.onCancel = { [weak self] in
             self?.onCancelled?()
+        }
+        overlayView.onSpaceToggle = { [weak self] in
+            self?.onSpaceToggle?()
         }
 
         self.contentView = overlayView

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -18,7 +18,7 @@ import EffectsKit
 import EditorKit
 
 /// Orchestrates recording flow:
-/// 1. Show overlay for area selection (drag or Space for window)
+/// 1. Show overlay for area selection (drag, or Space to switch to window selection)
 /// 2. Show recording toolbar (format, camera, mic, audio)
 /// 3. User clicks Record → start recording with selected area
 /// 4. Show controls (pause/stop/timer) + red border
@@ -87,6 +87,35 @@ final class RecordingCoordinator {
     // MARK: - Step 1: Area Selection
 
     private func showAreaSelectionOverlay() {
+        presentSelectionOverlay(mode: .area) { [weak self] in
+            self?.requestWindowSelectionOverlay()
+        }
+    }
+
+    private func requestWindowSelectionOverlay() {
+        Task {
+            let overlayIDs = Set(overlayWindows.map { CGWindowID($0.windowNumber) })
+            do {
+                let windows = try await ContentEnumerator.windows()
+                    .filter { !overlayIDs.contains($0.id) }
+                guard !windows.isEmpty else { return }
+                showWindowSelectionOverlay(windows: windows)
+            } catch {
+                print("Window enumeration failed: \(error)")
+            }
+        }
+    }
+
+    private func showWindowSelectionOverlay(windows: [WindowInfo]) {
+        presentSelectionOverlay(mode: .windowSelection(windows)) { [weak self] in
+            self?.showAreaSelectionOverlay()
+        }
+    }
+
+    private func presentSelectionOverlay(
+        mode: CaptureOverlayMode,
+        onSpaceToggle: @escaping () -> Void
+    ) {
         dismissOverlay()
 
         for screen in NSScreen.screens {
@@ -102,8 +131,8 @@ final class RecordingCoordinator {
             overlay.onCancelled = { [weak self] in
                 self?.dismissOverlay()
             }
-            // Use area mode — user can drag to select recording region
-            overlay.activate(mode: .area)
+            overlay.onSpaceToggle = onSpaceToggle
+            overlay.activate(mode: mode)
             overlayWindows.append(overlay)
         }
     }

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -196,27 +196,51 @@ final class RecordingCoordinator {
     }
 
     private func handleWindowSelected(windowID: CGWindowID) {
-        // If window selection happens, get window frame and use that
         Task {
             let windows = try? await ContentEnumerator.windows()
             guard let window = windows?.first(where: { $0.id == windowID }) else { return }
 
-            let screen = NSScreen.main ?? NSScreen.screens.first!
+            // `window.frame` is CG global top-left (from ScreenCaptureKit).
+            // Pick the display containing the window's center so a window
+            // on a secondary display doesn't get attributed to primary.
+            let center = CGPoint(x: window.frame.midX, y: window.frame.midY)
+            let pickedDisplayID = displayID(containing: center) ?? CGMainDisplayID()
+            guard let screen = NSScreen.screens.first(where: { $0.displayID == pickedDisplayID })
+                    ?? NSScreen.main ?? NSScreen.screens.first else {
+                return
+            }
             selectedScreen = screen
-            selectedDisplayID = screen.displayID
-            selectedRect = window.frame
+            selectedDisplayID = pickedDisplayID
 
-            // Convert screen rect to view rect for toolbar positioning
-            let screenFrame = screen.frame
-            let viewY = screenFrame.height - window.frame.origin.y - window.frame.height
-            let viewRect = CGRect(
-                x: window.frame.origin.x,
-                y: viewY,
+            // Convert to display-local top-left — same coord system that
+            // `handleAreaSelected` produces and that every downstream
+            // consumer (border, controls, ScreenCaptureKit) expects.
+            let displayBounds = CGDisplayBounds(pickedDisplayID)
+            selectedRect = CGRect(
+                x: window.frame.origin.x - displayBounds.origin.x,
+                y: window.frame.origin.y - displayBounds.origin.y,
                 width: window.frame.width,
                 height: window.frame.height
             )
+
+            let screenFrame = screen.frame
+            let viewY = screenFrame.height - selectedRect.origin.y - selectedRect.height
+            let viewRect = CGRect(
+                x: selectedRect.origin.x,
+                y: viewY,
+                width: selectedRect.width,
+                height: selectedRect.height
+            )
             showToolbar(selectionViewRect: viewRect, screen: screen)
         }
+    }
+
+    private func displayID(containing point: CGPoint) -> CGDirectDisplayID? {
+        var displays = [CGDirectDisplayID](repeating: 0, count: 16)
+        var count: UInt32 = 0
+        let err = CGGetDisplaysWithPoint(point, 16, &displays, &count)
+        guard err == .success, count > 0 else { return nil }
+        return displays[0]
     }
 
     // MARK: - Step 2: Recording Toolbar

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -231,6 +231,9 @@ final class RecordingCoordinator {
                 width: selectedRect.width,
                 height: selectedRect.height
             )
+            if settings.rememberLastRecordingArea {
+                settings.lastRecordingArea = .area(rect: viewRect, screenID: screen.displayID)
+            }
             showToolbar(selectionViewRect: viewRect, screen: screen)
         }
     }


### PR DESCRIPTION
## What changed

`RecordingCoordinator`'s class doc said the recording overlay supports
area drag OR Space to switch to window selection, but only area drag
was implemented. This PR closes that doc-vs-implementation gap.

### Changes

- Opt-in `onSpaceToggle` callback on `CaptureOverlayView` (nil by
  default, so screenshot overlays are unaffected).
- Recording wires Space to toggle between area and window selection,
  reusing the existing `ContentEnumerator.windows()` and
  `.windowSelection` overlay rendering.
- Fixes two latent bugs in `handleWindowSelected`: it always picked
  `NSScreen.main`, and assigned global top-left `window.frame`
  directly to display-local-top-left `selectedRect`. Now picks the
  right display via `CGGetDisplaysWithPoint` and converts coords.
- Window selection rect is persisted via `settings.lastRecordingArea`,
  matching area-selection behaviour.

### Known limitation

Window-selection here records the screen *area* under the chosen
window (same `RecordingConfig(captureRect:, displayID:)` path as area
mode), so other windows on top end up in the output. Proper
window-only capture (à la the screenshot flow's
`SCContentFilter(window:)`) is tracked separately in #145.

## Related issue

Closes #144. Refs #145.

## Screenshots / recordings

https://github.com/user-attachments/assets/10c8e152-0ae7-459d-9618-795b60a50f83

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [ ] Tests for any touched package pass (`swift test --package-path Packages/<Kit>`)
    - N/A: no SPM package was modified (App-only changes)
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)
