### PR TITLE
fix: keep capture preset badge below notch

### DIFF
--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -29,6 +29,7 @@ final class CaptureOverlayView: NSView {
     var onSpaceToggle: (() -> Void)?
 
     private let settings: AppSettings
+    private let safeAreaTopInset: CGFloat
     /// When true, preset features (badge, R-key, right-click menu, ratio lock) are disabled.
     /// Used by OCR and Recording overlays which always use freeform selection.
     private let presetsDisabled: Bool
@@ -76,8 +77,14 @@ final class CaptureOverlayView: NSView {
 
     nonisolated(unsafe) private var presetObserver: Any?
 
-    init(frame: NSRect, settings: AppSettings, presetsDisabled: Bool = false) {
+    init(
+        frame: NSRect,
+        settings: AppSettings,
+        safeAreaTopInset: CGFloat,
+        presetsDisabled: Bool = false
+    ) {
         self.settings = settings
+        self.safeAreaTopInset = safeAreaTopInset
         // Presets are disabled when explicitly requested (OCR/Recording) or when
         // the user has turned off the feature in Settings.
         self.presetsDisabled = presetsDisabled || !settings.capturePresetsEnabled
@@ -374,7 +381,11 @@ final class CaptureOverlayView: NSView {
         let badgeHeight = textSize.height + vPadding * 2
 
         let badgeX = (bounds.width - badgeWidth) / 2
-        let badgeY = bounds.height - badgeHeight - 20   // near top of screen
+        let badgeY = CaptureDisplayGeometry.presetBadgeY(
+            viewHeight: bounds.height,
+            badgeHeight: badgeHeight,
+            safeAreaTopInset: safeAreaTopInset
+        )
 
         let bgRect = CGRect(x: badgeX, y: badgeY, width: badgeWidth, height: badgeHeight)
         let pillRadius = badgeHeight / 2

--- a/App/Sources/Capture/CaptureOverlayWindow.swift
+++ b/App/Sources/Capture/CaptureOverlayWindow.swift
@@ -40,7 +40,12 @@ final class CaptureOverlayWindow: NSPanel {
             perform(preventsActivationSel, with: NSNumber(value: true))
         }
 
-        overlayView = CaptureOverlayView(frame: NSRect(origin: .zero, size: screen.frame.size), settings: settings, presetsDisabled: presetsDisabled)
+        overlayView = CaptureOverlayView(
+            frame: NSRect(origin: .zero, size: screen.frame.size),
+            settings: settings,
+            safeAreaTopInset: screen.safeAreaInsets.top,
+            presetsDisabled: presetsDisabled
+        )
         overlayView.onSelectionComplete = { [weak self] rect in
             guard let self, let screen = self.screen else { return }
             self.onAreaSelected?(rect, screen)

--- a/Packages/CaptureKit/Sources/CaptureKit/CaptureDisplayGeometry.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/CaptureDisplayGeometry.swift
@@ -24,6 +24,15 @@ public enum CaptureDisplayGeometry {
         return min(screenRect.width / imageSize.width, screenRect.height / imageSize.height)
     }
 
+    public static func presetBadgeY(
+        viewHeight: CGFloat,
+        badgeHeight: CGFloat,
+        safeAreaTopInset: CGFloat
+    ) -> CGFloat {
+        let topMargin: CGFloat = safeAreaTopInset > 0 ? 64 : 20
+        return viewHeight - badgeHeight - safeAreaTopInset - topMargin
+    }
+
     public static func frozenImageCropRect(
         screenLocalRect: CGRect,
         screenSize: CGSize,

--- a/Packages/CaptureKit/Tests/CaptureKitTests/CaptureDisplayGeometryTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/CaptureDisplayGeometryTests.swift
@@ -26,6 +26,28 @@ struct CaptureDisplayGeometryTests {
         #expect(scale == 0.5)
     }
 
+    @Test("Positions preset badge below the physical top on screens without a notch")
+    func presetBadgeYWithoutSafeAreaInset() {
+        let y = CaptureDisplayGeometry.presetBadgeY(
+            viewHeight: 1117,
+            badgeHeight: 29,
+            safeAreaTopInset: 0
+        )
+
+        #expect(y == 1068)
+    }
+
+    @Test("Positions preset badge below the notch safe area")
+    func presetBadgeYWithSafeAreaInset() {
+        let y = CaptureDisplayGeometry.presetBadgeY(
+            viewHeight: 1117,
+            badgeHeight: 29,
+            safeAreaTopInset: 32
+        )
+
+        #expect(y == 992)
+    }
+
     @Test("Rejects invalid geometry")
     func invalidGeometry() {
         #expect(CaptureDisplayGeometry.displayScale(


### PR DESCRIPTION
## Summary
- use the screen safe-area top inset when positioning the capture preset badge
- push the badge farther down on notched displays while preserving the old spacing on non-notched screens
- add regression tests for both notched and non-notched layout behavior

## Root Cause
The capture overlay always used a fixed top margin, so the preset badge could sit inside the MacBook notch area.

## Validation
- `swift test --package-path Packages/CaptureKit`
- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug -derivedDataPath /tmp/Capso-Issue158-Verify build`

Closes #158.
