### PR TITLE
fix: record selected windows by target

### DIFF
--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -26,6 +26,7 @@ final class CaptureOverlayView: NSView {
     var onSelectionComplete: ((CGRect) -> Void)?
     var onWindowSelected: ((CGWindowID) -> Void)?
     var onCancel: (() -> Void)?
+    var onSpaceToggle: (() -> Void)?
 
     private let settings: AppSettings
     /// When true, preset features (badge, R-key, right-click menu, ratio lock) are disabled.
@@ -821,6 +822,9 @@ final class CaptureOverlayView: NSView {
     override func keyDown(with event: NSEvent) {
         if event.keyCode == 53 { // ESC
             cancelOverlay()
+        } else if event.keyCode == 49 { // Space
+            guard !isDragging, onSpaceToggle != nil else { return }
+            onSpaceToggle?()
         } else if event.keyCode == 15 { // R key
             guard case .area = mode, !isDragging, !presetsDisabled else { return }
             let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)

--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -823,8 +823,7 @@ final class CaptureOverlayView: NSView {
         if event.keyCode == 53 { // ESC
             cancelOverlay()
         } else if event.keyCode == 49 { // Space
-            guard !isDragging, onSpaceToggle != nil else { return }
-            onSpaceToggle?()
+            requestSpaceToggle()
         } else if event.keyCode == 15 { // R key
             guard case .area = mode, !isDragging, !presetsDisabled else { return }
             let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
@@ -836,6 +835,11 @@ final class CaptureOverlayView: NSView {
     override var acceptsFirstResponder: Bool { true }
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+    func requestSpaceToggle() {
+        guard !isDragging, onSpaceToggle != nil else { return }
+        onSpaceToggle?()
+    }
 
     private func cancelCurrentSelection() {
         isDragging = false

--- a/App/Sources/Capture/CaptureOverlayWindow.swift
+++ b/App/Sources/Capture/CaptureOverlayWindow.swift
@@ -8,6 +8,7 @@ final class CaptureOverlayWindow: NSPanel {
     var onAreaSelected: ((CGRect, NSScreen) -> Void)?
     var onWindowSelected: ((CGWindowID) -> Void)?
     var onCancelled: (() -> Void)?
+    var onSpaceToggle: (() -> Void)?
 
     private let settings: AppSettings
     private var overlayView: CaptureOverlayView!
@@ -49,6 +50,9 @@ final class CaptureOverlayWindow: NSPanel {
         }
         overlayView.onCancel = { [weak self] in
             self?.onCancelled?()
+        }
+        overlayView.onSpaceToggle = { [weak self] in
+            self?.onSpaceToggle?()
         }
 
         self.contentView = overlayView

--- a/App/Sources/Capture/CaptureOverlayWindow.swift
+++ b/App/Sources/Capture/CaptureOverlayWindow.swift
@@ -80,7 +80,7 @@ final class CaptureOverlayWindow: NSPanel {
 
         // Also install global ESC monitor as fallback
         // (in case the window doesn't receive key events)
-        installEscMonitor()
+        installKeyMonitor()
     }
 
     func setFrozenBackground(_ image: CGImage) {
@@ -92,30 +92,42 @@ final class CaptureOverlayWindow: NSPanel {
 
     func deactivate() {
         overlayView.restoreCursorIfNeeded()
-        removeEscMonitor()
+        removeKeyMonitor()
         orderOut(nil)
     }
 
-    private func installEscMonitor() {
-        // Global monitor: catches ESC even when another app is frontmost
+    private func installKeyMonitor() {
+        // Global monitor: catches ESC/Space even when another app is frontmost.
         globalEscMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            if event.keyCode == 53 {
+            switch event.keyCode {
+            case 53:
                 DispatchQueue.main.async {
                     self?.onCancelled?()
                 }
+            case 49:
+                DispatchQueue.main.async {
+                    self?.overlayView.requestSpaceToggle()
+                }
+            default:
+                break
             }
         }
-        // Local monitor: catches ESC when our window is key
+        // Local monitor: catches ESC/Space when our window is key.
         localEscMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            if event.keyCode == 53 {
+            switch event.keyCode {
+            case 53:
                 self?.onCancelled?()
                 return nil
+            case 49:
+                self?.overlayView.requestSpaceToggle()
+                return nil
+            default:
+                return event
             }
-            return event
         }
     }
 
-    private func removeEscMonitor() {
+    private func removeKeyMonitor() {
         if let globalEscMonitor {
             NSEvent.removeMonitor(globalEscMonitor)
             self.globalEscMonitor = nil

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -18,7 +18,7 @@ import EffectsKit
 import EditorKit
 
 /// Orchestrates recording flow:
-/// 1. Show overlay for area selection (drag or Space for window)
+/// 1. Show overlay for area selection (drag, or Space to switch to window selection)
 /// 2. Show recording toolbar (format, camera, mic, audio)
 /// 3. User clicks Record → start recording with selected area
 /// 4. Show controls (pause/stop/timer) + red border
@@ -87,6 +87,35 @@ final class RecordingCoordinator {
     // MARK: - Step 1: Area Selection
 
     private func showAreaSelectionOverlay() {
+        presentSelectionOverlay(mode: .area) { [weak self] in
+            self?.requestWindowSelectionOverlay()
+        }
+    }
+
+    private func requestWindowSelectionOverlay() {
+        Task {
+            let overlayIDs = Set(overlayWindows.map { CGWindowID($0.windowNumber) })
+            do {
+                let windows = try await ContentEnumerator.windows()
+                    .filter { !overlayIDs.contains($0.id) }
+                guard !windows.isEmpty else { return }
+                showWindowSelectionOverlay(windows: windows)
+            } catch {
+                print("Window enumeration failed: \(error)")
+            }
+        }
+    }
+
+    private func showWindowSelectionOverlay(windows: [WindowInfo]) {
+        presentSelectionOverlay(mode: .windowSelection(windows)) { [weak self] in
+            self?.showAreaSelectionOverlay()
+        }
+    }
+
+    private func presentSelectionOverlay(
+        mode: CaptureOverlayMode,
+        onSpaceToggle: @escaping () -> Void
+    ) {
         dismissOverlay()
 
         for screen in NSScreen.screens {
@@ -102,8 +131,8 @@ final class RecordingCoordinator {
             overlay.onCancelled = { [weak self] in
                 self?.dismissOverlay()
             }
-            // Use area mode — user can drag to select recording region
-            overlay.activate(mode: .area)
+            overlay.onSpaceToggle = onSpaceToggle
+            overlay.activate(mode: mode)
             overlayWindows.append(overlay)
         }
     }

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -196,27 +196,51 @@ final class RecordingCoordinator {
     }
 
     private func handleWindowSelected(windowID: CGWindowID) {
-        // If window selection happens, get window frame and use that
         Task {
             let windows = try? await ContentEnumerator.windows()
             guard let window = windows?.first(where: { $0.id == windowID }) else { return }
 
-            let screen = NSScreen.main ?? NSScreen.screens.first!
+            // `window.frame` is CG global top-left (from ScreenCaptureKit).
+            // Pick the display containing the window's center so a window
+            // on a secondary display doesn't get attributed to primary.
+            let center = CGPoint(x: window.frame.midX, y: window.frame.midY)
+            let pickedDisplayID = displayID(containing: center) ?? CGMainDisplayID()
+            guard let screen = NSScreen.screens.first(where: { $0.displayID == pickedDisplayID })
+                    ?? NSScreen.main ?? NSScreen.screens.first else {
+                return
+            }
             selectedScreen = screen
-            selectedDisplayID = screen.displayID
-            selectedRect = window.frame
+            selectedDisplayID = pickedDisplayID
 
-            // Convert screen rect to view rect for toolbar positioning
-            let screenFrame = screen.frame
-            let viewY = screenFrame.height - window.frame.origin.y - window.frame.height
-            let viewRect = CGRect(
-                x: window.frame.origin.x,
-                y: viewY,
+            // Convert to display-local top-left — same coord system that
+            // `handleAreaSelected` produces and that every downstream
+            // consumer (border, controls, ScreenCaptureKit) expects.
+            let displayBounds = CGDisplayBounds(pickedDisplayID)
+            selectedRect = CGRect(
+                x: window.frame.origin.x - displayBounds.origin.x,
+                y: window.frame.origin.y - displayBounds.origin.y,
                 width: window.frame.width,
                 height: window.frame.height
             )
+
+            let screenFrame = screen.frame
+            let viewY = screenFrame.height - selectedRect.origin.y - selectedRect.height
+            let viewRect = CGRect(
+                x: selectedRect.origin.x,
+                y: viewY,
+                width: selectedRect.width,
+                height: selectedRect.height
+            )
             showToolbar(selectionViewRect: viewRect, screen: screen)
         }
+    }
+
+    private func displayID(containing point: CGPoint) -> CGDirectDisplayID? {
+        var displays = [CGDirectDisplayID](repeating: 0, count: 16)
+        var count: UInt32 = 0
+        let err = CGGetDisplaysWithPoint(point, 16, &displays, &count)
+        guard err == .success, count > 0 else { return nil }
+        return displays[0]
     }
 
     // MARK: - Step 2: Recording Toolbar

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -53,6 +53,7 @@ final class RecordingCoordinator {
     private var selectedRect: CGRect = .zero
     private var selectedScreen: NSScreen?
     private var selectedDisplayID: CGDirectDisplayID = CGMainDisplayID()
+    private var selectedTarget: RecordingTarget?
 
     // Current recording inputs (used by restart)
     private var currentRecordingFormat: RecordingFormatChoice?
@@ -130,6 +131,7 @@ final class RecordingCoordinator {
             }
             overlay.onCancelled = { [weak self] in
                 self?.dismissOverlay()
+                self?.selectedTarget = nil
             }
             overlay.onSpaceToggle = onSpaceToggle
             overlay.activate(mode: mode)
@@ -190,6 +192,7 @@ final class RecordingCoordinator {
             width: rect.width,
             height: rect.height
         )
+        selectedTarget = .displayArea(displayID: screen.displayID, rect: selectedRect)
 
         // Show the recording toolbar below the selected area
         showToolbar(selectionViewRect: rect, screen: screen)
@@ -200,28 +203,22 @@ final class RecordingCoordinator {
             let windows = try? await ContentEnumerator.windows()
             guard let window = windows?.first(where: { $0.id == windowID }) else { return }
 
-            // `window.frame` is CG global top-left (from ScreenCaptureKit).
-            // Pick the display containing the window's center so a window
-            // on a secondary display doesn't get attributed to primary.
-            let center = CGPoint(x: window.frame.midX, y: window.frame.midY)
-            let pickedDisplayID = displayID(containing: center) ?? CGMainDisplayID()
-            guard let screen = NSScreen.screens.first(where: { $0.displayID == pickedDisplayID })
+            guard let screen = screenWithLargestIntersection(forGlobalTopLeftRect: window.frame)
                     ?? NSScreen.main ?? NSScreen.screens.first else {
                 return
             }
+            let pickedDisplayID = screen.displayID
             selectedScreen = screen
             selectedDisplayID = pickedDisplayID
 
-            // Convert to display-local top-left — same coord system that
-            // `handleAreaSelected` produces and that every downstream
-            // consumer (border, controls, ScreenCaptureKit) expects.
             let displayBounds = CGDisplayBounds(pickedDisplayID)
-            selectedRect = CGRect(
-                x: window.frame.origin.x - displayBounds.origin.x,
-                y: window.frame.origin.y - displayBounds.origin.y,
-                width: window.frame.width,
-                height: window.frame.height
+            let displayLocalRect = CaptureDisplayGeometry.displayLocalRect(
+                fromGlobalTopLeftRect: window.frame,
+                displayBounds: displayBounds
             )
+            guard !displayLocalRect.isNull, !displayLocalRect.isEmpty else { return }
+            selectedRect = displayLocalRect
+            selectedTarget = .window(windowID: windowID)
 
             let screenFrame = screen.frame
             let viewY = screenFrame.height - selectedRect.origin.y - selectedRect.height
@@ -231,19 +228,17 @@ final class RecordingCoordinator {
                 width: selectedRect.width,
                 height: selectedRect.height
             )
-            if settings.rememberLastRecordingArea {
-                settings.lastRecordingArea = .area(rect: viewRect, screenID: screen.displayID)
-            }
             showToolbar(selectionViewRect: viewRect, screen: screen)
         }
     }
 
-    private func displayID(containing point: CGPoint) -> CGDirectDisplayID? {
-        var displays = [CGDirectDisplayID](repeating: 0, count: 16)
-        var count: UInt32 = 0
-        let err = CGGetDisplaysWithPoint(point, 16, &displays, &count)
-        guard err == .success, count > 0 else { return nil }
-        return displays[0]
+    private func screenWithLargestIntersection(forGlobalTopLeftRect rect: CGRect) -> NSScreen? {
+        let screensByVisibleArea = NSScreen.screens.compactMap { screen -> (screen: NSScreen, area: CGFloat)? in
+            let intersection = rect.intersection(CGDisplayBounds(screen.displayID))
+            guard !intersection.isNull, !intersection.isEmpty else { return nil }
+            return (screen, intersection.width * intersection.height)
+        }
+        return screensByVisibleArea.max { $0.area < $1.area }?.screen
     }
 
     // MARK: - Step 2: Recording Toolbar
@@ -407,6 +402,7 @@ final class RecordingCoordinator {
         countdownWindow?.cancel()
         countdownWindow = nil
         dismissToolbarUI()
+        selectedTarget = nil
     }
 
     private func dismissToolbarUI(keepCamera: Bool = false, removeEscapeMonitors shouldRemoveEscapeMonitors: Bool = true) {
@@ -426,6 +422,36 @@ final class RecordingCoordinator {
 
     // MARK: - Step 3: Start Recording
 
+    private func makeRecordingConfig(
+        format: RecordingKit.RecordingFormat,
+        fps: Int,
+        captureSystemAudio: Bool,
+        captureMicrophone: Bool,
+        showCursor: Bool
+    ) -> RecordingConfig {
+        switch selectedTarget ?? .displayArea(displayID: selectedDisplayID, rect: selectedRect) {
+        case .displayArea(let displayID, let rect):
+            return RecordingConfig(
+                captureRect: rect,
+                displayID: displayID,
+                format: format,
+                fps: fps,
+                captureSystemAudio: captureSystemAudio,
+                captureMicrophone: captureMicrophone,
+                showCursor: showCursor
+            )
+        case .window(let windowID):
+            return RecordingConfig(
+                windowID: windowID,
+                format: format,
+                fps: fps,
+                captureSystemAudio: captureSystemAudio,
+                captureMicrophone: captureMicrophone,
+                showCursor: showCursor
+            )
+        }
+    }
+
     private func startRecording(
         format: RecordingFormatChoice,
         cameraEnabled: Bool,
@@ -440,9 +466,7 @@ final class RecordingCoordinator {
         // Editor flow renders the cursor from telemetry, so avoid baking the
         // hardware cursor into the source video in that path. The quick-preview
         // flow still keeps the native hardware cursor in the captured file.
-        let config = RecordingConfig(
-            captureRect: selectedRect,
-            displayID: selectedDisplayID,
+        let config = makeRecordingConfig(
             format: format == .gif ? .gif : .video,
             fps: 30,
             captureSystemAudio: systemAudioEnabled,
@@ -523,7 +547,8 @@ final class RecordingCoordinator {
                     openEditor(
                         tempURL: tempURL,
                         cursorTelemetryURL: cursorTelemetryURL,
-                        showsCursor: settings.showCursor
+                        showsCursor: settings.showCursor,
+                        recordingAreaSize: result.size
                     )
                 } else {
                     // Quick-preview flow: show thumbnail preview with Save/Copy/Discard
@@ -650,7 +675,12 @@ final class RecordingCoordinator {
         alert.runModal()
     }
 
-    func openEditor(tempURL: URL, cursorTelemetryURL: URL?, showsCursor: Bool) {
+    func openEditor(
+        tempURL: URL,
+        cursorTelemetryURL: URL?,
+        showsCursor: Bool,
+        recordingAreaSize: CGSize
+    ) {
         Task {
             let asset = AVURLAsset(url: tempURL)
             let duration = (try? await asset.load(.duration).seconds) ?? 0
@@ -663,10 +693,7 @@ final class RecordingCoordinator {
                 showsCursor: showsCursor,
                 videoDuration: duration,
                 videoSize: naturalSize,
-                recordingAreaSize: CGSize(
-                    width: selectedRect.width,
-                    height: selectedRect.height
-                )
+                recordingAreaSize: recordingAreaSize
             )
 
             let coordinator = EditorCoordinator(project: project)

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -231,6 +231,9 @@ final class RecordingCoordinator {
                 width: selectedRect.width,
                 height: selectedRect.height
             )
+            if settings.rememberLastRecordingArea {
+                settings.lastRecordingArea = .area(rect: viewRect, screenID: screen.displayID)
+            }
             showToolbar(selectionViewRect: viewRect, screen: screen)
         }
     }

--- a/Packages/CaptureKit/Sources/CaptureKit/CaptureDisplayGeometry.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/CaptureDisplayGeometry.swift
@@ -48,4 +48,26 @@ public enum CaptureDisplayGeometry {
             height: screenLocalRect.height * scaleY
         ).integral
     }
+
+    public static func displayLocalRect(
+        fromGlobalTopLeftRect globalRect: CGRect,
+        displayBounds: CGRect
+    ) -> CGRect {
+        guard globalRect.width > 0,
+              globalRect.height > 0,
+              displayBounds.width > 0,
+              displayBounds.height > 0 else {
+            return .null
+        }
+
+        let localRect = CGRect(
+            x: globalRect.origin.x - displayBounds.origin.x,
+            y: globalRect.origin.y - displayBounds.origin.y,
+            width: globalRect.width,
+            height: globalRect.height
+        )
+        let localBounds = CGRect(origin: .zero, size: displayBounds.size)
+        let visibleRect = localRect.intersection(localBounds)
+        return visibleRect.isNull || visibleRect.isEmpty ? .null : visibleRect
+    }
 }

--- a/Packages/CaptureKit/Tests/CaptureKitTests/CaptureDisplayGeometryTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/CaptureDisplayGeometryTests.swift
@@ -55,4 +55,24 @@ struct CaptureDisplayGeometryTests {
 
         #expect(crop.isNull)
     }
+
+    @Test("Converts global top-left window frame to display-local rect")
+    func displayLocalRectFromGlobalWindowFrame() {
+        let rect = CaptureDisplayGeometry.displayLocalRect(
+            fromGlobalTopLeftRect: CGRect(x: 1540, y: 140, width: 500, height: 320),
+            displayBounds: CGRect(x: 1440, y: 0, width: 1920, height: 1080)
+        )
+
+        #expect(rect == CGRect(x: 100, y: 140, width: 500, height: 320))
+    }
+
+    @Test("Clamps display-local window frame to visible display area")
+    func displayLocalRectClampsPartiallyOffscreenWindow() {
+        let rect = CaptureDisplayGeometry.displayLocalRect(
+            fromGlobalTopLeftRect: CGRect(x: -20, y: 10, width: 100, height: 80),
+            displayBounds: CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        )
+
+        #expect(rect == CGRect(x: 0, y: 10, width: 80, height: 80))
+    }
 }

--- a/Packages/RecordingKit/Sources/RecordingKit/RecordingState.swift
+++ b/Packages/RecordingKit/Sources/RecordingKit/RecordingState.swift
@@ -19,9 +19,13 @@ public enum RecordingFormat: String, Sendable {
     case gif
 }
 
+public enum RecordingTarget: Sendable, Equatable {
+    case displayArea(displayID: CGDirectDisplayID, rect: CGRect)
+    case window(windowID: CGWindowID)
+}
+
 public struct RecordingConfig: Sendable {
-    public let captureRect: CGRect
-    public let displayID: CGDirectDisplayID
+    public let target: RecordingTarget
     public var format: RecordingFormat
     public var fps: Int
     public var captureSystemAudio: Bool
@@ -37,8 +41,23 @@ public struct RecordingConfig: Sendable {
         captureMicrophone: Bool = false,
         showCursor: Bool = true
     ) {
-        self.captureRect = captureRect
-        self.displayID = displayID
+        self.target = .displayArea(displayID: displayID, rect: captureRect)
+        self.format = format
+        self.fps = fps
+        self.captureSystemAudio = captureSystemAudio
+        self.captureMicrophone = captureMicrophone
+        self.showCursor = showCursor
+    }
+
+    public init(
+        windowID: CGWindowID,
+        format: RecordingFormat = .video,
+        fps: Int = 30,
+        captureSystemAudio: Bool = true,
+        captureMicrophone: Bool = false,
+        showCursor: Bool = true
+    ) {
+        self.target = .window(windowID: windowID)
         self.format = format
         self.fps = fps
         self.captureSystemAudio = captureSystemAudio

--- a/Packages/RecordingKit/Sources/RecordingKit/ScreenRecorder.swift
+++ b/Packages/RecordingKit/Sources/RecordingKit/ScreenRecorder.swift
@@ -20,6 +20,7 @@ func capsoLog(_ msg: String) {
 public enum RecordingError: Error, LocalizedError {
     case noMatchingDisplay, writerSetupFailed(String), writerFailedToStart
     case writerFailed(Error?), notRecording, alreadyRecording, cancelled, noFramesCaptured
+    case windowNotFound(CGWindowID)
 
     public var errorDescription: String? {
         switch self {
@@ -31,6 +32,7 @@ public enum RecordingError: Error, LocalizedError {
         case .alreadyRecording: return "Already recording."
         case .cancelled: return "Cancelled."
         case .noFramesCaptured: return "No frames captured."
+        case .windowNotFound(let id): return "Window not found: \(id)."
         }
     }
 }
@@ -55,6 +57,7 @@ public final class ScreenRecorder {
     private var recordingStartTime: Date?
     private var outputFileURL: URL?
     private var recordingConfig: RecordingConfig?
+    private var recordingSourceSize: CGSize?
 
     public init() {}
 
@@ -62,7 +65,7 @@ public final class ScreenRecorder {
         config: RecordingConfig,
         excludeWindowIDs: [CGWindowID] = []
     ) async throws {
-        capsoLog("startRecording rect=\(config.captureRect) display=\(config.displayID)")
+        capsoLog("startRecording target=\(config.target)")
         guard state == .idle else { throw RecordingError.alreadyRecording }
 
         state = .preparing
@@ -76,13 +79,14 @@ public final class ScreenRecorder {
             outputFileURL = fileURL
 
             // Set up SCStream first (creates the dispatch queue)
-            let dims = try await setupStream(config: config, excludeWindowIDs: excludeWindowIDs)
+            let streamSetup = try await setupStream(config: config, excludeWindowIDs: excludeWindowIDs)
+            recordingSourceSize = streamSetup.sourceSize
 
             // Create writer ON the recording dispatch queue (thread affinity —
             // AVAssetWriter's AAC encoder must be created and used on same thread)
             let wr = writer
             let cfg = config
-            let w = dims.w; let h = dims.h; let url = fileURL
+            let w = streamSetup.dimensions.w; let h = streamSetup.dimensions.h; let url = fileURL
             try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
                 self.recordingQueue!.async {
                     do {
@@ -138,8 +142,12 @@ public final class ScreenRecorder {
             cleanup(); state = .idle; throw RecordingError.notRecording
         }
 
-        let result = RecordingResult(fileURL: url, duration: elapsedTime,
-                                     format: cfg.format, size: cfg.captureRect.size)
+        let result = RecordingResult(
+            fileURL: url,
+            duration: elapsedTime,
+            format: cfg.format,
+            size: recordingSourceSize ?? .zero
+        )
         capsoLog("Done: \(url.lastPathComponent) \(elapsedTime)s")
         cleanup(); state = .idle
         return result
@@ -147,45 +155,22 @@ public final class ScreenRecorder {
 
     // MARK: - SCStream
 
-    private func setupStream(config: RecordingConfig, excludeWindowIDs: [CGWindowID]) async throws -> RecordingVideoDimensions {
+    private func setupStream(config: RecordingConfig, excludeWindowIDs: [CGWindowID]) async throws -> RecordingStreamSetup {
         let excludeSet = Set(excludeWindowIDs)
         let content = try await shareableContent(excludingWindowIDs: excludeSet)
-        guard let display = content.displays.first(where: { $0.displayID == config.displayID }) else {
-            throw RecordingError.noMatchingDisplay
-        }
-
-        // Two layers of window exclusion:
-        // 1. Per-window `sharingType = .none` on RecordingBorderWindow,
-        //    RecordingControlsWindow, CountdownWindow, ClickHighlightWindow
-        //    — macOS 14.2+ hides them from ScreenCaptureKit entirely (belt).
-        // 2. `SCContentFilter(excludingWindows:)` below — works on older
-        //    macOS and handles arbitrary window IDs the caller wants
-        //    excluded that aren't covered by (1) (suspenders).
-        // `sharingType = .none` windows won't appear in `content.windows`,
-        // so they'll be silently skipped by the filter build; the
-        // "Proceeding without excluding" log below is only meaningful for
-        // windows that don't use sharingType.
-        let excludedWindows = excludeSet.isEmpty
-            ? []
-            : content.windows.filter { excludeSet.contains($0.windowID) }
-        if !excludeSet.isEmpty, excludedWindows.count != excludeSet.count {
-            let missingIDs = excludeSet.subtracting(excludedWindows.map(\.windowID))
-            capsoLog("Proceeding without excluding windows: \(missingIDs)")
-        }
-        let filter = SCContentFilter(display: display, excludingWindows: excludedWindows)
-        let dims = RecordingVideoGeometry.dimensions(
-            for: config.captureRect,
-            pointPixelScale: CGFloat(filter.pointPixelScale)
-        )
+        let target = try makeStreamTarget(for: config.target, content: content, excludeSet: excludeSet)
         let sc = SCStreamConfiguration()
 
-        sc.width = dims.w
-        sc.height = dims.h
-        sc.sourceRect = config.captureRect
+        sc.width = target.dimensions.w
+        sc.height = target.dimensions.h
+        if let sourceRect = target.sourceRect {
+            sc.sourceRect = sourceRect
+        }
         sc.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(config.fps))
         sc.showsCursor = config.showCursor
         sc.queueDepth = 5
         sc.pixelFormat = kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange  // NV12
+        sc.ignoreShadowsSingleWindow = true
 
         if config.captureSystemAudio {
             sc.capturesAudio = true
@@ -197,10 +182,10 @@ public final class ScreenRecorder {
             sc.captureMicrophone = true
         }
 
-        capsoLog("Stream: \(dims.w)x\(dims.h) NV12")
+        capsoLog("Stream: \(target.dimensions.w)x\(target.dimensions.h) NV12")
 
         let output = StreamOutput()
-        let captureStream = SCStream(filter: filter, configuration: sc, delegate: output)
+        let captureStream = SCStream(filter: target.filter, configuration: sc, delegate: output)
 
         let wr = writer
         output.onVideo = { buf in wr.appendVideo(buf) }
@@ -218,7 +203,60 @@ public final class ScreenRecorder {
         }
 
         self.stream = captureStream; self.streamOutput = output
-        return dims
+        return RecordingStreamSetup(dimensions: target.dimensions, sourceSize: target.sourceSize)
+    }
+
+    private func makeStreamTarget(
+        for target: RecordingTarget,
+        content: SCShareableContent,
+        excludeSet: Set<CGWindowID>
+    ) throws -> RecordingResolvedTarget {
+        switch target {
+        case .displayArea(let displayID, let rect):
+            guard let display = content.displays.first(where: { $0.displayID == displayID }) else {
+                throw RecordingError.noMatchingDisplay
+            }
+
+            // Two layers of window exclusion:
+            // 1. Per-window `sharingType = .none` on Capso's recording chrome.
+            // 2. `SCContentFilter(excludingWindows:)` for OS versions or
+            //    windows not covered by sharingType.
+            let excludedWindows = excludeSet.isEmpty
+                ? []
+                : content.windows.filter { excludeSet.contains($0.windowID) }
+            if !excludeSet.isEmpty, excludedWindows.count != excludeSet.count {
+                let missingIDs = excludeSet.subtracting(excludedWindows.map(\.windowID))
+                capsoLog("Proceeding without excluding windows: \(missingIDs)")
+            }
+            let filter = SCContentFilter(display: display, excludingWindows: excludedWindows)
+            let dimensions = RecordingVideoGeometry.dimensions(
+                for: rect,
+                pointPixelScale: CGFloat(filter.pointPixelScale)
+            )
+            return RecordingResolvedTarget(
+                filter: filter,
+                sourceRect: rect,
+                dimensions: dimensions,
+                sourceSize: rect.size
+            )
+
+        case .window(let windowID):
+            guard let window = content.windows.first(where: { $0.windowID == windowID }) else {
+                throw RecordingError.windowNotFound(windowID)
+            }
+            let filter = SCContentFilter(desktopIndependentWindow: window)
+            let sourceSize = filter.contentRect.size
+            let dimensions = RecordingVideoGeometry.dimensions(
+                for: CGRect(origin: .zero, size: sourceSize),
+                pointPixelScale: CGFloat(filter.pointPixelScale)
+            )
+            return RecordingResolvedTarget(
+                filter: filter,
+                sourceRect: nil,
+                dimensions: dimensions,
+                sourceSize: sourceSize
+            )
+        }
     }
 
     private func shareableContent(excludingWindowIDs excludeSet: Set<CGWindowID>) async throws -> SCShareableContent {
@@ -263,9 +301,21 @@ public final class ScreenRecorder {
     }
 
     private func cleanup() {
-        stream = nil; streamOutput = nil; recordingConfig = nil; recordingQueue = nil
+        stream = nil; streamOutput = nil; recordingConfig = nil; recordingQueue = nil; recordingSourceSize = nil
         writer.reset(); stopElapsedTimer()
     }
+}
+
+private struct RecordingStreamSetup: Sendable {
+    let dimensions: RecordingVideoDimensions
+    let sourceSize: CGSize
+}
+
+private struct RecordingResolvedTarget {
+    let filter: SCContentFilter
+    let sourceRect: CGRect?
+    let dimensions: RecordingVideoDimensions
+    let sourceSize: CGSize
 }
 
 struct RecordingVideoDimensions: Sendable, Equatable {

--- a/Packages/RecordingKit/Tests/RecordingKitTests/RecordingStateTests.swift
+++ b/Packages/RecordingKit/Tests/RecordingKitTests/RecordingStateTests.swift
@@ -28,13 +28,22 @@ struct RecordingStateTests {
 
     @Test("RecordingConfig defaults")
     func configDefaults() {
-        let config = RecordingConfig(
-            captureRect: CGRect(x: 0, y: 0, width: 1920, height: 1080),
-            displayID: 1
-        )
+        let rect = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+        let config = RecordingConfig(captureRect: rect, displayID: 1)
+        #expect(config.target == .displayArea(displayID: 1, rect: rect))
         #expect(config.format == .video)
         #expect(config.fps == 30)
         #expect(config.captureSystemAudio == true)
+        #expect(config.captureMicrophone == false)
+        #expect(config.showCursor == true)
+    }
+
+    @Test("RecordingConfig can target a window")
+    func configWindowTarget() {
+        let config = RecordingConfig(windowID: 42, captureSystemAudio: false)
+
+        #expect(config.target == .window(windowID: 42))
+        #expect(config.captureSystemAudio == false)
         #expect(config.captureMicrophone == false)
         #expect(config.showCursor == true)
     }


### PR DESCRIPTION
## Summary
- Builds on #146 by @CHU1PC to keep the Space-to-window-selection recording flow.
- Adds a real `RecordingTarget.window` path so selected-window recording uses `SCContentFilter(desktopIndependentWindow:)` instead of recording the same screen rect.
- Keeps the recording toolbar/border aligned for windows on secondary or partially offscreen displays, and avoids persisting window selections as the last area.

Closes #144.
Closes #145.

## Test Plan
- [x] `swift test --package-path Packages/RecordingKit`
- [x] `swift test --package-path Packages/CaptureKit`
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build`
- [x] Smoke-tested the recording overlay locally: Record Screen -> Space -> window highlight -> window click shows recording toolbar.
