### PR TITLE
feat: add translation input and annotation workflows

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -1888,6 +1888,13 @@
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "关闭" } }
       }
     },
+    "Clipboard" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "クリップボード" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "클립보드" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "剪贴板" } }
+      }
+    },
     "Copy" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1909,6 +1916,69 @@
             "value" : "复制"
           }
         }
+      }
+    },
+    "Copy original" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "原文をコピー" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "원문 복사" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "复制原文" } }
+      }
+    },
+    "Edit Clipboard Image" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "クリップボードの画像を編集" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "클립보드 이미지 편집" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "编辑剪贴板图片" } }
+      }
+    },
+    "Open the image currently copied to the clipboard in Annotate" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "現在クリップボードにコピーされている画像を注釈エディタで開く" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "현재 클립보드에 복사된 이미지를 주석 편집기에서 열기" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "在标注编辑器中打开当前复制到剪贴板的图片" } }
+      }
+    },
+    "No image found on clipboard" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "クリップボードに画像がありません" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "클립보드에 이미지가 없습니다" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "剪贴板中没有图片" } }
+      }
+    },
+    "No text to translate." : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "翻訳するテキストがありません。" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "번역할 텍스트가 없습니다." } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "没有可翻译的文本。" } }
+      }
+    },
+    "Original" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "原文" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "원문" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "原文" } }
+      }
+    },
+    "Translate" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "翻訳" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "번역" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "翻译" } }
+      }
+    },
+    "Translate Text" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "テキストを翻訳" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "텍스트 번역" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "翻译文本" } }
+      }
+    },
+    "Translate Typed Text" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "入力したテキストを翻訳" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "입력한 텍스트 번역" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "翻译输入文本" } }
       }
     },
     "Copy All" : {
@@ -6522,6 +6592,13 @@
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "ハイライター幅" } },
         "ko" : { "stringUnit" : { "state" : "translated", "value" : "형광펜 너비" } },
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "荧光笔宽度" } }
+      }
+    },
+    "Line" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "線" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "선" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "直线" } }
       }
     },
     "Line Width" : {

--- a/App/Sources/AnnotationEditor/AnnotationEditorView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorView.swift
@@ -227,6 +227,7 @@ struct AnnotationEditorView: View {
             canvasArea
             zoomBar
         }
+        .annotationToolShortcuts(currentTool: $currentTool, isEnabled: !isEditingText)
     }
 
     private var toolbar: some View {

--- a/App/Sources/AnnotationEditor/AnnotationToolShortcutMonitor.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolShortcutMonitor.swift
@@ -26,6 +26,7 @@ private struct AnnotationToolShortcutMonitor: NSViewRepresentable {
         coordinator.uninstall()
     }
 
+    @MainActor
     final class Coordinator {
         var currentTool: Binding<AnnotationTool>?
         var isEnabled = true

--- a/App/Sources/AnnotationEditor/AnnotationToolShortcutMonitor.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolShortcutMonitor.swift
@@ -1,0 +1,89 @@
+import AppKit
+import SwiftUI
+import AnnotationKit
+
+private struct AnnotationToolShortcutMonitor: NSViewRepresentable {
+    @Binding var currentTool: AnnotationTool
+    let isEnabled: Bool
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        context.coordinator.currentTool = $currentTool
+        context.coordinator.isEnabled = isEnabled
+        context.coordinator.install()
+        return NSView(frame: .zero)
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.currentTool = $currentTool
+        context.coordinator.isEnabled = isEnabled
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.uninstall()
+    }
+
+    final class Coordinator {
+        var currentTool: Binding<AnnotationTool>?
+        var isEnabled = true
+        private var monitor: Any?
+
+        func install() {
+            guard monitor == nil else { return }
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                self?.handle(event) ?? event
+            }
+        }
+
+        func uninstall() {
+            if let monitor {
+                NSEvent.removeMonitor(monitor)
+                self.monitor = nil
+            }
+        }
+
+        private func handle(_ event: NSEvent) -> NSEvent? {
+            guard isEnabled,
+                  !isTextInputActive(in: event.window),
+                  allowsToolShortcutModifiers(event.modifierFlags),
+                  let key = event.charactersIgnoringModifiers,
+                  let tool = AnnotationToolShortcut.tool(for: key) else {
+                return event
+            }
+
+            currentTool?.wrappedValue = tool
+            return nil
+        }
+
+        private func allowsToolShortcutModifiers(_ flags: NSEvent.ModifierFlags) -> Bool {
+            let normalized = flags.intersection(.deviceIndependentFlagsMask)
+            let disallowed: NSEvent.ModifierFlags = [.command, .option, .control, .function]
+            return normalized.intersection(disallowed).isEmpty
+        }
+
+        private func isTextInputActive(in window: NSWindow?) -> Bool {
+            guard let responder = window?.firstResponder else { return false }
+            return responder is NSTextView
+                || responder is NSTextField
+                || responder is NSComboBox
+        }
+    }
+}
+
+extension View {
+    func annotationToolShortcuts(
+        currentTool: Binding<AnnotationTool>,
+        isEnabled: Bool
+    ) -> some View {
+        background(
+            AnnotationToolShortcutMonitor(
+                currentTool: currentTool,
+                isEnabled: isEnabled
+            )
+            .frame(width: 0, height: 0)
+        )
+    }
+}

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -72,20 +72,20 @@ struct AnnotationToolbar: View {
 
     private var toolGroup: some View {
         HStack(spacing: 4) {
-            toolButton(.select, icon: "cursorarrow", label: "Select")
-            toolButton(.arrow, icon: "arrow.up.right", label: "Arrow")
-            toolButton(.line, icon: "line.diagonal", label: "Line")
-            toolButton(.rectangle, icon: "rectangle", label: "Rectangle")
-            toolButton(.ellipse, icon: "circle", label: "Ellipse")
+            toolButton(.select, icon: "cursorarrow")
+            toolButton(.arrow, icon: "arrow.up.right")
+            toolButton(.line, icon: "line.diagonal")
+            toolButton(.rectangle, icon: "rectangle")
+            toolButton(.ellipse, icon: "circle")
             textToolButton
-            toolButton(.freehand, icon: "pencil.tip", label: "Draw")
-            toolButton(.pixelate, icon: "eye.slash.fill", label: "Pixelate / Blur")
-            toolButton(.counter, icon: "number.circle.fill", label: "Counter")
-            toolButton(.highlighter, icon: "highlighter", label: "Highlighter")
+            toolButton(.freehand, icon: "pencil.tip")
+            toolButton(.pixelate, icon: "eye.slash.fill")
+            toolButton(.counter, icon: "number.circle.fill")
+            toolButton(.highlighter, icon: "highlighter")
         }
     }
 
-    private func toolButton(_ tool: AnnotationTool, icon: String, label: LocalizedStringKey) -> some View {
+    private func toolButton(_ tool: AnnotationTool, icon: String) -> some View {
         Button(action: { currentTool = tool }) {
             Image(systemName: icon)
                 .font(.system(size: 14, weight: .medium))
@@ -96,7 +96,7 @@ struct AnnotationToolbar: View {
                 .overlay(toolbarButtonStroke)
         }
         .buttonStyle(.plain)
-        .help(label)
+        .help(tool.localizedShortcutHelpTitle)
     }
 
     /// Text-tool button. Rendered as a literal "Aa" glyph rather than the
@@ -118,7 +118,7 @@ struct AnnotationToolbar: View {
                 .overlay(toolbarButtonStroke)
         }
         .buttonStyle(.plain)
-        .help("Text")
+        .help(AnnotationTool.text.localizedShortcutHelpTitle)
     }
 
     private var colorGroup: some View {
@@ -351,6 +351,27 @@ struct AnnotationToolbar: View {
     private func actionButtonStroke(isPrimary: Bool) -> some View {
         RoundedRectangle(cornerRadius: 6, style: .continuous)
             .stroke(isPrimary ? Color.white.opacity(0.18) : Color.primary.opacity(0.08), lineWidth: 0.5)
+    }
+}
+
+extension AnnotationTool {
+    var localizedShortcutHelpTitle: String {
+        AnnotationToolShortcut.helpTitle(localizedToolName, for: self)
+    }
+
+    private var localizedToolName: String {
+        switch self {
+        case .select: return String(localized: "Select")
+        case .arrow: return String(localized: "Arrow")
+        case .line: return String(localized: "Line")
+        case .rectangle: return String(localized: "Rectangle")
+        case .ellipse: return String(localized: "Ellipse")
+        case .text: return String(localized: "Text")
+        case .freehand: return String(localized: "Draw")
+        case .pixelate: return String(localized: "Pixelate / Blur")
+        case .counter: return String(localized: "Counter")
+        case .highlighter: return String(localized: "Highlighter")
+        }
     }
 }
 

--- a/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
@@ -218,6 +218,7 @@ private struct InlineAnnotationEditorView: View {
         .onChange(of: textOutlineEnabled) { _, _ in updateSelectedStyle() }
         .onChange(of: textStrokeEnabled) { _, _ in updateSelectedStyle() }
         .onChange(of: redactionMode) { _, _ in updateSelectedStyle() }
+        .annotationToolShortcuts(currentTool: $currentTool, isEnabled: !isEditingText)
     }
 
     private var dimmingOverlay: some View {
@@ -691,7 +692,7 @@ private struct InlineAnnotationToolbar: View {
             .clipShape(RoundedRectangle(cornerRadius: 7))
         }
         .buttonStyle(.plain)
-        .help(helpText(for: tool))
+        .help(tool.localizedShortcutHelpTitle)
     }
 
     private func iconButton(
@@ -735,21 +736,6 @@ private struct InlineAnnotationToolbar: View {
         case .pixelate: return "eye.slash.fill"
         case .counter: return "number.circle.fill"
         case .highlighter: return "highlighter"
-        }
-    }
-
-    private func helpText(for tool: AnnotationTool) -> LocalizedStringKey {
-        switch tool {
-        case .select: return "Select"
-        case .arrow: return "Arrow"
-        case .line: return "Line"
-        case .rectangle: return "Rectangle"
-        case .ellipse: return "Ellipse"
-        case .text: return "Text"
-        case .freehand: return "Draw"
-        case .pixelate: return "Pixelate / Blur"
-        case .counter: return "Counter"
-        case .highlighter: return "Highlighter"
         }
     }
 

--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -152,6 +152,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         KeyboardShortcuts.onKeyDown(for: .captureAreaAndAnnotate) { [weak self] in
             self?.captureCoordinator?.captureAreaAndAnnotate()
         }
+        KeyboardShortcuts.onKeyDown(for: .editClipboardImage) { [weak self] in
+            self?.captureCoordinator?.editClipboardImage()
+        }
         KeyboardShortcuts.onKeyDown(for: .captureLastArea) { [weak self] in
             self?.captureCoordinator?.replayLastCapture()
         }
@@ -172,6 +175,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         KeyboardShortcuts.onKeyDown(for: .translateSelectedText) { [weak self] in
             self?.translationCoordinator?.translateSelectedText()
+        }
+        KeyboardShortcuts.onKeyDown(for: .translateTypedText) { [weak self] in
+            self?.translationCoordinator?.translateTypedText()
         }
     }
 

--- a/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
+++ b/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
@@ -592,11 +592,20 @@ private struct AllInOneAnnotationToolbarView: View {
     }
 
     var body: some View {
-        if session.usesMiniToolbar && !session.showsOverflow {
-            miniToolbar
-        } else {
-            adaptiveToolbar
+        Group {
+            if session.usesMiniToolbar && !session.showsOverflow {
+                miniToolbar
+            } else {
+                adaptiveToolbar
+            }
         }
+        .annotationToolShortcuts(
+            currentTool: Binding(
+                get: { session.currentTool },
+                set: { session.switchTool($0) }
+            ),
+            isEnabled: !session.isEditingText
+        )
     }
 
     private var adaptiveToolbar: some View {
@@ -1139,7 +1148,7 @@ private struct AllInOneAnnotationToolbarView: View {
         }
         .buttonStyle(.plain)
         .onHover { hoveredTool = $0 ? tool : nil }
-        .help(helpText(for: tool))
+        .help(tool.localizedShortcutHelpTitle)
     }
 
     private func iconButton(
@@ -1181,21 +1190,6 @@ private struct AllInOneAnnotationToolbarView: View {
         case .pixelate: return "eye.slash.fill"
         case .counter: return "number.circle.fill"
         case .highlighter: return "highlighter"
-        }
-    }
-
-    private func helpText(for tool: AnnotationTool) -> LocalizedStringKey {
-        switch tool {
-        case .select: return "Select"
-        case .arrow: return "Arrow"
-        case .line: return "Line"
-        case .rectangle: return "Rectangle"
-        case .ellipse: return "Ellipse"
-        case .text: return "Text"
-        case .freehand: return "Draw"
-        case .pixelate: return "Pixelate / Blur"
-        case .counter: return "Counter"
-        case .highlighter: return "Highlighter"
         }
     }
 

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -33,6 +33,7 @@ final class CaptureCoordinator {
     private var scrollCaptureController: ScrollCaptureController?
     private var scrollCaptureOverlay: ScrollCaptureOverlay?
     private var selfTimerHUD: SelfTimerHUD?
+    private var toastWindow: ToastWindow?
 
     var lastCaptureResult: CaptureResult?
     var ocrCoordinator: OCRCoordinator?
@@ -154,6 +155,28 @@ final class CaptureCoordinator {
     func captureAreaAndAnnotate() {
         pendingAction = .annotate
         startAreaCapture()
+    }
+
+    func editClipboardImage() {
+        guard let image = ClipboardImageReader.image() else {
+            showToast(
+                String(localized: "No image found on clipboard"),
+                icon: "photo.on.rectangle.angled",
+                iconColor: .systemYellow
+            )
+            return
+        }
+
+        let screen = NSScreen.screens.first { NSMouseInRect(NSEvent.mouseLocation, $0.frame, false) }
+            ?? NSScreen.main
+        let result = CaptureResult(
+            image: image,
+            mode: .area,
+            captureRect: CGRect(x: 0, y: 0, width: image.width, height: image.height),
+            appName: String(localized: "Clipboard"),
+            displayID: screen?.displayID ?? CGMainDisplayID()
+        )
+        openAnnotationEditor(result, anchorScreen: screen)
     }
 
     func captureAreaAndShare() {
@@ -1604,6 +1627,17 @@ final class CaptureCoordinator {
 
     private func copyRenderedImage(_ image: CGImage) {
         copyImageToClipboard(image)
+    }
+
+    private func showToast(
+        _ message: String,
+        icon: String = "checkmark.circle.fill",
+        iconColor: NSColor = .systemGreen,
+        screen: NSScreen? = nil
+    ) {
+        toastWindow?.close()
+        toastWindow = ToastWindow(message: message, icon: icon, iconColor: iconColor, screen: screen)
+        toastWindow?.show()
     }
 
     // MARK: - Cloud Share Upload

--- a/App/Sources/MenuBar/MenuBarController.swift
+++ b/App/Sources/MenuBar/MenuBarController.swift
@@ -89,6 +89,11 @@ final class MenuBarController: NSObject {
         captureWindow.setShortcut(for: .captureWindow)
         menu.addItem(captureWindow)
 
+        let editClipboardImage = menuItem(String(localized: "Edit Clipboard Image"), action: #selector(editClipboardImage))
+        editClipboardImage.setShortcut(for: .editClipboardImage)
+        editClipboardImage.toolTip = String(localized: "Open the image currently copied to the clipboard in Annotate")
+        menu.addItem(editClipboardImage)
+
         menu.addItem(.separator())
 
         let captureText = menuItem(String(localized: "Capture Text (OCR)"), action: #selector(captureText))
@@ -102,6 +107,10 @@ final class MenuBarController: NSObject {
         let translateSelectedText = menuItem(String(localized: "Translate Selected Text"), action: #selector(self.translateSelectedText))
         translateSelectedText.setShortcut(for: .translateSelectedText)
         menu.addItem(translateSelectedText)
+
+        let translateTypedText = menuItem(String(localized: "Translate Typed Text"), action: #selector(self.translateTypedText))
+        translateTypedText.setShortcut(for: .translateTypedText)
+        menu.addItem(translateTypedText)
 
         let captureScrolling = menuItem(String(localized: "Scrolling Capture"), action: #selector(captureScrolling))
         captureScrolling.setShortcut(for: .captureScrolling)
@@ -182,6 +191,10 @@ final class MenuBarController: NSObject {
         captureCoordinator.captureWindow()
     }
 
+    @objc private func editClipboardImage() {
+        captureCoordinator.editClipboardImage()
+    }
+
     @objc private func captureText() {
         ocrCoordinator.startInstantOCR()
     }
@@ -192,6 +205,10 @@ final class MenuBarController: NSObject {
 
     @objc private func translateSelectedText() {
         translationCoordinator.translateSelectedText()
+    }
+
+    @objc private func translateTypedText() {
+        translationCoordinator.translateTypedText()
     }
 
     @objc private func captureScrolling() {
@@ -235,9 +252,11 @@ extension MenuBarController: NSMenuDelegate {
             case #selector(captureArea): item.setShortcut(for: .captureArea)
             case #selector(captureFullscreen): item.setShortcut(for: .captureFullscreen)
             case #selector(captureWindow): item.setShortcut(for: .captureWindow)
+            case #selector(editClipboardImage): item.setShortcut(for: .editClipboardImage)
             case #selector(captureText): item.setShortcut(for: .captureText)
             case #selector(captureAndTranslate): item.setShortcut(for: .captureAndTranslate)
             case #selector(translateSelectedText): item.setShortcut(for: .translateSelectedText)
+            case #selector(translateTypedText): item.setShortcut(for: .translateTypedText)
             case #selector(recordScreen): item.setShortcut(for: .recordScreen)
             case #selector(captureScrolling): item.setShortcut(for: .captureScrolling)
             case #selector(captureSelfTimer):

--- a/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
@@ -13,9 +13,11 @@ extension KeyboardShortcuts.Name {
     static let captureAreaToClipboard = Self("captureAreaToClipboard", default: .init(.seven, modifiers: [.option, .shift]))
     static let captureAreaAndShare = Self("captureAreaAndShare", default: .init(.zero, modifiers: [.option, .shift]))
     static let captureAreaAndAnnotate = Self("captureAreaAndAnnotate", default: .init(.eight, modifiers: [.option, .shift]))
+    static let editClipboardImage = Self("editClipboardImage")
     static let screenshotHistory = Self("screenshotHistory", default: .init(.nine, modifiers: [.option, .shift]))
     static let captureAndTranslate = Self("captureAndTranslate", default: .init(.t, modifiers: [.option, .shift]))
     static let translateSelectedText = Self("translateSelectedText", default: .init(.y, modifiers: [.option, .shift]))
+    static let translateTypedText = Self("translateTypedText")
     /// No default binding — opt-in. Self-Timer is discoverable from the
     /// menu bar; shipping a default risks colliding with whatever the user
     /// has already bound in macOS or third-party apps.
@@ -78,8 +80,15 @@ struct ShortcutSettingsView: View {
                     shortcutRow("Capture Area to Clipboard", name: .captureAreaToClipboard, showDivider: true)
                     shortcutRow("Capture and Share to Cloud", name: .captureAreaAndShare, showDivider: true)
                     shortcutRow("Capture Area & Annotate", name: .captureAreaAndAnnotate, showDivider: true)
+                    shortcutRow(
+                        "Edit Clipboard Image",
+                        name: .editClipboardImage,
+                        showDivider: true,
+                        help: "Open the image currently copied to the clipboard in Annotate"
+                    )
                     shortcutRow("Capture & Translate", name: .captureAndTranslate, showDivider: true)
                     shortcutRow("Translate Selected Text", name: .translateSelectedText, showDivider: true)
+                    shortcutRow("Translate Typed Text", name: .translateTypedText, showDivider: true)
                     shortcutRow("Capture Previous Area", name: .captureLastArea, showDivider: true)
                     shortcutRow("Start / Stop Recording", name: .recordScreen, showDivider: true)
                     shortcutRow("Screenshot History", name: .screenshotHistory)
@@ -96,10 +105,22 @@ struct ShortcutSettingsView: View {
         }
     }
 
-    private func shortcutRow(_ label: LocalizedStringKey, name: KeyboardShortcuts.Name, showDivider: Bool = false) -> some View {
-        SettingRow(label: label, showDivider: showDivider) {
+    @ViewBuilder
+    private func shortcutRow(
+        _ label: LocalizedStringKey,
+        name: KeyboardShortcuts.Name,
+        showDivider: Bool = false,
+        help: LocalizedStringKey? = nil
+    ) -> some View {
+        let row = SettingRow(label: label, showDivider: showDivider) {
             KeyboardShortcuts.Recorder(for: name)
                 .controlSize(.small)
+        }
+
+        if let help {
+            row.help(help)
+        } else {
+            row
         }
     }
 

--- a/App/Sources/Translation/TranslationCoordinator.swift
+++ b/App/Sources/Translation/TranslationCoordinator.swift
@@ -18,6 +18,7 @@ final class TranslationCoordinator {
     private let settings: AppSettings
     private var overlayWindows: [CaptureOverlayWindow] = []
     private var onboardingWindow: TranslationOnboardingWindow?
+    private var typedInputWindow: TypedTranslationInputWindow?
     private var resultWindow: TranslationResultWindow?
     private var toastWindow: ToastWindow?
 
@@ -41,6 +42,24 @@ final class TranslationCoordinator {
         } else {
             beginSelectedTextFlow()
         }
+    }
+
+    func translateTypedText() {
+        typedInputWindow?.close()
+        let window = TypedTranslationInputWindow(
+            onSubmit: { [weak self] text in
+                self?.submitTypedText(text)
+            },
+            onCancel: { [weak self] in
+                self?.typedInputWindow?.close()
+                self?.typedInputWindow = nil
+            },
+            onClose: { [weak self] in
+                self?.typedInputWindow = nil
+            }
+        )
+        typedInputWindow = window
+        window.show()
     }
 
     /// - Parameter anchorScreen: The screen where the capture came from.
@@ -215,6 +234,22 @@ final class TranslationCoordinator {
                 anchor: anchor,
                 anchorScreen: screen
             )
+        }
+    }
+
+    private func submitTypedText(_ text: String) {
+        do {
+            let region = try TypedTranslationInput(rawText: text).makeTextRegion()
+            typedInputWindow?.close()
+            typedInputWindow = nil
+            showLoadingResult(
+                regions: [region],
+                target: settings.translationTargetLanguage,
+                anchor: nil,
+                anchorScreen: NSScreen.main
+            )
+        } catch {
+            showToast(error.localizedDescription, icon: "text.cursor", iconColor: .systemYellow)
         }
     }
 

--- a/App/Sources/Translation/TranslationResultView.swift
+++ b/App/Sources/Translation/TranslationResultView.swift
@@ -189,23 +189,33 @@ struct TranslationResultView: View {
 
                 if showOriginal {
                     // ORIGINAL (collapsible)
-                    Button(action: toggleOriginal) {
-                        HStack(spacing: 8) {
-                            Text("ORIGINAL")
-                                .font(.system(size: 10, weight: .semibold))
-                                .foregroundStyle(.tertiary)
-                                .tracking(1.0)
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                                .font(.system(size: 9, weight: .semibold))
-                                .foregroundStyle(.tertiary)
-                                .rotationEffect(.degrees(originalExpanded ? 90 : 0))
+                    HStack(spacing: 8) {
+                        Button(action: toggleOriginal) {
+                            HStack(spacing: 8) {
+                                Text("ORIGINAL")
+                                    .font(.system(size: 10, weight: .semibold))
+                                    .foregroundStyle(.tertiary)
+                                    .tracking(1.0)
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 9, weight: .semibold))
+                                    .foregroundStyle(.tertiary)
+                                    .rotationEffect(.degrees(originalExpanded ? 90 : 0))
+                            }
+                            .contentShape(Rectangle())
                         }
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 10)
-                        .contentShape(Rectangle())
+                        .buttonStyle(.plain)
+                        .frame(maxWidth: .infinity)
+
+                        Button(action: { copyText(region.original.text) }) {
+                            Image(systemName: "doc.on.doc")
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(.tertiary)
+                        .help("Copy original")
                     }
-                    .buttonStyle(.plain)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
 
                     if originalExpanded {
                         renderedText(
@@ -528,9 +538,13 @@ struct TranslationResultView: View {
 
     private func copyCurrent() {
         guard case .done(let regions) = phase, let region = regions.first else { return }
+        copyText(region.translation)
+    }
+
+    private func copyText(_ text: String) {
         let pb = NSPasteboard.general
         pb.clearContents()
-        pb.setString(region.translation, forType: .string)
+        pb.setString(text, forType: .string)
 
         // Show a brief "Copied" feedback so manual copy doesn't feel silent.
         // When `autoCopy` is on, the indicator is already visible; this still

--- a/App/Sources/Translation/TypedTranslationInputWindow.swift
+++ b/App/Sources/Translation/TypedTranslationInputWindow.swift
@@ -1,0 +1,128 @@
+import AppKit
+import SwiftUI
+import TranslationKit
+
+@MainActor
+final class TypedTranslationInputWindow: NSPanel {
+    private var onCloseAction: (() -> Void)?
+
+    init(
+        onSubmit: @escaping (String) -> Void,
+        onCancel: @escaping () -> Void,
+        onClose: @escaping () -> Void
+    ) {
+        self.onCloseAction = onClose
+
+        let screen = NSScreen.screens.first { NSMouseInRect(NSEvent.mouseLocation, $0.frame, false) }
+            ?? NSScreen.main
+            ?? NSScreen.screens.first
+        let visible = screen?.visibleFrame ?? NSRect(x: 0, y: 0, width: 900, height: 700)
+        let size = NSSize(width: 460, height: 300)
+        let frame = NSRect(
+            x: visible.midX - size.width / 2,
+            y: visible.midY - size.height / 2,
+            width: size.width,
+            height: size.height
+        )
+
+        super.init(
+            contentRect: frame,
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+
+        title = String(localized: "Translate Text")
+        titleVisibility = .hidden
+        titlebarAppearsTransparent = true
+        isMovableByWindowBackground = true
+        isReleasedWhenClosed = false
+        level = .floating
+        hidesOnDeactivate = false
+        collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+
+        contentView = NSHostingView(
+            rootView: TypedTranslationInputView(
+                onSubmit: onSubmit,
+                onCancel: onCancel
+            )
+        )
+    }
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+
+    func show() {
+        NSApp.activate(ignoringOtherApps: true)
+        makeKeyAndOrderFront(nil)
+    }
+
+    override func close() {
+        onCloseAction?()
+        onCloseAction = nil
+        super.close()
+    }
+}
+
+private struct TypedTranslationInputView: View {
+    @State private var text = ""
+    @FocusState private var textEditorFocused: Bool
+
+    let onSubmit: (String) -> Void
+    let onCancel: () -> Void
+
+    private var input: TypedTranslationInput {
+        TypedTranslationInput(rawText: text)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 8) {
+                Image(systemName: "text.bubble")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(.tint)
+                Text("Translate Text")
+                    .font(.system(size: 18, weight: .semibold))
+                Spacer()
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Original")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                TextEditor(text: $text)
+                    .font(.system(size: 14))
+                    .scrollContentBackground(.hidden)
+                    .padding(8)
+                    .focused($textEditorFocused)
+                    .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.primary.opacity(0.10), lineWidth: 0.5)
+                    )
+            }
+
+            HStack(spacing: 10) {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button(action: submit) {
+                    Label("Translate", systemImage: "arrow.right.circle.fill")
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.return, modifiers: .command)
+                .disabled(!input.canSubmit)
+            }
+        }
+        .padding(20)
+        .frame(width: 460, height: 300)
+        .onAppear {
+            textEditorFocused = true
+        }
+    }
+
+    private func submit() {
+        guard input.canSubmit else { return }
+        onSubmit(text)
+    }
+}

--- a/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationToolShortcut.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationToolShortcut.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+public enum AnnotationToolShortcut {
+    private static let shortcuts: [String: AnnotationTool] = [
+        "s": .select,
+        "a": .arrow,
+        "l": .line,
+        "r": .rectangle,
+        "e": .ellipse,
+        "o": .ellipse,
+        "t": .text,
+        "d": .freehand,
+        "f": .freehand,
+        "p": .pixelate,
+        "b": .pixelate,
+        "c": .counter,
+        "n": .counter,
+        "h": .highlighter,
+    ]
+
+    private static let displayKeys: [AnnotationTool: String] = [
+        .select: "S",
+        .arrow: "A",
+        .line: "L",
+        .rectangle: "R",
+        .ellipse: "E",
+        .text: "T",
+        .freehand: "D",
+        .pixelate: "P",
+        .counter: "C",
+        .highlighter: "H",
+    ]
+
+    public static func tool(for key: String) -> AnnotationTool? {
+        guard key.count == 1 else { return nil }
+        return shortcuts[key.lowercased()]
+    }
+
+    public static func displayKey(for tool: AnnotationTool) -> String? {
+        displayKeys[tool]
+    }
+
+    public static func helpTitle(_ title: String, for tool: AnnotationTool) -> String {
+        guard let key = displayKey(for: tool) else { return title }
+        return "\(title) (\(key))"
+    }
+}

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationToolShortcutTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationToolShortcutTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import AnnotationKit
+
+@Suite("AnnotationToolShortcut")
+struct AnnotationToolShortcutTests {
+    @Test("maps requested annotation tool shortcuts")
+    func mapsRequestedToolShortcuts() {
+        #expect(AnnotationToolShortcut.tool(for: "s") == .select)
+        #expect(AnnotationToolShortcut.tool(for: "a") == .arrow)
+        #expect(AnnotationToolShortcut.tool(for: "t") == .text)
+        #expect(AnnotationToolShortcut.tool(for: "l") == .line)
+    }
+
+    @Test("maps every annotation tool to at least one shortcut")
+    func mapsEveryTool() {
+        let shortcuts: [String: AnnotationTool] = [
+            "s": .select,
+            "a": .arrow,
+            "l": .line,
+            "r": .rectangle,
+            "e": .ellipse,
+            "t": .text,
+            "d": .freehand,
+            "p": .pixelate,
+            "c": .counter,
+            "h": .highlighter,
+        ]
+
+        for (key, tool) in shortcuts {
+            #expect(AnnotationToolShortcut.tool(for: key) == tool)
+            #expect(AnnotationToolShortcut.displayKey(for: tool) != nil)
+        }
+    }
+
+    @Test("supports intuitive aliases")
+    func supportsAliases() {
+        #expect(AnnotationToolShortcut.tool(for: "o") == .ellipse)
+        #expect(AnnotationToolShortcut.tool(for: "f") == .freehand)
+        #expect(AnnotationToolShortcut.tool(for: "b") == .pixelate)
+        #expect(AnnotationToolShortcut.tool(for: "n") == .counter)
+    }
+
+    @Test("formats discoverable help titles with shortcut keys")
+    func formatsHelpTitlesWithShortcutKeys() {
+        #expect(AnnotationToolShortcut.helpTitle("Arrow", for: .arrow) == "Arrow (A)")
+        #expect(AnnotationToolShortcut.helpTitle("Pixelate / Blur", for: .pixelate) == "Pixelate / Blur (P)")
+    }
+
+    @Test("is case insensitive and ignores unknown keys")
+    func handlesCaseAndUnknownKeys() {
+        #expect(AnnotationToolShortcut.tool(for: "A") == .arrow)
+        #expect(AnnotationToolShortcut.tool(for: " ") == nil)
+        #expect(AnnotationToolShortcut.tool(for: "save") == nil)
+    }
+}

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ClipboardImageReader.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ClipboardImageReader.swift
@@ -1,0 +1,40 @@
+import AppKit
+import CoreGraphics
+
+public enum ClipboardImageReader {
+    public static func image(from pasteboard: NSPasteboard = .general) -> CGImage? {
+        fileURLImage(from: pasteboard)
+            ?? objectImage(from: pasteboard)
+            ?? dataImage(from: pasteboard)
+    }
+
+    private static func fileURLImage(from pasteboard: NSPasteboard) -> CGImage? {
+        let options: [NSPasteboard.ReadingOptionKey: Any] = [
+            .urlReadingFileURLsOnly: true
+        ]
+        let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: options) as? [URL]
+        guard let url = urls?.first(where: { $0.isFileURL }),
+              let image = NSImage(contentsOf: url) else {
+            return nil
+        }
+        return ImageUtilities.cgImage(from: image)
+    }
+
+    private static func objectImage(from pasteboard: NSPasteboard) -> CGImage? {
+        let images = pasteboard.readObjects(forClasses: [NSImage.self], options: nil) as? [NSImage]
+        guard let image = images?.first else { return nil }
+        return ImageUtilities.cgImage(from: image)
+    }
+
+    private static func dataImage(from pasteboard: NSPasteboard) -> CGImage? {
+        for type in [NSPasteboard.PasteboardType.png, .tiff] {
+            guard let data = pasteboard.data(forType: type),
+                  let image = NSImage(data: data),
+                  let cgImage = ImageUtilities.cgImage(from: image) else {
+                continue
+            }
+            return cgImage
+        }
+        return nil
+    }
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/ClipboardImageReaderTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ClipboardImageReaderTests.swift
@@ -1,0 +1,65 @@
+import AppKit
+import Testing
+@testable import SharedKit
+
+@Suite("ClipboardImageReader")
+struct ClipboardImageReaderTests {
+    @Test("reads image objects from the pasteboard")
+    func readsImageObjects() throws {
+        let pasteboard = makePasteboard()
+        let image = try makeImage(width: 7, height: 5)
+        pasteboard.writeObjects([ImageUtilities.nsImage(from: image)])
+
+        let result = try #require(ClipboardImageReader.image(from: pasteboard))
+
+        #expect(result.width == 7)
+        #expect(result.height == 5)
+    }
+
+    @Test("reads image file URLs from the pasteboard")
+    func readsImageFileURLs() throws {
+        let pasteboard = makePasteboard()
+        let image = try makeImage(width: 9, height: 4)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-clipboard-\(UUID().uuidString)")
+            .appendingPathExtension("png")
+        try #require(ImageUtilities.pngData(from: image)).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+        pasteboard.writeObjects([url as NSURL])
+
+        let result = try #require(ClipboardImageReader.image(from: pasteboard))
+
+        #expect(result.width == 9)
+        #expect(result.height == 4)
+    }
+
+    @Test("returns nil when the pasteboard has no image")
+    func returnsNilWithoutImage() throws {
+        let pasteboard = makePasteboard()
+        pasteboard.setString("not an image", forType: .string)
+
+        #expect(ClipboardImageReader.image(from: pasteboard) == nil)
+    }
+
+    private func makePasteboard() -> NSPasteboard {
+        let name = NSPasteboard.Name("CapsoClipboardImageReaderTests.\(UUID().uuidString)")
+        let pasteboard = NSPasteboard(name: name)
+        pasteboard.clearContents()
+        return pasteboard
+    }
+
+    private func makeImage(width: Int, height: Int) throws -> CGImage {
+        let context = try #require(CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(CGColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return try #require(context.makeImage())
+    }
+}

--- a/Packages/TranslationKit/Sources/TranslationKit/TypedTranslationInput.swift
+++ b/Packages/TranslationKit/Sources/TranslationKit/TypedTranslationInput.swift
@@ -1,0 +1,35 @@
+import Foundation
+import CoreGraphics
+import OCRKit
+
+public enum TypedTranslationInputError: LocalizedError, Sendable {
+    case empty
+
+    public var errorDescription: String? {
+        switch self {
+        case .empty:
+            String(localized: "No text to translate.")
+        }
+    }
+}
+
+public struct TypedTranslationInput: Sendable {
+    public let rawText: String
+
+    public init(rawText: String) {
+        self.rawText = rawText
+    }
+
+    public var translationText: String {
+        rawText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public var canSubmit: Bool {
+        !translationText.isEmpty
+    }
+
+    public func makeTextRegion() throws -> TextRegion {
+        guard canSubmit else { throw TypedTranslationInputError.empty }
+        return TextRegion(text: translationText, boundingBox: .zero, confidence: 1)
+    }
+}

--- a/Packages/TranslationKit/Tests/TranslationKitTests/TypedTranslationInputTests.swift
+++ b/Packages/TranslationKit/Tests/TranslationKitTests/TypedTranslationInputTests.swift
@@ -1,0 +1,31 @@
+import CoreGraphics
+import Testing
+@testable import TranslationKit
+
+@Suite("TypedTranslationInput")
+struct TypedTranslationInputTests {
+    @Test("trims outer whitespace while preserving typed line breaks")
+    func trimmedTextPreservesLineBreaks() throws {
+        let input = TypedTranslationInput(rawText: "  Hello\nworld  \n")
+
+        #expect(input.translationText == "Hello\nworld")
+        #expect(input.canSubmit)
+    }
+
+    @Test("blank input cannot be submitted")
+    func blankInputCannotSubmit() {
+        let input = TypedTranslationInput(rawText: " \n\t ")
+
+        #expect(input.translationText == "")
+        #expect(!input.canSubmit)
+    }
+
+    @Test("creates a text region from typed input")
+    func createsTextRegion() throws {
+        let region = try TypedTranslationInput(rawText: "  Bonjour  ").makeTextRegion()
+
+        #expect(region.text == "Bonjour")
+        #expect(region.boundingBox == CGRect.zero)
+        #expect(region.confidence == 1)
+    }
+}


### PR DESCRIPTION
## Summary

- Add a typed-text translation flow with a floating input window and original-text copy support in translation results.
- Add an Edit Clipboard Image command that opens copied images in the annotation editor.
- Add annotation tool keyboard shortcuts across annotation entry points and surface them through hover tooltips.
- Add localization coverage for the new menu, settings, tooltip, and error strings.

Closes #166
Closes #172
Closes #173

## Validation

- `swift test --package-path Packages/AnnotationKit`
- `swift test --package-path Packages/SharedKit`
- `swift test --package-path Packages/TranslationKit`
- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build`
- `git diff --cached --check` before commit

## Notes

- `Edit Clipboard Image` is intentionally unbound by default and can be assigned in Settings > Shortcuts.
- Annotation tool shortcuts are active only while an annotation surface is focused and text editing is not active.
