### PR TITLE
feat: add screenshot output controls

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -194,6 +194,14 @@ final class AnnotationCanvasNSView: NSView {
 
     override func mouseMoved(with event: NSEvent) {
         let pointInView = convert(event.locationInWindow, from: nil)
+        // Mouse-moved events can still reach this first-responder canvas while
+        // the pointer is over SwiftUI toolbar controls. Do not let the canvas
+        // leak its drawing cursor into non-canvas chrome.
+        guard bounds.contains(pointInView) else {
+            NSCursor.arrow.set()
+            return
+        }
+
         if let handle = liveTextHandleHitTest(pointInView: pointInView) {
             cursorForHandle(handle).set()
             return
@@ -218,12 +226,16 @@ final class AnnotationCanvasNSView: NSView {
         }
     }
 
+    override func mouseExited(with event: NSEvent) {
+        NSCursor.arrow.set()
+    }
+
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
         for area in trackingAreas { removeTrackingArea(area) }
         addTrackingArea(NSTrackingArea(
             rect: bounds,
-            options: [.mouseMoved, .activeInKeyWindow, .inVisibleRect],
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
             owner: self, userInfo: nil
         ))
     }

--- a/App/Sources/AnnotationEditor/AnnotationColorControls.swift
+++ b/App/Sources/AnnotationEditor/AnnotationColorControls.swift
@@ -57,6 +57,17 @@ struct AnnotationColorControls: View {
             }
             .buttonStyle(.plain)
             .help("Pick Color From Screen")
+
+            Button(action: copyCurrentHex) {
+                Text(currentColor.hexRGB)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 56, height: swatchSize + 8)
+                    .background(RoundedRectangle(cornerRadius: 4).fill(Color.primary.opacity(0.06)))
+                    .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color.primary.opacity(0.12), lineWidth: 0.5))
+            }
+            .buttonStyle(.plain)
+            .help("Copy HEX Color")
         }
     }
 
@@ -75,6 +86,12 @@ struct AnnotationColorControls: View {
             }
             self.sampler = nil
         }
+    }
+
+    private func copyCurrentHex() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(currentColor.hexRGB, forType: .string)
     }
 
     private func readableGlyphColor(for color: NSColor) -> Color {

--- a/App/Sources/AnnotationEditor/AnnotationEditorView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorView.swift
@@ -2,6 +2,7 @@
 import SwiftUI
 import AnnotationKit
 import OCRKit
+import SharedKit
 
 struct AnnotationEditorView: View {
     let initialSourceImage: CGImage
@@ -68,6 +69,7 @@ struct AnnotationEditorView: View {
     @State private var refreshTrigger = 0
     @State private var zoomScale: CGFloat = 1.0
     @State private var isCropMode = false
+    @State private var outputSize: CGSize?
     @State private var commitEditingTrigger = 0
     /// Cached text line bounding boxes for smart highlighter snapping.
     @State private var textRegions: [CGRect] = []
@@ -205,6 +207,7 @@ struct AnnotationEditorView: View {
         CropEditorView(
             sourceImage: sourceImage,
             initialCropRect: document.cropRect,
+            initialOutputSize: outputSize,
             canTransformImage: document.objects.isEmpty,
             onCancel: { isCropMode = false },
             onCommit: commitCrop
@@ -365,7 +368,7 @@ struct AnnotationEditorView: View {
         beautifySettings.isEnabled && beautifySettings.shadowEnabled ? 6 * zoomScale : 0
     }
 
-    private func commitCrop(newImage: CGImage?, newRect: CGRect?) {
+    private func commitCrop(newImage: CGImage?, newRect: CGRect?, newOutputSize: CGSize?) {
         if let newImage {
             sourceImage = newImage
             document.replaceImage(size: CGSize(width: newImage.width, height: newImage.height))
@@ -373,6 +376,7 @@ struct AnnotationEditorView: View {
         } else {
             document.setCropRect(newRect)
         }
+        outputSize = newOutputSize
         isCropMode = false
     }
 
@@ -501,7 +505,17 @@ struct AnnotationEditorView: View {
         ) else {
             return nil
         }
-        return BeautifyRenderer.render(image: annotated, settings: beautifySettings)
+        guard let rendered = BeautifyRenderer.render(image: annotated, settings: beautifySettings) else {
+            return nil
+        }
+        guard let outputSize else { return rendered }
+
+        let width = max(1, Int(outputSize.width.rounded()))
+        let height = max(1, Int(outputSize.height.rounded()))
+        guard width != rendered.width || height != rendered.height else {
+            return rendered
+        }
+        return ImageUtilities.resized(rendered, width: width, height: height) ?? rendered
     }
 
     private func save() {

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -1,4 +1,5 @@
 // App/Sources/AnnotationEditor/AnnotationToolbar.swift
+import AppKit
 import SwiftUI
 import AnnotationKit
 
@@ -59,6 +60,14 @@ struct AnnotationToolbar: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
+        .onHover { hovering in
+            if hovering {
+                NSCursor.arrow.set()
+            }
+        }
+        .onChange(of: currentTool) { _, _ in
+            NSCursor.arrow.set()
+        }
     }
 
     private var toolGroup: some View {

--- a/App/Sources/AnnotationEditor/Crop/CropEditorView.swift
+++ b/App/Sources/AnnotationEditor/Crop/CropEditorView.swift
@@ -5,6 +5,7 @@ import AnnotationKit
 struct CropEditorView: View {
     let sourceImage: CGImage
     let initialCropRect: CGRect?
+    let initialOutputSize: CGSize?
     /// True when the document already has annotations. Rotate and flip are
     /// disabled in that case to avoid orphaning annotations whose coordinates
     /// assume the pre-transform image space.
@@ -13,12 +14,16 @@ struct CropEditorView: View {
     /// Receives the (possibly transformed) image and the committed crop rect.
     /// `image` is nil if no rotate/flip was applied (caller keeps its existing
     /// source image). `cropRect` is nil when the rect covers the full image.
-    let onCommit: (_ image: CGImage?, _ cropRect: CGRect?) -> Void
+    let onCommit: (_ image: CGImage?, _ cropRect: CGRect?, _ outputSize: CGSize?) -> Void
 
     /// The live preview image. Starts equal to `sourceImage` and accumulates
     /// rotate/flip transforms on user action. Never mutated by Cancel.
     @State private var displayImage: CGImage
     @State private var cropRect: CGRect
+    @State private var resizeOutputEnabled: Bool
+    @State private var outputWidthDraft: String
+    @State private var outputHeightDraft: String
+    @State private var outputAspectLocked = true
     /// Persist the most recently chosen ratio preset across editor sessions.
     @AppStorage("annotationLastCropPreset") private var preset: CropPreset = .freeform
     @AppStorage("annotationCropSnapEnabled") private var snapEnabled: Bool = true
@@ -40,22 +45,32 @@ struct CropEditorView: View {
     /// `true` once the user has applied a rotate or flip. Drives the commit
     /// callback so the caller knows to swap its source image.
     @State private var didTransformImage: Bool = false
+    @FocusState private var focusedOutputField: OutputField?
+
+    private enum OutputField { case width, height }
 
     init(
         sourceImage: CGImage,
         initialCropRect: CGRect?,
+        initialOutputSize: CGSize?,
         canTransformImage: Bool,
         onCancel: @escaping () -> Void,
-        onCommit: @escaping (_ image: CGImage?, _ cropRect: CGRect?) -> Void
+        onCommit: @escaping (_ image: CGImage?, _ cropRect: CGRect?, _ outputSize: CGSize?) -> Void
     ) {
         self.sourceImage = sourceImage
         self.initialCropRect = initialCropRect
+        self.initialOutputSize = initialOutputSize
         self.canTransformImage = canTransformImage
         self.onCancel = onCancel
         self.onCommit = onCommit
         let size = CGSize(width: sourceImage.width, height: sourceImage.height)
+        let cropSize = initialCropRect?.size ?? size
+        let outputSize = initialOutputSize ?? cropSize
         self._displayImage = State(initialValue: sourceImage)
-        self._cropRect = State(initialValue: initialCropRect ?? CGRect(origin: .zero, size: size))
+        self._cropRect = State(initialValue: CGRect(origin: initialCropRect?.origin ?? .zero, size: cropSize))
+        self._resizeOutputEnabled = State(initialValue: initialOutputSize != nil)
+        self._outputWidthDraft = State(initialValue: "\(Int(outputSize.width.rounded()))")
+        self._outputHeightDraft = State(initialValue: "\(Int(outputSize.height.rounded()))")
     }
 
     private var imageSize: CGSize {
@@ -89,7 +104,8 @@ struct CropEditorView: View {
                 onCommit: {
                     onCommit(
                         didTransformImage ? displayImage : nil,
-                        isIdentityCrop ? nil : cropRect
+                        isIdentityCrop ? nil : cropRect,
+                        committedOutputSize
                     )
                 }
             )
@@ -137,6 +153,11 @@ struct CropEditorView: View {
                 .onChange(of: selectedCustom) { _, newCustom in
                     guard !isApplyingHistory else { return }
                     if let newCustom { applyRatio(newCustom.ratio) }
+                }
+                .onChange(of: cropRect) { _, _ in
+                    if !resizeOutputEnabled {
+                        syncOutputDraftsToCrop()
+                    }
                 }
             }
 
@@ -216,6 +237,10 @@ struct CropEditorView: View {
 
             Spacer()
 
+            outputResizeControls
+
+            Divider().frame(height: 18)
+
             if !isIdentityCrop {
                 Button("Revert to Original") {
                     cropRect = CGRect(origin: .zero, size: imageSize)
@@ -228,6 +253,106 @@ struct CropEditorView: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
         .background(.bar)
+    }
+
+    private var outputResizeControls: some View {
+        HStack(spacing: 8) {
+            Toggle("Resize output", isOn: resizeOutputBinding)
+                .toggleStyle(.checkbox)
+                .controlSize(.small)
+
+            if resizeOutputEnabled {
+                outputDimensionField(draft: $outputWidthDraft, field: .width)
+                    .help("Output width in pixels")
+                Text("×")
+                    .foregroundStyle(.secondary)
+                    .font(.system(size: 12))
+                outputDimensionField(draft: $outputHeightDraft, field: .height)
+                    .help("Output height in pixels")
+                Text("px")
+                    .foregroundStyle(.secondary)
+                    .font(.system(size: 11))
+
+                Button {
+                    outputAspectLocked.toggle()
+                    if outputAspectLocked {
+                        commitOutputDraft(for: .width)
+                    }
+                } label: {
+                    Image(systemName: outputAspectLocked ? "lock.fill" : "lock.open")
+                        .font(.system(size: 11, weight: .medium))
+                        .frame(width: 20, height: 20)
+                }
+                .buttonStyle(.borderless)
+                .help(outputAspectLocked ? "Keep crop aspect ratio" : "Allow custom output ratio")
+            }
+        }
+        .onChange(of: focusedOutputField) { oldField, newField in
+            if let oldField, newField != oldField {
+                commitOutputDraft(for: oldField)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func outputDimensionField(draft: Binding<String>, field: OutputField) -> some View {
+        TextField("", text: draft)
+            .textFieldStyle(.roundedBorder)
+            .controlSize(.small)
+            .font(.system(size: 12, design: .monospaced))
+            .multilineTextAlignment(.center)
+            .frame(width: 62)
+            .focused($focusedOutputField, equals: field)
+            .onSubmit { commitOutputDraft(for: field) }
+    }
+
+    private var resizeOutputBinding: Binding<Bool> {
+        Binding(
+            get: { resizeOutputEnabled },
+            set: { enabled in
+                resizeOutputEnabled = enabled
+                if enabled {
+                    syncOutputDraftsToCrop()
+                }
+            }
+        )
+    }
+
+    private var committedOutputSize: CGSize? {
+        guard resizeOutputEnabled,
+              let width = Int(outputWidthDraft),
+              let height = Int(outputHeightDraft),
+              width > 0,
+              height > 0 else {
+            return nil
+        }
+        return CGSize(width: width, height: height)
+    }
+
+    private func syncOutputDraftsToCrop() {
+        outputWidthDraft = "\(max(1, Int(cropRect.width.rounded())))"
+        outputHeightDraft = "\(max(1, Int(cropRect.height.rounded())))"
+    }
+
+    private func commitOutputDraft(for field: OutputField) {
+        let rawWidth = max(1, Int(outputWidthDraft) ?? max(1, Int(cropRect.width.rounded())))
+        let rawHeight = max(1, Int(outputHeightDraft) ?? max(1, Int(cropRect.height.rounded())))
+
+        guard outputAspectLocked, cropRect.width > 0, cropRect.height > 0 else {
+            outputWidthDraft = "\(rawWidth)"
+            outputHeightDraft = "\(rawHeight)"
+            return
+        }
+
+        let ratio = cropRect.width / cropRect.height
+        switch field {
+        case .width:
+            outputWidthDraft = "\(rawWidth)"
+            outputHeightDraft = "\(max(1, Int((CGFloat(rawWidth) / ratio).rounded())))"
+        case .height:
+            outputHeightDraft = "\(rawHeight)"
+            outputWidthDraft = "\(max(1, Int((CGFloat(rawHeight) * ratio).rounded())))"
+        }
     }
 
     private func rotateCCW() {

--- a/App/Sources/AnnotationEditor/Crop/CropToolbar.swift
+++ b/App/Sources/AnnotationEditor/Crop/CropToolbar.swift
@@ -83,7 +83,7 @@ struct CropToolbar: View {
             .keyboardShortcut(.cancelAction)
 
             Button(action: onCommit) {
-                Text("Crop").font(.system(size: 12, weight: .medium))
+                Text("Apply").font(.system(size: 12, weight: .medium))
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.small)

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -118,6 +118,29 @@ final class CaptureCoordinator {
         )
     }
 
+    private func timestampedResultIfNeeded(_ result: CaptureResult) -> CaptureResult {
+        let options = settings.screenshotTimestampOptions
+        guard options.isEnabled,
+              let image = ScreenshotTimestampRenderer.render(
+                image: result.image,
+                date: result.timestamp,
+                options: options
+              ) else {
+            return result
+        }
+
+        return CaptureResult(
+            image: image,
+            mode: result.mode,
+            captureRect: result.captureRect,
+            windowName: result.windowName,
+            appName: result.appName,
+            appBundleIdentifier: result.appBundleIdentifier,
+            timestamp: result.timestamp,
+            displayID: result.displayID
+        )
+    }
+
     func captureArea() {
         pendingAction = .default
         startAreaCapture()
@@ -1138,6 +1161,7 @@ final class CaptureCoordinator {
 
     private func handleCaptureResult(_ capturedResult: CaptureResult) {
         let result = captureResultWithPendingSource(capturedResult)
+        let outputResult = timestampedResultIfNeeded(result)
         lastCaptureResult = result
 
         let action = pendingAction
@@ -1154,24 +1178,24 @@ final class CaptureCoordinator {
 
         switch action {
         case .clipboard:
-            copyImageToClipboard(result.image)
+            copyImageToClipboard(outputResult.image)
         case .annotate:
             // Open the editor on the same screen the capture came from.
-            openAnnotationEditor(result, anchorScreen: screenFor(result: result))
+            openAnnotationEditor(outputResult, anchorScreen: screenFor(result: result))
         case .inlineAnnotate:
-            openInlineAnnotationEditor(result, anchorScreen: screenFor(result: result))
+            openInlineAnnotationEditor(outputResult, anchorScreen: screenFor(result: result))
         case .ocr:
             ocrCoordinator?.startVisualOCR(image: result.image, anchorScreen: screenFor(result: result))
         case .pin:
-            pinToScreen(result, anchor: anchorRect(for: result))
+            pinToScreen(outputResult, anchor: anchorRect(for: result))
         case .save:
-            saveImageToFile(result)
+            saveImageToFile(outputResult)
         case .share:
             // Skip Quick Access, save to history, then upload in background.
-            logDiagnostic("Cloud Share capture completed mode=\(result.mode) displayID=\(result.displayID)")
-            historyCoordinator?.saveCapture(result: result, entryID: entryID)
+            logDiagnostic("Cloud Share capture completed mode=\(outputResult.mode) displayID=\(outputResult.displayID)")
+            historyCoordinator?.saveCapture(result: outputResult, entryID: entryID)
             if let coord = shareCoordinator {
-                Task { await self.performShareAfterCapture(result: result, entryID: entryID, coord: coord) }
+                Task { await self.performShareAfterCapture(result: outputResult, entryID: entryID, coord: coord) }
             } else {
                 logDiagnostic("Cloud Share capture completed but coordinator is nil")
                 Self.postNotification(
@@ -1182,18 +1206,18 @@ final class CaptureCoordinator {
             return  // history already saved above; skip the call below
         case .default:
             if settings.screenshotAutoCopy {
-                copyImageToClipboard(result.image)
+                copyImageToClipboard(outputResult.image)
             }
             if settings.screenshotAutoSave {
-                saveImageToFile(result)
+                saveImageToFile(outputResult)
             }
             if settings.screenshotShowPreview {
-                showQuickAccess(for: result, entryID: entryID)
+                showQuickAccess(for: outputResult, entryID: entryID)
             }
         }
 
         if action.savesOriginalCaptureToHistory {
-            historyCoordinator?.saveCapture(result: result, entryID: entryID)
+            historyCoordinator?.saveCapture(result: action == .ocr ? result : outputResult, entryID: entryID)
         }
     }
 

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -136,6 +136,61 @@ final class PreferencesViewModel {
             }
         }
     }
+    var screenshotTimestampEnabled: Bool {
+        get {
+            access(keyPath: \.screenshotTimestampEnabled)
+            return settings.screenshotTimestampEnabled
+        }
+        set {
+            withMutation(keyPath: \.screenshotTimestampEnabled) {
+                settings.screenshotTimestampEnabled = newValue
+            }
+        }
+    }
+    var screenshotTimestampPosition: ScreenshotTimestampPosition {
+        get {
+            access(keyPath: \.screenshotTimestampPosition)
+            return settings.screenshotTimestampPosition
+        }
+        set {
+            withMutation(keyPath: \.screenshotTimestampPosition) {
+                settings.screenshotTimestampPosition = newValue
+            }
+        }
+    }
+    var screenshotTimestampFormat: ScreenshotTimestampFormat {
+        get {
+            access(keyPath: \.screenshotTimestampFormat)
+            return settings.screenshotTimestampFormat
+        }
+        set {
+            withMutation(keyPath: \.screenshotTimestampFormat) {
+                settings.screenshotTimestampFormat = newValue
+            }
+        }
+    }
+    var screenshotTimestampColorHex: String {
+        get {
+            access(keyPath: \.screenshotTimestampColorHex)
+            return settings.screenshotTimestampColorHex
+        }
+        set {
+            withMutation(keyPath: \.screenshotTimestampColorHex) {
+                settings.screenshotTimestampColorHex = newValue
+            }
+        }
+    }
+    var screenshotTimestampFontSize: Int {
+        get {
+            access(keyPath: \.screenshotTimestampFontSize)
+            return settings.screenshotTimestampFontSize
+        }
+        set {
+            withMutation(keyPath: \.screenshotTimestampFontSize) {
+                settings.screenshotTimestampFontSize = newValue
+            }
+        }
+    }
     var captureWindowShadow: Bool {
         get {
             access(keyPath: \.captureWindowShadow)

--- a/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
@@ -54,6 +54,59 @@ struct ScreenshotSettingsView: View {
                 }
             }
 
+            SettingGroup(title: "Timestamp") {
+                SettingCard {
+                    SettingRow(label: "Add Timestamp", sublabel: "Draw the capture time onto screenshots") {
+                        Toggle("", isOn: $viewModel.screenshotTimestampEnabled)
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                    }
+
+                    if viewModel.screenshotTimestampEnabled {
+                        SettingRow(label: "Position", showDivider: true) {
+                            Picker("", selection: $viewModel.screenshotTimestampPosition) {
+                                ForEach(ScreenshotTimestampPosition.allCases, id: \.self) { position in
+                                    Text(position.displayName).tag(position)
+                                }
+                            }
+                            .labelsHidden()
+                            .frame(width: 150)
+                        }
+
+                        SettingRow(label: "Format", showDivider: true) {
+                            Picker("", selection: $viewModel.screenshotTimestampFormat) {
+                                ForEach(ScreenshotTimestampFormat.allCases, id: \.self) { format in
+                                    Text(format.displayName).tag(format)
+                                }
+                            }
+                            .labelsHidden()
+                            .frame(width: 150)
+                        }
+
+                        SettingRow(label: "Color", showDivider: true) {
+                            TextField("#FFFFFF", text: $viewModel.screenshotTimestampColorHex)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.system(size: 12, design: .monospaced))
+                                .frame(width: 88)
+                        }
+
+                        SettingRow(label: "Font Size", showDivider: true) {
+                            HStack(spacing: 8) {
+                                Text("\(viewModel.screenshotTimestampFontSize) pt")
+                                    .font(.system(size: 13, weight: .medium).monospacedDigit())
+                                    .frame(minWidth: 42, alignment: .trailing)
+                                Stepper(
+                                    "",
+                                    value: $viewModel.screenshotTimestampFontSize,
+                                    in: ScreenshotTimestampOptions.fontSizeRange
+                                )
+                                .labelsHidden()
+                            }
+                        }
+                    }
+                }
+            }
+
             SettingGroup(title: "Self-Timer") {
                 SettingCard {
                     SettingRow(

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -393,6 +393,67 @@ public final class AppSettings: @unchecked Sendable {
         set { defaults.set(newValue, forKey: "screenshotShowsCursor") }
     }
 
+    public var screenshotTimestampEnabled: Bool {
+        get { defaults.object(forKey: "screenshotTimestampEnabled") as? Bool ?? false }
+        set { defaults.set(newValue, forKey: "screenshotTimestampEnabled") }
+    }
+
+    public var screenshotTimestampPosition: ScreenshotTimestampPosition {
+        get {
+            guard let raw = defaults.string(forKey: "screenshotTimestampPosition"),
+                  let value = ScreenshotTimestampPosition(rawValue: raw) else { return .bottomRight }
+            return value
+        }
+        set { defaults.set(newValue.rawValue, forKey: "screenshotTimestampPosition") }
+    }
+
+    public var screenshotTimestampFormat: ScreenshotTimestampFormat {
+        get {
+            guard let raw = defaults.string(forKey: "screenshotTimestampFormat"),
+                  let value = ScreenshotTimestampFormat(rawValue: raw) else { return .dateTime }
+            return value
+        }
+        set { defaults.set(newValue.rawValue, forKey: "screenshotTimestampFormat") }
+    }
+
+    public var screenshotTimestampColorHex: String {
+        get {
+            let raw = defaults.string(forKey: "screenshotTimestampColorHex") ?? "#FFFFFF"
+            return ScreenshotTimestampOptions.normalizedColorHex(raw) ?? "#FFFFFF"
+        }
+        set {
+            let normalized = ScreenshotTimestampOptions.normalizedColorHex(newValue) ?? "#FFFFFF"
+            defaults.set(normalized, forKey: "screenshotTimestampColorHex")
+        }
+    }
+
+    public var screenshotTimestampFontSize: Int {
+        get {
+            let raw = defaults.object(forKey: "screenshotTimestampFontSize") as? Int ?? 14
+            return min(
+                max(raw, ScreenshotTimestampOptions.fontSizeRange.lowerBound),
+                ScreenshotTimestampOptions.fontSizeRange.upperBound
+            )
+        }
+        set {
+            let clamped = min(
+                max(newValue, ScreenshotTimestampOptions.fontSizeRange.lowerBound),
+                ScreenshotTimestampOptions.fontSizeRange.upperBound
+            )
+            defaults.set(clamped, forKey: "screenshotTimestampFontSize")
+        }
+    }
+
+    public var screenshotTimestampOptions: ScreenshotTimestampOptions {
+        ScreenshotTimestampOptions(
+            isEnabled: screenshotTimestampEnabled,
+            position: screenshotTimestampPosition,
+            format: screenshotTimestampFormat,
+            colorHex: screenshotTimestampColorHex,
+            fontSize: screenshotTimestampFontSize
+        )
+    }
+
     public var captureWindowShadow: Bool {
         get { defaults.object(forKey: "captureWindowShadow") as? Bool ?? true }
         set { defaults.set(newValue, forKey: "captureWindowShadow") }

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ImageUtilities.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ImageUtilities.swift
@@ -48,4 +48,22 @@ public enum ImageUtilities {
         context.draw(cgImage, in: CGRect(x: 0, y: 0, width: newWidth, height: newHeight))
         return context.makeImage()
     }
+
+    public static func resized(_ cgImage: CGImage, width: Int, height: Int) -> CGImage? {
+        guard width > 0, height > 0 else { return nil }
+
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: cgImage.colorSpace ?? CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+
+        context.interpolationQuality = .high
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return context.makeImage()
+    }
 }

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ScreenshotTimestampRenderer.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ScreenshotTimestampRenderer.swift
@@ -1,0 +1,200 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+public enum ScreenshotTimestampPosition: String, CaseIterable, Sendable {
+    case topLeft
+    case top
+    case topRight
+    case right
+    case bottomRight
+    case bottom
+    case bottomLeft
+    case left
+
+    public var displayName: String {
+        switch self {
+        case .topLeft: "Top Left"
+        case .top: "Top"
+        case .topRight: "Top Right"
+        case .right: "Right"
+        case .bottomRight: "Bottom Right"
+        case .bottom: "Bottom"
+        case .bottomLeft: "Bottom Left"
+        case .left: "Left"
+        }
+    }
+}
+
+public enum ScreenshotTimestampFormat: String, CaseIterable, Sendable {
+    case dateTime
+    case date
+    case time
+    case iso8601
+
+    public var displayName: String {
+        switch self {
+        case .dateTime: "Date & Time"
+        case .date: "Date"
+        case .time: "Time"
+        case .iso8601: "ISO 8601"
+        }
+    }
+
+    public func string(from date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = .current
+        formatter.timeZone = .current
+        switch self {
+        case .dateTime:
+            formatter.dateFormat = "yyyy-MM-dd HH:mm"
+        case .date:
+            formatter.dateFormat = "yyyy-MM-dd"
+        case .time:
+            formatter.dateFormat = "HH:mm:ss"
+        case .iso8601:
+            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        }
+        return formatter.string(from: date)
+    }
+}
+
+public struct ScreenshotTimestampOptions: Sendable {
+    public static let fontSizeRange: ClosedRange<Int> = 8...72
+
+    public var isEnabled: Bool
+    public var position: ScreenshotTimestampPosition
+    public var format: ScreenshotTimestampFormat
+    public var colorHex: String
+    public var fontSize: Int
+
+    public init(
+        isEnabled: Bool = false,
+        position: ScreenshotTimestampPosition = .bottomRight,
+        format: ScreenshotTimestampFormat = .dateTime,
+        colorHex: String = "#FFFFFF",
+        fontSize: Int = 14
+    ) {
+        self.isEnabled = isEnabled
+        self.position = position
+        self.format = format
+        self.colorHex = Self.normalizedColorHex(colorHex) ?? "#FFFFFF"
+        self.fontSize = min(max(fontSize, Self.fontSizeRange.lowerBound), Self.fontSizeRange.upperBound)
+    }
+
+    public static func normalizedColorHex(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hex = trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed
+        guard hex.count == 6, UInt32(hex, radix: 16) != nil else { return nil }
+        return "#\(hex.uppercased())"
+    }
+}
+
+public enum ScreenshotTimestampRenderer {
+    public static func render(
+        image: CGImage,
+        date: Date,
+        options: ScreenshotTimestampOptions
+    ) -> CGImage? {
+        guard options.isEnabled else { return image }
+
+        let width = image.width
+        let height = image.height
+        guard width > 0, height > 0 else { return nil }
+
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: image.colorSpace ?? CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+
+        let canvas = CGRect(x: 0, y: 0, width: width, height: height)
+        context.draw(image, in: canvas)
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(cgContext: context, flipped: false)
+        defer { NSGraphicsContext.restoreGraphicsState() }
+
+        let font = NSFont.monospacedDigitSystemFont(ofSize: CGFloat(options.fontSize), weight: .medium)
+        let shadow = NSShadow()
+        shadow.shadowColor = NSColor.black.withAlphaComponent(0.65)
+        shadow.shadowBlurRadius = max(2, CGFloat(options.fontSize) * 0.16)
+        shadow.shadowOffset = CGSize(width: 0, height: -1)
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: color(from: options.colorHex),
+            .shadow: shadow,
+        ]
+        let text = options.format.string(from: date)
+        let attributed = NSAttributedString(string: text, attributes: attributes)
+        let size = attributed.size()
+        let margin = max(8, CGFloat(options.fontSize))
+        let rect = textRect(
+            textSize: size,
+            canvasSize: CGSize(width: width, height: height),
+            margin: margin,
+            position: options.position
+        )
+        attributed.draw(in: rect)
+
+        return context.makeImage()
+    }
+
+    private static func textRect(
+        textSize: CGSize,
+        canvasSize: CGSize,
+        margin: CGFloat,
+        position: ScreenshotTimestampPosition
+    ) -> CGRect {
+        let x: CGFloat
+        let y: CGFloat
+        switch position {
+        case .topLeft:
+            x = margin
+            y = canvasSize.height - margin - textSize.height
+        case .top:
+            x = (canvasSize.width - textSize.width) / 2
+            y = canvasSize.height - margin - textSize.height
+        case .topRight:
+            x = canvasSize.width - margin - textSize.width
+            y = canvasSize.height - margin - textSize.height
+        case .right:
+            x = canvasSize.width - margin - textSize.width
+            y = (canvasSize.height - textSize.height) / 2
+        case .bottomRight:
+            x = canvasSize.width - margin - textSize.width
+            y = margin
+        case .bottom:
+            x = (canvasSize.width - textSize.width) / 2
+            y = margin
+        case .bottomLeft:
+            x = margin
+            y = margin
+        case .left:
+            x = margin
+            y = (canvasSize.height - textSize.height) / 2
+        }
+        return CGRect(
+            x: max(margin, min(canvasSize.width - margin - textSize.width, x)),
+            y: max(margin, min(canvasSize.height - margin - textSize.height, y)),
+            width: textSize.width,
+            height: textSize.height
+        )
+    }
+
+    private static func color(from hex: String) -> NSColor {
+        let normalized = ScreenshotTimestampOptions.normalizedColorHex(hex) ?? "#FFFFFF"
+        let value = UInt32(normalized.dropFirst(), radix: 16) ?? 0xFFFFFF
+        return NSColor(
+            srgbRed: CGFloat((value >> 16) & 0xFF) / 255,
+            green: CGFloat((value >> 8) & 0xFF) / 255,
+            blue: CGFloat(value & 0xFF) / 255,
+            alpha: 0.96
+        )
+    }
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -102,6 +102,41 @@ struct AppSettingsTests {
         #expect(second.screenshotShowsCursor == true)
     }
 
+    @Test("Screenshot timestamp defaults are opt-in")
+    func screenshotTimestampDefaultsAreOptIn() {
+        let suite = "test.screenshotTimestamp.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+
+        #expect(settings.screenshotTimestampEnabled == false)
+        #expect(settings.screenshotTimestampPosition == .bottomRight)
+        #expect(settings.screenshotTimestampFormat == .dateTime)
+        #expect(settings.screenshotTimestampColorHex == "#FFFFFF")
+        #expect(settings.screenshotTimestampFontSize == 14)
+    }
+
+    @Test("Screenshot timestamp settings persist")
+    func screenshotTimestampSettingsPersist() {
+        let suite = "test.screenshotTimestamp.persist"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let first = AppSettings(defaults: defaults)
+
+        first.screenshotTimestampEnabled = true
+        first.screenshotTimestampPosition = .topLeft
+        first.screenshotTimestampFormat = .iso8601
+        first.screenshotTimestampColorHex = "#112233"
+        first.screenshotTimestampFontSize = 22
+
+        let second = AppSettings(defaults: defaults)
+        #expect(second.screenshotTimestampEnabled == true)
+        #expect(second.screenshotTimestampPosition == .topLeft)
+        #expect(second.screenshotTimestampFormat == .iso8601)
+        #expect(second.screenshotTimestampColorHex == "#112233")
+        #expect(second.screenshotTimestampFontSize == 22)
+    }
+
     @Test("Default Quick Access position is bottomLeft")
     func defaultQuickAccessPosition() {
         let settings = AppSettings()

--- a/Packages/SharedKit/Tests/SharedKitTests/ImageUtilitiesTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ImageUtilitiesTests.swift
@@ -1,0 +1,42 @@
+import AppKit
+import CoreGraphics
+import Testing
+@testable import SharedKit
+
+@Suite("ImageUtilities")
+struct ImageUtilitiesTests {
+    @Test("Exact resize creates requested pixel dimensions")
+    func exactResizeCreatesRequestedPixelDimensions() throws {
+        let image = try makeSolidImage(width: 12, height: 8, color: CGColor(red: 1, green: 0, blue: 0, alpha: 1))
+
+        let resized = try #require(ImageUtilities.resized(image, width: 5, height: 7))
+
+        #expect(resized.width == 5)
+        #expect(resized.height == 7)
+    }
+
+    @Test("Exact resize can upscale")
+    func exactResizeCanUpscale() throws {
+        let image = try makeSolidImage(width: 4, height: 4, color: CGColor(red: 0, green: 0, blue: 1, alpha: 1))
+
+        let resized = try #require(ImageUtilities.resized(image, width: 9, height: 6))
+
+        #expect(resized.width == 9)
+        #expect(resized.height == 6)
+    }
+}
+
+private func makeSolidImage(width: Int, height: Int, color: CGColor) throws -> CGImage {
+    let context = try #require(CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(color)
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    return try #require(context.makeImage())
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/ScreenshotTimestampRendererTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ScreenshotTimestampRendererTests.swift
@@ -1,0 +1,70 @@
+import AppKit
+import CoreGraphics
+import Testing
+@testable import SharedKit
+
+@Suite("ScreenshotTimestampRenderer")
+struct ScreenshotTimestampRendererTests {
+    @Test("Renderer keeps image size and changes pixels when enabled")
+    func rendererKeepsImageSizeAndChangesPixelsWhenEnabled() throws {
+        let image = try makeSolidImage(width: 320, height: 180, color: CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+        let date = Date(timeIntervalSince1970: 1_705_348_800)
+        let options = ScreenshotTimestampOptions(
+            isEnabled: true,
+            position: .bottomRight,
+            format: .dateTime,
+            colorHex: "#000000",
+            fontSize: 20
+        )
+
+        let rendered = try #require(ScreenshotTimestampRenderer.render(image: image, date: date, options: options))
+
+        #expect(rendered.width == image.width)
+        #expect(rendered.height == image.height)
+        #expect(try pixelData(rendered) != pixelData(image))
+    }
+
+    @Test("Renderer returns original image when disabled")
+    func rendererReturnsOriginalWhenDisabled() throws {
+        let image = try makeSolidImage(width: 64, height: 64, color: CGColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 1))
+        let options = ScreenshotTimestampOptions(isEnabled: false)
+
+        let rendered = ScreenshotTimestampRenderer.render(image: image, date: Date(), options: options)
+
+        #expect(rendered === image)
+    }
+}
+
+private func pixelData(_ image: CGImage) throws -> [UInt8] {
+    let width = image.width
+    let height = image.height
+    var pixels = [UInt8](repeating: 0, count: width * height * 4)
+    let context = try pixels.withUnsafeMutableBytes { buffer in
+        try #require(CGContext(
+            data: buffer.baseAddress,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+    }
+    context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+    return pixels
+}
+
+private func makeSolidImage(width: Int, height: Int, color: CGColor) throws -> CGImage {
+    let context = try #require(CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(color)
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    return try #require(context.makeImage())
+}


### PR DESCRIPTION
## Summary
- add crop output resize controls and final image resizing
- show and copy annotation color HEX values
- add optional screenshot timestamp settings and output rendering
- fix annotation editor cursor leaking crosshair into toolbar controls

## Issues
Closes #164
Closes #165
Closes #167

#166 remains open pending clarification.

## Validation
- xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build
- swift test --package-path Packages/SharedKit
- swift test --package-path Packages/AnnotationKit
- swift test --package-path Packages/CaptureKit
- swift test --package-path Packages/RecordingKit
- git diff --check
- manual cursor verification with Computer Use and screencapture
