### PR TITLE
fix: align redaction source sampling

### DIFF
--- a/Packages/AnnotationKit/Sources/AnnotationKit/Objects/PixelateObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/Objects/PixelateObject.swift
@@ -62,47 +62,48 @@ public final class PixelateObject: AnnotationObject, @unchecked Sendable {
             return
         }
 
-        let imgH = CGFloat(sourceImage.height)
-
-        // CGImage.cropping uses bottom-left origin — flip Y
+        // Redaction bounds already use source-image pixel coordinates with a top-left origin.
         let cropRect = CGRect(
             x: rect.origin.x,
-            y: imgH - rect.origin.y - rect.height,
+            y: rect.origin.y,
             width: rect.width,
             height: rect.height
-        ).intersection(CGRect(x: 0, y: 0, width: CGFloat(sourceImage.width), height: imgH))
+        ).intersection(CGRect(
+            x: 0,
+            y: 0,
+            width: CGFloat(sourceImage.width),
+            height: CGFloat(sourceImage.height)
+        ))
 
-        guard !cropRect.isEmpty, let cropped = sourceImage.cropping(to: cropRect) else { return }
+        guard !cropRect.isEmpty,
+              let cropped = sourceImage.cropping(to: cropRect),
+              let redacted = Self.makeRedactedImage(from: cropped, blockSize: blockSize, mode: mode)
+        else { return }
 
-        let redacted: CGImage?
+        draw(redacted, in: cropRect, context: ctx)
+    }
 
+    private static func makeRedactedImage(
+        from image: CGImage,
+        blockSize: CGFloat,
+        mode: RedactionMode
+    ) -> CGImage? {
         switch mode {
         case .pixelate:
-            redacted = Self.makePixelatedImage(from: cropped, blockSize: blockSize)
+            makePixelatedImage(from: image, blockSize: blockSize)
         case .blur:
-            let ciImage = CIImage(cgImage: cropped)
-            let filter = CIFilter(name: "CIGaussianBlur")
-            filter?.setValue(ciImage.clampedToExtent(), forKey: kCIInputImageKey)
-            filter?.setValue(max(4, blockSize * 0.9), forKey: kCIInputRadiusKey)
-            if let outputImage = filter?.outputImage?.cropped(to: ciImage.extent) {
-                redacted = CIContext().createCGImage(outputImage, from: ciImage.extent)
-            } else {
-                redacted = nil
-            }
+            makeBlurredImage(from: image, radius: max(4, blockSize * 0.9))
         case .solid:
-            redacted = nil
+            nil
         }
+    }
 
-        guard let redacted else { return }
-
-        // Draw pixelated result — flip for CGContext.draw in flipped coordinate system
+    private func draw(_ image: CGImage, in rect: CGRect, context ctx: CGContext) {
         ctx.saveGState()
-        if mode == .pixelate {
-            ctx.interpolationQuality = .none
-        }
-        ctx.translateBy(x: rect.origin.x, y: rect.origin.y + rect.height)
+        ctx.interpolationQuality = mode == .pixelate ? .none : .high
+        ctx.translateBy(x: rect.minX, y: rect.maxY)
         ctx.scaleBy(x: 1, y: -1)
-        ctx.draw(redacted, in: CGRect(origin: .zero, size: rect.size))
+        ctx.draw(image, in: CGRect(origin: .zero, size: rect.size))
         ctx.restoreGState()
     }
 
@@ -153,6 +154,15 @@ public final class PixelateObject: AnnotationObject, @unchecked Sendable {
         outputContext.interpolationQuality = .none
         outputContext.draw(chunky, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
         return outputContext.makeImage()
+    }
+
+    private static func makeBlurredImage(from image: CGImage, radius: CGFloat) -> CGImage? {
+        let ciImage = CIImage(cgImage: image)
+        let filter = CIFilter(name: "CIGaussianBlur")
+        filter?.setValue(ciImage.clampedToExtent(), forKey: kCIInputImageKey)
+        filter?.setValue(radius, forKey: kCIInputRadiusKey)
+        guard let outputImage = filter?.outputImage?.cropped(to: ciImage.extent) else { return nil }
+        return CIContext().createCGImage(outputImage, from: ciImage.extent)
     }
 
     public func move(by delta: CGSize) {

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/RedactionObjectTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/RedactionObjectTests.swift
@@ -70,6 +70,56 @@ struct RedactionObjectTests {
         #expect(sampleRGBA(rendered, x: 1, y: 8) == sampleRGBA(rendered, x: 6, y: 8))
         #expect(sampleRGBA(rendered, x: 1, y: 8) != sampleRGBA(rendered, x: 10, y: 8))
     }
+
+    @Test("Pixelate samples the selected top-left source region")
+    func pixelateSamplesSelectedTopLeftSourceRegion() throws {
+        let source = try makeQuadrantImage(width: 16, height: 16)
+        let redaction = PixelateObject(
+            rect: CGRect(x: 0, y: 0, width: 8, height: 8),
+            blockSize: 4,
+            mode: .pixelate
+        )
+
+        let rendered = try #require(AnnotationRenderer.render(sourceImage: source, objects: [redaction]))
+        let sampled = sampleRGBA(rendered, x: 3, y: 3)
+
+        #expect(sampled.r > 200)
+        #expect(sampled.b < 80)
+    }
+
+    @Test("Pixelate samples the selected top-right source region")
+    func pixelateSamplesSelectedTopRightSourceRegion() throws {
+        let source = try makeQuadrantImage(width: 16, height: 16)
+        let redaction = PixelateObject(
+            rect: CGRect(x: 8, y: 0, width: 8, height: 8),
+            blockSize: 4,
+            mode: .pixelate
+        )
+
+        let rendered = try #require(AnnotationRenderer.render(sourceImage: source, objects: [redaction]))
+        let sampled = sampleRGBA(rendered, x: 11, y: 3)
+
+        #expect(sampled.g > 180)
+        #expect(sampled.r < 100)
+        #expect(sampled.b < 100)
+    }
+
+    @Test("Pixelate draws inside the selected region in a flipped scaled canvas")
+    func pixelateDrawsInsideSelectedRegionInFlippedScaledCanvas() throws {
+        let source = try makeQuadrantImage(width: 16, height: 16)
+        let redaction = PixelateObject(
+            rect: CGRect(x: 8, y: 0, width: 8, height: 8),
+            blockSize: 4,
+            mode: .pixelate
+        )
+
+        let rendered = try #require(renderFlippedCanvas(source: source, objects: [redaction], zoomScale: 2))
+        let sampled = sampleRGBA(rendered, x: 22, y: 6)
+
+        #expect(sampled.g > 180)
+        #expect(sampled.r < 100)
+        #expect(sampled.b < 100)
+    }
 }
 
 private struct RGBA: Equatable {
@@ -105,6 +155,19 @@ private func makeHorizontalGradientImage(width: Int, height: Int) throws -> CGIm
     return try #require(context.makeImage())
 }
 
+private func makeQuadrantImage(width: Int, height: Int) throws -> CGImage {
+    let context = try #require(makeBitmapContext(width: width, height: height))
+    context.setFillColor(CGColor(red: 0, green: 0, blue: 1, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: width / 2, height: height / 2))
+    context.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: 1))
+    context.fill(CGRect(x: width / 2, y: 0, width: width / 2, height: height / 2))
+    context.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 1))
+    context.fill(CGRect(x: 0, y: height / 2, width: width / 2, height: height / 2))
+    context.setFillColor(CGColor(red: 0, green: 1, blue: 0, alpha: 1))
+    context.fill(CGRect(x: width / 2, y: height / 2, width: width / 2, height: height / 2))
+    return try #require(context.makeImage())
+}
+
 private func makeBitmapContext(width: Int, height: Int) -> CGContext? {
     CGContext(
         data: nil,
@@ -115,6 +178,40 @@ private func makeBitmapContext(width: Int, height: Int) -> CGContext? {
         space: CGColorSpaceCreateDeviceRGB(),
         bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
     )
+}
+
+private func renderFlippedCanvas(
+    source: CGImage,
+    objects: [any AnnotationObject],
+    zoomScale: CGFloat
+) -> CGImage? {
+    let width = Int(CGFloat(source.width) * zoomScale)
+    let height = Int(CGFloat(source.height) * zoomScale)
+    guard let context = makeBitmapContext(width: width, height: height) else { return nil }
+
+    context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+    context.translateBy(x: 0, y: CGFloat(height))
+    context.scaleBy(x: 1, y: -1)
+    context.scaleBy(x: zoomScale, y: zoomScale)
+
+    let imageRect = CGRect(x: 0, y: 0, width: source.width, height: source.height)
+    context.saveGState()
+    context.translateBy(x: 0, y: CGFloat(source.height))
+    context.scaleBy(x: 1, y: -1)
+    context.draw(source, in: imageRect)
+    context.restoreGState()
+
+    for object in objects {
+        if let pixelate = object as? PixelateObject {
+            pixelate.renderWithSource(in: context, sourceImage: source)
+        } else {
+            object.render(in: context)
+        }
+    }
+
+    return context.makeImage()
 }
 
 private func sampleRGBA(_ image: CGImage, x: Int, y: Int) -> RGBA {


### PR DESCRIPTION
## Summary

- Fix pixelate/blur redaction source sampling so the sampled content stays aligned with the selected region
- Rewrite the redaction subimage paste-back path to use a local CoreGraphics transform instead of mixing AppKit flipped drawing state
- Add regression coverage for top-left/top-right redaction sampling and scaled flipped canvas rendering

Fixes #150

## Root cause

Redaction objects store bounds in source-image coordinates with a top-left origin, but the previous pixelate/blur path mixed source cropping, flipped CGContext drawing, and AppKit image drawing state. In the annotation editor this could make the selected mosaic frame render content from a different vertical position, especially visible when resizing the mosaic region.

## Testing

- `swift test --package-path Packages/AnnotationKit`
- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug -destination 'platform=macOS,arch=arm64' build`
- `git diff --check`

## Manual check

I verified locally that drawing and resizing a pixelate region now keeps the mosaic content inside the selected frame instead of appearing lower in the box.
