### PR TITLE
chore: restore bundle identifiers

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -325,7 +325,7 @@ jobs:
             app "Capso.app"
 
             zap trash: [
-              "~/Library/Preferences/io.github.lzhgus.capso.plist",
+              "~/Library/Preferences/com.awesomemacapps.capso.plist",
             ]
           end
           CASK

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -6247,11 +6247,11 @@
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "未能完全清除 Keychain" } }
       }
     },
-    "Some credentials may still be in Keychain: %@.\n\nOpen 'Keychain Access.app' and search for 'io.github.lzhgus.capso.share' to remove them manually." : {
+    "Some credentials may still be in Keychain: %@.\n\nOpen 'Keychain Access.app' and search for 'com.awesomemacapps.capso.share' to remove them manually." : {
       "localizations" : {
-        "ja" : { "stringUnit" : { "state" : "translated", "value" : "一部の資格情報が Keychain に残っている可能性があります：%@。\n\n「キーチェーンアクセス.app」を開き、'io.github.lzhgus.capso.share' で検索して手動で削除してください。" } },
-        "ko" : { "stringUnit" : { "state" : "translated", "value" : "일부 자격 증명이 Keychain에 남아 있을 수 있습니다: %@.\n\n'키체인 접근.app'을 열고 'io.github.lzhgus.capso.share'를 검색하여 수동으로 삭제하세요." } },
-        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "部分凭据可能仍保留在 Keychain 中：%@。\n\n请打开“钥匙串访问.app”，搜索 'io.github.lzhgus.capso.share' 手动删除。" } }
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "一部の資格情報が Keychain に残っている可能性があります：%@。\n\n「キーチェーンアクセス.app」を開き、'com.awesomemacapps.capso.share' で検索して手動で削除してください。" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "일부 자격 증명이 Keychain에 남아 있을 수 있습니다: %@.\n\n'키체인 접근.app'을 열고 'com.awesomemacapps.capso.share'를 검색하여 수동으로 삭제하세요." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "部分凭据可能仍保留在 Keychain 中：%@。\n\n请打开“钥匙串访问.app”，搜索 'com.awesomemacapps.capso.share' 手动删除。" } }
       }
     },
     "All-in-One" : {

--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -214,7 +214,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return nil
         }
 
-        let keychain = KeychainHelper(service: "io.github.lzhgus.capso.share.\(provider.rawValue)")
+        let keychain = KeychainHelper(service: "com.awesomemacapps.capso.share.\(provider.rawValue)")
         guard
             let access = AppDelegate.keychainString(keychain, account: "accessKey"),
             let secret = AppDelegate.keychainString(keychain, account: "secretKey")

--- a/App/Sources/OCR/OCRCoordinator.swift
+++ b/App/Sources/OCR/OCRCoordinator.swift
@@ -6,7 +6,7 @@ import CaptureKit
 import OCRKit
 import SharedKit
 
-private let logger = Logger(subsystem: "io.github.lzhgus.capso", category: "OCR")
+private let logger = Logger(subsystem: "com.awesomemacapps.capso", category: "OCR")
 
 @MainActor
 @Observable

--- a/App/Sources/Preferences/Tabs/CloudShareSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/CloudShareSettingsView.swift
@@ -154,7 +154,7 @@ struct CloudShareSettingsView: View {
             return
         }
 
-        let keychain = KeychainHelper(service: "io.github.lzhgus.capso.share.\(provider.rawValue)")
+        let keychain = KeychainHelper(service: "com.awesomemacapps.capso.share.\(provider.rawValue)")
         let accessKey = (try? keychain.get(account: "accessKey")) ?? ""
         let secretKey = (try? keychain.get(account: "secretKey")) ?? ""
 
@@ -236,7 +236,7 @@ struct CloudShareSettingsView: View {
         // 2. Delete Keychain entries — surface failures instead of silently swallowing.
         var keychainErrors: [String] = []
         for provider in ShareProvider.allCases {
-            let keychain = KeychainHelper(service: "io.github.lzhgus.capso.share.\(provider.rawValue)")
+            let keychain = KeychainHelper(service: "com.awesomemacapps.capso.share.\(provider.rawValue)")
             do {
                 try keychain.delete(account: "accessKey")
             } catch {
@@ -272,7 +272,7 @@ struct CloudShareSettingsView: View {
             let list = keychainErrors.joined(separator: ", ")
             testResult = TestResultAlert(
                 title: String(localized: "Couldn't fully clear Keychain"),
-                message: String(format: String(localized: "Some credentials may still be in Keychain: %@.\n\nOpen 'Keychain Access.app' and search for 'io.github.lzhgus.capso.share' to remove them manually."), list)
+                message: String(format: String(localized: "Some credentials may still be in Keychain: %@.\n\nOpen 'Keychain Access.app' and search for 'com.awesomemacapps.capso.share' to remove them manually."), list)
             )
         }
     }

--- a/App/Sources/Preferences/Tabs/CloudShareWizard/CloudShareWizardView.swift
+++ b/App/Sources/Preferences/Tabs/CloudShareWizard/CloudShareWizardView.swift
@@ -168,7 +168,7 @@ struct CloudShareWizardView: View {
     private func save() async {
         // Step 1: Keychain first — if this fails, abort (no AppSettings writes,
         // so the UI never shows a half-saved "configured" state).
-        let keychain = KeychainHelper(service: "io.github.lzhgus.capso.share.\(model.provider.rawValue)")
+        let keychain = KeychainHelper(service: "com.awesomemacapps.capso.share.\(model.provider.rawValue)")
         do {
             try keychain.set(model.accessKey, account: "accessKey")
             try keychain.set(model.secretKey, account: "secretKey")

--- a/App/Sources/Translation/TranslationCoordinator.swift
+++ b/App/Sources/Translation/TranslationCoordinator.swift
@@ -10,7 +10,7 @@ import OCRKit
 import SharedKit
 import TranslationKit
 
-private let logger = Logger(subsystem: "io.github.lzhgus.capso", category: "Translation")
+private let logger = Logger(subsystem: "com.awesomemacapps.capso", category: "Translation")
 
 @MainActor
 @Observable

--- a/Packages/HistoryKit/Sources/HistoryKit/HistoryStore.swift
+++ b/Packages/HistoryKit/Sources/HistoryKit/HistoryStore.swift
@@ -40,7 +40,7 @@ public final class HistoryStore: Sendable {
     private static func defaultDirectory() -> URL {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         return appSupport
-            .appendingPathComponent("io.github.lzhgus.capso", isDirectory: true)
+            .appendingPathComponent("com.awesomemacapps.capso", isDirectory: true)
             .appendingPathComponent("history", isDirectory: true)
     }
 

--- a/Packages/SharedKit/Sources/SharedKit/Diagnostics/DiagnosticLogger.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Diagnostics/DiagnosticLogger.swift
@@ -19,12 +19,12 @@ private func capsoUncaughtExceptionHandler(_ exception: NSException) {
 public enum DiagnosticLogger {
     public static let maxLogBytes = 1_000_000
 
-    private static let queue = DispatchQueue(label: "io.github.lzhgus.capso.diagnostic-logger")
+    private static let queue = DispatchQueue(label: "com.awesomemacapps.capso.diagnostic-logger")
 
     public static var logDirectory: URL {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         return appSupport
-            .appendingPathComponent("io.github.lzhgus.capso", isDirectory: true)
+            .appendingPathComponent("com.awesomemacapps.capso", isDirectory: true)
             .appendingPathComponent("logs", isDirectory: true)
     }
 
@@ -95,7 +95,7 @@ public enum DiagnosticLogger {
             return urls.filter { url in
                 let name = url.lastPathComponent.lowercased()
                 let ext = url.pathExtension.lowercased()
-                return (name.contains("capso") || name.contains("io.github.lzhgus.capso"))
+                return (name.contains("capso") || name.contains("com.awesomemacapps.capso"))
                     && ["crash", "ips", "diag"].contains(ext)
             }
         }

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -686,12 +686,12 @@ public final class AppSettings: @unchecked Sendable {
     }
 
     public func translationAPIKey() -> String? {
-        try? KeychainHelper(service: "io.github.lzhgus.capso.translation")
+        try? KeychainHelper(service: "com.awesomemacapps.capso.translation")
             .get(account: translationProvider.rawValue)
     }
 
     public func setTranslationAPIKey(_ value: String?) throws {
-        let keychain = KeychainHelper(service: "io.github.lzhgus.capso.translation")
+        let keychain = KeychainHelper(service: "com.awesomemacapps.capso.translation")
         let account = translationProvider.rawValue
         let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if trimmed.isEmpty {

--- a/Packages/SharedKit/Tests/SharedKitTests/KeychainHelperTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/KeychainHelperTests.swift
@@ -5,7 +5,7 @@ import Foundation
 
 @Suite("KeychainHelper")
 struct KeychainHelperTests {
-    private let testService = "io.github.lzhgus.capso.test.\(UUID().uuidString)"
+    private let testService = "com.awesomemacapps.capso.test.\(UUID().uuidString)"
 
     @Test("write then read returns the value")
     func roundTrip() throws {

--- a/project.yml
+++ b/project.yml
@@ -1,7 +1,7 @@
 # project.yml
 name: Capso
 options:
-  bundleIdPrefix: io.github.lzhgus
+  bundleIdPrefix: com.awesomemacapps
   deploymentTarget:
     macOS: "15.0"
   xcodeVersion: "26.0"
@@ -69,7 +69,7 @@ targets:
           - "Info.plist"
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: io.github.lzhgus.capso
+        PRODUCT_BUNDLE_IDENTIFIER: com.awesomemacapps.capso
         INFOPLIST_FILE: App/Resources/Info.plist
         CODE_SIGN_ENTITLEMENTS: App/Entitlements/Capso.entitlements
         LD_RUNPATH_SEARCH_PATHS: "@executable_path/../Frameworks"


### PR DESCRIPTION
## Summary
- Restore the original Bundle ID and app identifier namespace
- Keep keychain, history, diagnostics, and release metadata aligned with existing installs
- Leave README, funding, and license metadata cleanup intact

## Validation
- xcodegen
- xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build
- Keyword sweep for replacement identifiers and removed public website references