### PR TITLE
feat: add screenshot filename templates

### DIFF
--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -1197,7 +1197,12 @@ final class CaptureCoordinator {
             image: result.image,
             anchorScreen: screen,
             onSave: { [weak self] (rendered: CGImage) in
-                self?.saveRenderedImage(rendered, sourceAppName: result.appName, date: result.timestamp)
+                self?.saveRenderedImage(
+                    rendered,
+                    sourceAppName: result.appName,
+                    sourceWindowTitle: result.windowName,
+                    date: result.timestamp
+                )
                 self?.annotationWindow = nil
             },
             onCopy: { [weak self] (rendered: CGImage) in
@@ -1205,7 +1210,13 @@ final class CaptureCoordinator {
                 self?.annotationWindow = nil
             },
             onPin: { [weak self] (rendered: CGImage, anchor: CGRect?) in
-                self?.pinRenderedImage(rendered, anchor: anchor, sourceAppName: result.appName, date: result.timestamp)
+                self?.pinRenderedImage(
+                    rendered,
+                    anchor: anchor,
+                    sourceAppName: result.appName,
+                    sourceWindowTitle: result.windowName,
+                    date: result.timestamp
+                )
                 self?.annotationWindow = nil
             },
             onClose: { [weak self] in
@@ -1247,7 +1258,12 @@ final class CaptureCoordinator {
             screen: screen,
             screenLocalRect: screenLocalRect,
             onSave: { [weak self] rendered in
-                self?.saveRenderedImage(rendered, sourceAppName: result.appName, date: result.timestamp)
+                self?.saveRenderedImage(
+                    rendered,
+                    sourceAppName: result.appName,
+                    sourceWindowTitle: result.windowName,
+                    date: result.timestamp
+                )
                 self?.inlineAnnotationWindow = nil
             },
             onCopy: { [weak self] rendered in
@@ -1255,7 +1271,13 @@ final class CaptureCoordinator {
                 self?.inlineAnnotationWindow = nil
             },
             onPin: { [weak self] rendered, anchor in
-                self?.pinRenderedImage(rendered, anchor: anchor, sourceAppName: result.appName, date: result.timestamp)
+                self?.pinRenderedImage(
+                    rendered,
+                    anchor: anchor,
+                    sourceAppName: result.appName,
+                    sourceWindowTitle: result.windowName,
+                    date: result.timestamp
+                )
                 self?.inlineAnnotationWindow = nil
             },
             onClose: { [weak self] in
@@ -1316,13 +1338,20 @@ final class CaptureCoordinator {
     }
 
     private func pinToScreen(_ result: CaptureResult, anchor: CGRect) {
-        pinRenderedImage(result.image, anchor: anchor, sourceAppName: result.appName, date: result.timestamp)
+        pinRenderedImage(
+            result.image,
+            anchor: anchor,
+            sourceAppName: result.appName,
+            sourceWindowTitle: result.windowName,
+            date: result.timestamp
+        )
     }
 
     private func pinRenderedImage(
         _ image: CGImage,
         anchor: CGRect?,
         sourceAppName: String? = nil,
+        sourceWindowTitle: String? = nil,
         date: Date = Date()
     ) {
         let controller = PinnedScreenshotController(
@@ -1332,7 +1361,12 @@ final class CaptureCoordinator {
                 self?.copyImageToClipboard(image)
             },
             onSave: { [weak self] in
-                self?.saveImageToFile(image, sourceAppName: sourceAppName, date: date)
+                self?.saveImageToFile(
+                    image,
+                    sourceAppName: sourceAppName,
+                    sourceWindowTitle: sourceWindowTitle,
+                    date: date
+                )
             },
             onDidClose: { [weak self] controllerID in
                 self?.pinnedControllers.removeAll { $0.id == controllerID }
@@ -1350,10 +1384,20 @@ final class CaptureCoordinator {
     }
 
     private func saveImageToFile(_ result: CaptureResult) {
-        saveImageToFile(result.image, sourceAppName: result.appName, date: result.timestamp)
+        saveImageToFile(
+            result.image,
+            sourceAppName: result.appName,
+            sourceWindowTitle: result.windowName,
+            date: result.timestamp
+        )
     }
 
-    private func saveImageToFile(_ image: CGImage, sourceAppName: String? = nil, date: Date = Date()) {
+    private func saveImageToFile(
+        _ image: CGImage,
+        sourceAppName: String? = nil,
+        sourceWindowTitle: String? = nil,
+        date: Date = Date()
+    ) {
         guard let encoded = screenshotData(from: image) else { return }
         let directory = settings.screenshotMonthlyFolders
             ? FileNaming.monthlyDirectory(in: settings.exportLocation)
@@ -1363,7 +1407,9 @@ final class CaptureCoordinator {
             type: .screenshot,
             format: encoded.format,
             date: date,
-            sourceAppName: sourceAppName
+            sourceAppName: sourceAppName,
+            sourceWindowTitle: sourceWindowTitle,
+            template: settings.screenshotFilenameTemplate
         )
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         try? encoded.data.write(to: url)
@@ -1383,8 +1429,18 @@ final class CaptureCoordinator {
         return (data, preset.fileFormat)
     }
 
-    private func saveRenderedImage(_ image: CGImage, sourceAppName: String? = nil, date: Date = Date()) {
-        saveImageToFile(image, sourceAppName: sourceAppName, date: date)
+    private func saveRenderedImage(
+        _ image: CGImage,
+        sourceAppName: String? = nil,
+        sourceWindowTitle: String? = nil,
+        date: Date = Date()
+    ) {
+        saveImageToFile(
+            image,
+            sourceAppName: sourceAppName,
+            sourceWindowTitle: sourceWindowTitle,
+            date: date
+        )
     }
 
     private func copyRenderedImage(_ image: CGImage) {

--- a/App/Sources/History/HistoryCoordinator.swift
+++ b/App/Sources/History/HistoryCoordinator.swift
@@ -357,13 +357,27 @@ final class HistoryCoordinator {
         case .recording:
             nil
         }
+        let sourceWindowTitle: String? = switch captureType {
+        case .screenshot:
+            entry.sourceWindowTitle
+        case .recording:
+            nil
+        }
+        let filenameTemplate: String? = switch captureType {
+        case .screenshot:
+            settings.screenshotFilenameTemplate
+        case .recording:
+            nil
+        }
 
         let panel = NSSavePanel()
         panel.nameFieldStringValue = FileNaming.generateFileName(
             for: captureType,
             format: fileFormat,
             date: entry.createdAt,
-            sourceAppName: sourceAppName
+            sourceAppName: sourceAppName,
+            sourceWindowTitle: sourceWindowTitle,
+            template: filenameTemplate
         )
         panel.allowedContentTypes = [fileFormat.contentType]
         panel.canCreateDirectories = true

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -15,6 +15,19 @@ final class PreferencesViewModel {
     private(set) var cameraGranted: Bool = false
     private(set) var microphoneGranted: Bool = false
 
+    private static let filenamePreviewDate: Date = {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = .current
+        components.year = 2026
+        components.month = 6
+        components.day = 7
+        components.hour = 16
+        components.minute = 11
+        components.second = 23
+        return components.date ?? Date(timeIntervalSince1970: 0)
+    }()
+
     init(settings: AppSettings, permissionManager: PermissionManager) {
         self.settings = settings
         self.permissionManager = permissionManager
@@ -417,6 +430,30 @@ final class PreferencesViewModel {
         withMutation(keyPath: \.exportLocation) {
             settings.setExportLocation(url)
         }
+    }
+    var screenshotFilenameTemplate: String {
+        get {
+            access(keyPath: \.screenshotFilenameTemplate)
+            return settings.screenshotFilenameTemplate
+        }
+        set {
+            withMutation(keyPath: \.screenshotFilenameTemplate) {
+                settings.screenshotFilenameTemplate = newValue
+            }
+        }
+    }
+    func resetScreenshotFilenameTemplate() {
+        screenshotFilenameTemplate = FileNaming.defaultScreenshotTemplate
+    }
+    var screenshotFilenamePreview: String {
+        FileNaming.generateFileName(
+            for: .screenshot,
+            format: screenshotOutputPreset.fileFormat,
+            date: Self.filenamePreviewDate,
+            sourceAppName: "Safari",
+            sourceWindowTitle: "Example Window",
+            template: screenshotFilenameTemplate
+        )
     }
 
     // MARK: OCR

--- a/App/Sources/Preferences/Tabs/ExportSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ExportSettingsView.swift
@@ -4,6 +4,8 @@ import SharedKit
 
 struct ExportSettingsView: View {
     @Bindable var viewModel: PreferencesViewModel
+    @State private var showingFilenameTokens = false
+    @State private var filenameTemplateDraft = ""
 
     private var displayedPath: String {
         viewModel.exportLocation.path.replacingOccurrences(of: NSHomeDirectory(), with: "~")
@@ -58,8 +60,60 @@ struct ExportSettingsView: View {
                             .toggleStyle(.switch)
                             .controlSize(.small)
                     }
+                    SettingRow(label: "Screenshot Filename", sublabel: "Extension is added automatically", showDivider: true) {
+                        HStack(spacing: 8) {
+                            TextField("", text: $filenameTemplateDraft)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.system(size: 12, design: .monospaced))
+                                .frame(width: 220)
+                                .onSubmit {
+                                    normalizeFilenameTemplate()
+                                }
+                            Button {
+                                showingFilenameTokens.toggle()
+                            } label: {
+                                Image(systemName: "info.circle")
+                            }
+                            .buttonStyle(.plain)
+                            .help("Show filename tokens")
+                            .popover(isPresented: $showingFilenameTokens, arrowEdge: .bottom) {
+                                filenameTokensPopover
+                            }
+                            Button("Reset") {
+                                viewModel.resetScreenshotFilenameTemplate()
+                                filenameTemplateDraft = viewModel.screenshotFilenameTemplate
+                            }
+                            .controlSize(.small)
+                        }
+                    }
+                    VStack(spacing: 0) {
+                        Divider()
+                            .background(Color.white.opacity(0.06))
+                        HStack(alignment: .firstTextBaseline, spacing: 10) {
+                            Text("Preview")
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(.tertiary)
+                            Text(viewModel.screenshotFilenamePreview)
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer()
+                        }
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                    }
                 }
             }
+        }
+        .onAppear {
+            filenameTemplateDraft = viewModel.screenshotFilenameTemplate
+        }
+        .onDisappear {
+            normalizeFilenameTemplate()
+        }
+        .onChange(of: filenameTemplateDraft) { _, newValue in
+            viewModel.screenshotFilenameTemplate = newValue
         }
     }
 
@@ -72,6 +126,40 @@ struct ExportSettingsView: View {
         panel.prompt = String(localized: "Select")
         if panel.runModal() == .OK, let url = panel.url {
             viewModel.setExportLocation(url)
+        }
+    }
+
+    private func normalizeFilenameTemplate() {
+        if filenameTemplateDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            viewModel.resetScreenshotFilenameTemplate()
+            filenameTemplateDraft = viewModel.screenshotFilenameTemplate
+        }
+    }
+
+    private var filenameTokensPopover: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Filename Tokens")
+                .font(.system(size: 13, weight: .semibold))
+            tokenRow("{date}", "2026-06-07")
+            tokenRow("{time}", "16.11.23")
+            tokenRow("{timestamp}", "2026-06-07 at 16.11.23")
+            tokenRow("{source}", " - Safari")
+            tokenRow("{app}", "Safari")
+            tokenRow("{window}", "Example Window")
+            tokenRow("{random}", "8-character random text")
+        }
+        .padding(14)
+        .frame(width: 300, alignment: .leading)
+    }
+
+    private func tokenRow(_ token: String, _ description: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Text(token)
+                .font(.system(size: 11, design: .monospaced))
+                .frame(width: 88, alignment: .leading)
+            Text(description)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
         }
     }
 }

--- a/App/Sources/Preferences/Tabs/ExportSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ExportSettingsView.swift
@@ -60,49 +60,7 @@ struct ExportSettingsView: View {
                             .toggleStyle(.switch)
                             .controlSize(.small)
                     }
-                    SettingRow(label: "Screenshot Filename", sublabel: "Extension is added automatically", showDivider: true) {
-                        HStack(spacing: 8) {
-                            TextField("", text: $filenameTemplateDraft)
-                                .textFieldStyle(.roundedBorder)
-                                .font(.system(size: 12, design: .monospaced))
-                                .frame(width: 220)
-                                .onSubmit {
-                                    normalizeFilenameTemplate()
-                                }
-                            Button {
-                                showingFilenameTokens.toggle()
-                            } label: {
-                                Image(systemName: "info.circle")
-                            }
-                            .buttonStyle(.plain)
-                            .help("Show filename tokens")
-                            .popover(isPresented: $showingFilenameTokens, arrowEdge: .bottom) {
-                                filenameTokensPopover
-                            }
-                            Button("Reset") {
-                                viewModel.resetScreenshotFilenameTemplate()
-                                filenameTemplateDraft = viewModel.screenshotFilenameTemplate
-                            }
-                            .controlSize(.small)
-                        }
-                    }
-                    VStack(spacing: 0) {
-                        Divider()
-                            .background(Color.white.opacity(0.06))
-                        HStack(alignment: .firstTextBaseline, spacing: 10) {
-                            Text("Preview")
-                                .font(.system(size: 11, weight: .medium))
-                                .foregroundStyle(.tertiary)
-                            Text(viewModel.screenshotFilenamePreview)
-                                .font(.system(size: 11))
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                            Spacer()
-                        }
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 8)
-                    }
+                    filenameTemplateEditor
                 }
             }
         }
@@ -126,6 +84,75 @@ struct ExportSettingsView: View {
         panel.prompt = String(localized: "Select")
         if panel.runModal() == .OK, let url = panel.url {
             viewModel.setExportLocation(url)
+        }
+    }
+
+    private var filenameTemplateEditor: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Divider()
+                .background(Color.white.opacity(0.06))
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .firstTextBaseline, spacing: 10) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Screenshot Filename")
+                            .font(.system(size: 13))
+                            .foregroundStyle(.primary)
+                        Text("Extension is added automatically")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.tertiary)
+                    }
+                    Spacer()
+                    Button {
+                        showingFilenameTokens.toggle()
+                    } label: {
+                        Image(systemName: "info.circle")
+                            .font(.system(size: 13, weight: .medium))
+                            .frame(width: 24, height: 24)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .contentShape(Rectangle())
+                    .help("Show available filename tokens")
+                    .popover(isPresented: $showingFilenameTokens, arrowEdge: .bottom) {
+                        filenameTokensPopover
+                    }
+                    Button {
+                        viewModel.resetScreenshotFilenameTemplate()
+                        filenameTemplateDraft = viewModel.screenshotFilenameTemplate
+                    } label: {
+                        Image(systemName: "arrow.counterclockwise")
+                            .font(.system(size: 13, weight: .medium))
+                            .frame(width: 24, height: 24)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .contentShape(Rectangle())
+                    .help("Reset to the default filename template")
+                }
+                TextField("", text: $filenameTemplateDraft)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 12, design: .monospaced))
+                    .onSubmit {
+                        normalizeFilenameTemplate()
+                    }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            Divider()
+                .background(Color.white.opacity(0.06))
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text("Preview")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.tertiary)
+                Text(viewModel.screenshotFilenamePreview)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer()
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
         }
     }
 

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -378,6 +378,16 @@ public final class AppSettings: @unchecked Sendable {
         set { defaults.set(newValue, forKey: "screenshotMonthlyFolders") }
     }
 
+    public var screenshotFilenameTemplate: String {
+        get {
+            let raw = defaults.string(forKey: "screenshotFilenameTemplate") ?? FileNaming.defaultScreenshotTemplate
+            return raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? FileNaming.defaultScreenshotTemplate
+                : raw
+        }
+        set { defaults.set(newValue, forKey: "screenshotFilenameTemplate") }
+    }
+
     public var screenshotShowsCursor: Bool {
         get { defaults.object(forKey: "screenshotShowsCursor") as? Bool ?? false }
         set { defaults.set(newValue, forKey: "screenshotShowsCursor") }

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/FileNaming.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/FileNaming.swift
@@ -48,6 +48,12 @@ public enum FileFormat: String, Sendable {
 }
 
 public enum FileNaming {
+    public static let defaultScreenshotTemplate = "Capso Screenshot{source} {timestamp}"
+    public static let defaultRecordingTemplate = "Capso Recording {timestamp}"
+
+    private static let maxBaseNameUTF8Length = 200
+    private static let randomAlphabet = Array("0123456789abcdefghijklmnopqrstuvwxyz")
+
     private static let dateFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "yyyy-MM-dd"
@@ -66,15 +72,35 @@ public enum FileNaming {
         return f
     }()
 
-    public static func generateName(for type: CaptureType, date: Date = Date(), sourceAppName: String? = nil) -> String {
-        let prefix = switch type {
-        case .screenshot: "Capso Screenshot"
-        case .recording: "Capso Recording"
+    public static func generateName(
+        for type: CaptureType,
+        date: Date = Date(),
+        sourceAppName: String? = nil,
+        sourceWindowTitle: String? = nil,
+        template: String? = nil
+    ) -> String {
+        let fallback = defaultTemplate(for: type)
+        let rawTemplate = template ?? fallback
+        let effectiveTemplate = rawTemplate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? fallback
+            : rawTemplate
+        let rendered = renderTemplate(
+            effectiveTemplate,
+            date: date,
+            sourceAppName: sourceAppName,
+            sourceWindowTitle: sourceWindowTitle
+        )
+        let sanitized = sanitizeRenderedBaseName(rendered)
+        if sanitized.isEmpty && effectiveTemplate != fallback {
+            return generateName(
+                for: type,
+                date: date,
+                sourceAppName: sourceAppName,
+                sourceWindowTitle: sourceWindowTitle,
+                template: fallback
+            )
         }
-        let source = sanitizedSourceAppName(sourceAppName).map { " - \($0)" } ?? ""
-        let dateString = dateFormatter.string(from: date)
-        let timeString = timeFormatter.string(from: date)
-        return "\(prefix)\(source) \(dateString) at \(timeString)"
+        return sanitized.isEmpty ? fallbackBaseName(for: type) : sanitized
     }
 
     public static func fileExtension(for format: FileFormat) -> String {
@@ -85,9 +111,11 @@ public enum FileNaming {
         for type: CaptureType,
         format: FileFormat,
         date: Date = Date(),
-        sourceAppName: String? = nil
+        sourceAppName: String? = nil,
+        sourceWindowTitle: String? = nil,
+        template: String? = nil
     ) -> String {
-        "\(generateName(for: type, date: date, sourceAppName: sourceAppName)).\(fileExtension(for: format))"
+        "\(generateName(for: type, date: date, sourceAppName: sourceAppName, sourceWindowTitle: sourceWindowTitle, template: template)).\(fileExtension(for: format))"
     }
 
     public static func generateFileURL(
@@ -95,10 +123,19 @@ public enum FileNaming {
         type: CaptureType,
         format: FileFormat,
         date: Date = Date(),
-        sourceAppName: String? = nil
+        sourceAppName: String? = nil,
+        sourceWindowTitle: String? = nil,
+        template: String? = nil
     ) -> URL {
         directory.appendingPathComponent(
-            generateFileName(for: type, format: format, date: date, sourceAppName: sourceAppName)
+            generateFileName(
+                for: type,
+                format: format,
+                date: date,
+                sourceAppName: sourceAppName,
+                sourceWindowTitle: sourceWindowTitle,
+                template: template
+            )
         )
     }
 
@@ -106,16 +143,109 @@ public enum FileNaming {
         baseDirectory.appendingPathComponent(monthFormatter.string(from: date), isDirectory: true)
     }
 
-    private static func sanitizedSourceAppName(_ name: String?) -> String? {
+    private static func renderTemplate(
+        _ template: String,
+        date: Date,
+        sourceAppName: String?,
+        sourceWindowTitle: String?
+    ) -> String {
+        let app = sanitizedTokenValue(sourceAppName) ?? ""
+        let window = sanitizedTokenValue(sourceWindowTitle) ?? ""
+        let dateString = dateFormatter.string(from: date)
+        let timeString = timeFormatter.string(from: date)
+        let timestamp = "\(dateString) at \(timeString)"
+        let replacements: [String: String] = [
+            "{date}": dateString,
+            "{time}": timeString,
+            "{timestamp}": timestamp,
+            "{source}": app.isEmpty ? "" : " - \(app)",
+            "{app}": app,
+            "{window}": window,
+        ]
+
+        var output = template
+        for (token, value) in replacements {
+            output = output.replacingOccurrences(of: token, with: value)
+        }
+        while let range = output.range(of: "{random}") {
+            output.replaceSubrange(range, with: randomToken())
+        }
+        return output
+    }
+
+    private static func sanitizedTokenValue(_ name: String?) -> String? {
         guard let name else { return nil }
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
 
-        let invalidCharacters = CharacterSet(charactersIn: "/:")
-        let sanitized = trimmed
-            .components(separatedBy: invalidCharacters)
-            .joined(separator: "-")
+        let sanitized = sanitizeFilenameScalars(in: trimmed)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return sanitized.isEmpty ? nil : sanitized
+    }
+
+    private static func sanitizeRenderedBaseName(_ name: String) -> String {
+        var sanitized = sanitizeFilenameScalars(in: name)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        while sanitized.hasSuffix(".") {
+            sanitized.removeLast()
+        }
+        sanitized = sanitized.trimmingCharacters(in: .whitespacesAndNewlines)
+        return capToByteLength(sanitized, bytes: maxBaseNameUTF8Length)
+    }
+
+    private static func sanitizeFilenameScalars(in value: String) -> String {
+        var result = ""
+        result.reserveCapacity(value.count)
+        for scalar in value.unicodeScalars {
+            switch scalar {
+            case "/", ":", "\0":
+                result.append("-")
+            default:
+                if scalar.value >= 0x20 {
+                    result.unicodeScalars.append(scalar)
+                }
+            }
+        }
+        return result
+    }
+
+    private static func capToByteLength(_ value: String, bytes: Int) -> String {
+        guard value.utf8.count > bytes else { return value }
+        var result = ""
+        var usedBytes = 0
+        for scalar in value.unicodeScalars {
+            let scalarBytes = String(scalar).utf8.count
+            guard usedBytes + scalarBytes <= bytes else { break }
+            result.unicodeScalars.append(scalar)
+            usedBytes += scalarBytes
+        }
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func randomToken(length: Int = 8) -> String {
+        var result = ""
+        result.reserveCapacity(length)
+        for _ in 0..<length {
+            result.append(randomAlphabet[Int.random(in: 0..<randomAlphabet.count)])
+        }
+        return result
+    }
+
+    private static func defaultTemplate(for type: CaptureType) -> String {
+        switch type {
+        case .screenshot:
+            defaultScreenshotTemplate
+        case .recording:
+            defaultRecordingTemplate
+        }
+    }
+
+    private static func fallbackBaseName(for type: CaptureType) -> String {
+        switch type {
+        case .screenshot:
+            "Capso Screenshot"
+        case .recording:
+            "Capso Recording"
+        }
     }
 }

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -49,6 +49,29 @@ struct AppSettingsTests {
         #expect(settings.screenshotOutputPreset == .standardJPEG)
     }
 
+    @Test("Default screenshot filename template matches FileNaming default")
+    func defaultScreenshotFilenameTemplate() {
+        let suite = "test.screenshotFilenameTemplate.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+
+        #expect(settings.screenshotFilenameTemplate == FileNaming.defaultScreenshotTemplate)
+    }
+
+    @Test("Screenshot filename template persists")
+    func screenshotFilenameTemplatePersists() {
+        let suite = "test.screenshotFilenameTemplate.persist"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let first = AppSettings(defaults: defaults)
+        first.screenshotFilenameTemplate = "{date}-{time}"
+
+        let second = AppSettings(defaults: defaults)
+        #expect(second.screenshotFilenameTemplate == "{date}-{time}")
+    }
+
     @Test("Monthly screenshot folders are disabled by default")
     func defaultScreenshotMonthlyFolders() {
         let suite = "test.screenshotMonthlyFolders.default"

--- a/Packages/SharedKit/Tests/SharedKitTests/FileNamingTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/FileNamingTests.swift
@@ -5,6 +5,26 @@ import Foundation
 
 @Suite("FileNaming")
 struct FileNamingTests {
+    private func localDate(
+        year: Int = 2024,
+        month: Int = 1,
+        day: Int = 15,
+        hour: Int = 16,
+        minute: Int = 0,
+        second: Int = 0
+    ) -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = .current
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        components.second = second
+        return components.date!
+    }
+
     @Test("Default screenshot name contains 'Capso Screenshot'")
     func defaultScreenshotName() {
         let name = FileNaming.generateName(for: .screenshot)
@@ -44,6 +64,103 @@ struct FileNamingTests {
 
         #expect(fileName.hasPrefix("Capso Screenshot - Foo-Bar-Beta "))
         #expect(fileName.hasSuffix(".png"))
+    }
+
+    @Test("Custom screenshot template can omit Capso prefix")
+    func customScreenshotTemplateOmitsCapsoPrefix() {
+        let date = localDate()
+        let fileName = FileNaming.generateFileName(
+            for: .screenshot,
+            format: .png,
+            date: date,
+            template: "{date}-{time}"
+        )
+
+        #expect(fileName == "2024-01-15-16.00.00.png")
+    }
+
+    @Test("Screenshot template renders source app and window tokens")
+    func screenshotTemplateRendersSourceTokens() {
+        let date = localDate()
+        let fileName = FileNaming.generateFileName(
+            for: .screenshot,
+            format: .png,
+            date: date,
+            sourceAppName: "Foo/Bar:Beta",
+            sourceWindowTitle: "Doc/One:Draft",
+            template: "{app}-{window}-{timestamp}"
+        )
+
+        #expect(fileName == "Foo-Bar-Beta-Doc-One-Draft-2024-01-15 at 16.00.00.png")
+    }
+
+    @Test("Screenshot source token includes separator only when app exists")
+    func screenshotSourceTokenIncludesSeparatorOnlyWhenAppExists() {
+        let date = localDate()
+
+        let withApp = FileNaming.generateName(
+            for: .screenshot,
+            date: date,
+            sourceAppName: "Safari",
+            template: "Capso Screenshot{source} {timestamp}"
+        )
+        let withoutApp = FileNaming.generateName(
+            for: .screenshot,
+            date: date,
+            template: "Capso Screenshot{source} {timestamp}"
+        )
+
+        #expect(withApp == "Capso Screenshot - Safari 2024-01-15 at 16.00.00")
+        #expect(withoutApp == "Capso Screenshot 2024-01-15 at 16.00.00")
+    }
+
+    @Test("Unknown filename tokens remain visible")
+    func unknownFilenameTokensRemainVisible() {
+        let date = localDate()
+        let name = FileNaming.generateName(
+            for: .screenshot,
+            date: date,
+            template: "Shot {date} {project}"
+        )
+
+        #expect(name == "Shot 2024-01-15 {project}")
+    }
+
+    @Test("Empty filename template falls back to screenshot default")
+    func emptyFilenameTemplateFallsBackToScreenshotDefault() {
+        let date = localDate()
+        let name = FileNaming.generateName(
+            for: .screenshot,
+            date: date,
+            template: "   "
+        )
+
+        #expect(name == "Capso Screenshot 2024-01-15 at 16.00.00")
+    }
+
+    @Test("Rendered filename strips unsafe characters")
+    func renderedFilenameStripsUnsafeCharacters() {
+        let date = localDate()
+        let fileName = FileNaming.generateFileName(
+            for: .screenshot,
+            format: .png,
+            date: date,
+            sourceWindowTitle: "Doc\u{0001}/One:Draft.",
+            template: " {window}. "
+        )
+
+        #expect(fileName == "Doc-One-Draft.png")
+    }
+
+    @Test("Random filename token is lowercase base36")
+    func randomFilenameTokenIsLowercaseBase36() {
+        let name = FileNaming.generateName(
+            for: .screenshot,
+            template: "{random}"
+        )
+
+        #expect(name.count == 8)
+        #expect(name.range(of: #"^[0-9a-z]{8}$"#, options: String.CompareOptions.regularExpression) != nil)
     }
 
     @Test("File extension for PNG")

--- a/docs/superpowers/specs/2026-06-07-screenshot-filename-template-design.md
+++ b/docs/superpowers/specs/2026-06-07-screenshot-filename-template-design.md
@@ -1,0 +1,124 @@
+# Screenshot Filename Template Design
+
+## Context
+
+GitHub discussion #154 asks for screenshot filenames to be customizable. The motivating example is removing the `Capso Screenshot` prefix so screenshots can be named with only date and time.
+
+Capso currently centralizes screenshot and recording filename generation in `SharedKit` via `FileNaming`. Autosave, history Save As, and recording export already call that utility, so the feature can stay small and avoid duplicating naming logic across coordinators.
+
+Reference behavior:
+
+- `macshot` has a full template formatter with screenshot and recording templates, live settings previews, reset buttons, token help, filesystem sanitization, byte-length caps, and reuse across local saves and uploads.
+- `capcap` uses fixed timestamp-based names such as `capcap-yyMMdd-HHmmss.png` and does not expose filename templates.
+
+## Goals
+
+- Let users customize screenshot base filenames from Preferences.
+- Keep the current default filename behavior for existing users.
+- Keep extensions automatic so templates describe the base name only.
+- Centralize rendering and sanitization in `SharedKit`.
+- Show a live preview in Preferences so users can see the resulting filename before taking a screenshot.
+- Add focused unit tests for template rendering and fallback behavior.
+
+## Non-Goals
+
+- Do not add directory/path templates.
+- Do not let users include or override the file extension in the template.
+- Do not add a full date-format mini-language.
+- Do not change monthly folder behavior.
+- Do not require custom templates for recordings in v1.
+- Do not change upload naming unless a path already uses screenshot `FileNaming`.
+
+## Template Syntax
+
+Templates are plain strings with case-sensitive placeholder tokens. Unknown tokens remain visible in the rendered filename so typos are obvious.
+
+Supported v1 tokens:
+
+- `{date}`: `yyyy-MM-dd`
+- `{time}`: `HH.mm.ss`, matching Capso's current time separator
+- `{timestamp}`: `{date} at {time}`
+- `{source}`: ` - <app>` when a source app is available, otherwise blank
+- `{app}`: sanitized source app name, or blank when unavailable
+- `{window}`: sanitized source window title, or blank when unavailable
+- `{random}`: fresh 8-character lowercase base36 string
+
+Default screenshot template:
+
+```text
+Capso Screenshot{source} {timestamp}
+```
+
+The `{source}` token preserves today's default output without leaving punctuation behind when the source app is unavailable:
+
+```text
+Capso Screenshot - Safari 2026-06-07 at 16.11.23.png
+```
+
+For user-authored templates, `{app}` renders only the sanitized app name. Users can choose their own separators or use `{source}` when they want the current default-style suffix:
+
+```text
+{date}-{time}
+{app} {date} {time}
+{timestamp}-{random}
+```
+
+## Sanitization And Fallback
+
+The rendered base filename should be safe for macOS filesystems:
+
+- Replace `/`, `:`, and NUL with `-`.
+- Strip control characters.
+- Trim leading and trailing whitespace/newlines.
+- Trim trailing dots.
+- Cap the base filename to a conservative UTF-8 byte length.
+
+If the stored template is empty or renders to an empty filename, fall back to the default screenshot template. If that somehow still renders empty, use `Capso Screenshot`.
+
+The extension is appended after sanitization based on the selected screenshot format.
+
+## Preferences UI
+
+Add a filename template row to Preferences > Export, near save location and monthly folders:
+
+- Label: `Screenshot Filename`
+- Monospaced text field bound to the persisted template.
+- Small reset button restoring the default template.
+- Small info/help control showing supported tokens.
+- Live preview below the row, using a stable sample date, app, and window title.
+
+The UI should save edits as the user types and should reset blank input to the default when editing ends.
+
+## Storage
+
+Add an `AppSettings` string property for the screenshot filename template. It should return the default template if no value is stored.
+
+Do not migrate any existing setting because Capso does not currently have a legacy filename customization preference.
+
+## Application Flow
+
+Update screenshot save paths to pass `settings.screenshotFilenameTemplate` into `FileNaming`:
+
+- Auto-save after capture.
+- Save from pinned screenshot.
+- Save As from screenshot history.
+
+Keep recording filenames unchanged in v1, though the rendering API should be shaped so recording templates can reuse it later.
+
+## Tests
+
+Add `SharedKit` unit tests covering:
+
+- Existing default screenshot and recording names still pass.
+- A date/time-only template renders without the `Capso Screenshot` prefix.
+- `{app}` and `{window}` are sanitized.
+- `{source}` is blank when no source app is available and includes the default separator when one is available.
+- Unknown tokens remain visible.
+- Empty templates fall back to the default.
+- Filenames keep the requested extension.
+- `{random}` creates an 8-character lowercase base36 token.
+
+## Open Questions
+
+- Should recording templates be exposed in a follow-up? The shared rendering API can support it, but the discussion only requested screenshots.
+- Should `{timestamp}` use `yyyy-MM-dd at HH.mm.ss` for Capso compatibility or `yyyy-MM-dd_HH.mm.ss` for compact filenames? v1 chooses compatibility.


### PR DESCRIPTION
## Summary
- Add screenshot filename templates with date, time, source app/window, and random tokens.
- Expose the template in Preferences > Export with token help, reset, and live preview.
- Wire the template into screenshot autosave, pinned screenshot save, and history Save As while leaving recording names unchanged.

## Why
Discussion #154 asks for customizable screenshot filenames, especially date/time-only names without the `Capso Screenshot` prefix.

## Validation
- `swift test --package-path Packages/SharedKit`
- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build`
