### PR TITLE
feat: add counter edit controls

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -7,6 +7,7 @@ import AnnotationKit
 private enum ResizeHandle {
     case topLeft, topRight, bottomLeft, bottomRight
     case pathStart, pathEnd, pathControl
+    case counterTip
 
     var textResizeHandle: TextResizeHandle? {
         switch self {
@@ -18,10 +19,16 @@ private enum ResizeHandle {
             .bottomLeft
         case .bottomRight:
             .bottomRight
-        case .pathStart, .pathEnd, .pathControl:
+        case .pathStart, .pathEnd, .pathControl, .counterTip:
             nil
         }
     }
+}
+
+private enum SelectionAction {
+    case delete
+    case incrementCounter
+    case decrementCounter
 }
 
 private protocol PathEditableAnnotation: AnnotationObject {
@@ -154,6 +161,10 @@ final class AnnotationCanvasNSView: NSView {
     // MARK: - Handle Hit Testing
 
     private func handleHitTest(point: CGPoint, object: any AnnotationObject) -> ResizeHandle? {
+        if let counter = object as? CounterObject {
+            return counterHandleHitTest(point: point, counter: counter)
+        }
+
         if let pathObject = object as? any PathEditableAnnotation {
             return pathHandleHitTest(point: point, object: pathObject)
         }
@@ -163,6 +174,15 @@ final class AnnotationCanvasNSView: NSView {
             if hypot(point.x - corner.x, point.y - corner.y) <= r {
                 return handle
             }
+        }
+        return nil
+    }
+
+    private func counterHandleHitTest(point: CGPoint, counter: CounterObject) -> ResizeHandle? {
+        let r = max(10 / max(zoomScale, 0.1), handleRadius + 4)
+        let center = counterTipHandleCenter(for: counter)
+        if hypot(point.x - center.x, point.y - center.y) <= r {
+            return .counterTip
         }
         return nil
     }
@@ -243,7 +263,7 @@ final class AnnotationCanvasNSView: NSView {
     private func cursorForHandle(_ handle: ResizeHandle) -> NSCursor {
         let symbolName: String
         switch handle {
-        case .pathStart, .pathEnd, .pathControl:
+        case .pathStart, .pathEnd, .pathControl, .counterTip:
             return NSCursor.openHand
         case .topLeft, .bottomRight:
             // ↖↘ diagonal
@@ -302,6 +322,8 @@ final class AnnotationCanvasNSView: NSView {
             if let selected = doc.selectedObject {
                 if let text = selected as? TextObject, text === editingOriginalObject {
                     // The live inline editor draws matching selection chrome below.
+                } else if let counter = selected as? CounterObject {
+                    drawCounterSelectionChrome(ctx: ctx, counter: counter)
                 } else if let pathObject = selected as? any PathEditableAnnotation {
                     drawPathSelectionHandles(ctx: ctx, object: pathObject)
                 } else {
@@ -311,7 +333,7 @@ final class AnnotationCanvasNSView: NSView {
 
             if let start = dragStart, let current = dragCurrent,
                isDragging, activeResizeHandle == nil,
-               currentTool != .select, currentTool != .freehand, currentTool != .text, currentTool != .counter, currentTool != .highlighter {
+               currentTool != .select, currentTool != .freehand, currentTool != .text, currentTool != .highlighter {
                 drawPreview(ctx: ctx, from: start, to: current)
             }
         }
@@ -418,6 +440,50 @@ final class AnnotationCanvasNSView: NSView {
         ctx.restoreGState()
     }
 
+    private func drawCounterSelectionChrome(ctx: CGContext, counter: CounterObject) {
+        drawSelectionHandles(ctx: ctx, bounds: counter.bounds)
+
+        ctx.saveGState()
+        let scale = max(zoomScale, 0.1)
+        let handleSize: CGFloat = 8 / scale
+        let lw: CGFloat = 1.5 / scale
+        let accent = NSColor.controlAccentColor.withAlphaComponent(0.9).cgColor
+        let fill = NSColor.white.withAlphaComponent(0.92).cgColor
+        let tipCenter = counterTipHandleCenter(for: counter)
+
+        if !counter.hasArrow {
+            ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.36).cgColor)
+            ctx.setLineWidth(1 / scale)
+            ctx.setLineDash(phase: 0, lengths: [3 / scale, 4 / scale])
+            ctx.move(to: counter.center)
+            ctx.addLine(to: tipCenter)
+            ctx.strokePath()
+            ctx.setLineDash(phase: 0, lengths: [])
+        }
+
+        let tipRect = CGRect(
+            x: tipCenter.x - handleSize / 2,
+            y: tipCenter.y - handleSize / 2,
+            width: handleSize,
+            height: handleSize
+        )
+        ctx.setFillColor(fill)
+        ctx.fillEllipse(in: tipRect)
+        ctx.setStrokeColor(accent)
+        ctx.setLineWidth(lw)
+        ctx.strokeEllipse(in: tipRect.insetBy(dx: lw / 2, dy: lw / 2))
+
+        drawActionButton(ctx: ctx, rect: counterDeleteButtonRect(for: counter), kind: .xmark)
+        drawActionButton(
+            ctx: ctx,
+            rect: counterStepButtonRect(for: counter, increment: false),
+            kind: .minus,
+            enabled: counter.number > 1
+        )
+        drawActionButton(ctx: ctx, rect: counterStepButtonRect(for: counter, increment: true), kind: .plus)
+        ctx.restoreGState()
+    }
+
     private func pathHandleCenters(for object: any PathEditableAnnotation) -> [(ResizeHandle, CGPoint)] {
         [
             (.pathStart, object.start),
@@ -428,6 +494,14 @@ final class AnnotationCanvasNSView: NSView {
 
     private func pathMidpoint(_ object: any PathEditableAnnotation) -> CGPoint {
         CGPoint(x: (object.start.x + object.end.x) / 2, y: (object.start.y + object.end.y) / 2)
+    }
+
+    private func counterTipHandleCenter(for counter: CounterObject) -> CGPoint {
+        if let tip = counter.tip {
+            return tip
+        }
+        let offset = counter.radius + CounterObject.arrowClearance + 4 / max(zoomScale, 0.1)
+        return CGPoint(x: counter.center.x, y: counter.center.y - offset)
     }
 
     private func drawSelectionHandles(ctx: CGContext, bounds: CGRect) {
@@ -474,6 +548,88 @@ final class AnnotationCanvasNSView: NSView {
         ]
     }
 
+    private func counterDeleteButtonRect(for counter: CounterObject) -> CGRect {
+        let scale = max(zoomScale, 0.1)
+        let size = 22 / scale
+        let frame = selectionFrame(for: counter.bounds)
+        return CGRect(
+            x: frame.maxX + 5 / scale,
+            y: frame.minY - size / 2,
+            width: size,
+            height: size
+        )
+    }
+
+    private func counterStepButtonRect(for counter: CounterObject, increment: Bool) -> CGRect {
+        let scale = max(zoomScale, 0.1)
+        let size = 20 / scale
+        let gap = 4 / scale
+        let centerX = increment
+            ? counter.center.x + gap / 2 + size / 2
+            : counter.center.x - gap / 2 - size / 2
+        let centerY = counter.center.y + counter.radius + 8 / scale + size / 2
+        return CGRect(x: centerX - size / 2, y: centerY - size / 2, width: size, height: size)
+    }
+
+    private enum CounterActionButtonKind {
+        case xmark, plus, minus
+    }
+
+    private func drawActionButton(
+        ctx: CGContext,
+        rect: CGRect,
+        kind: CounterActionButtonKind,
+        enabled: Bool = true
+    ) {
+        let scale = max(zoomScale, 0.1)
+        let alpha: CGFloat = enabled ? 1 : 0.4
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let radius = rect.width / 2
+
+        ctx.saveGState()
+        ctx.setFillColor(NSColor(white: 0.12, alpha: 0.94 * alpha).cgColor)
+        ctx.fillEllipse(in: rect)
+        ctx.setStrokeColor(NSColor.controlAccentColor.withAlphaComponent(0.9 * alpha).cgColor)
+        ctx.setLineWidth(1.4 / scale)
+        ctx.strokeEllipse(in: rect.insetBy(dx: 0.7 / scale, dy: 0.7 / scale))
+        ctx.setStrokeColor(NSColor.white.withAlphaComponent(0.96 * alpha).cgColor)
+        ctx.setLineWidth(1.7 / scale)
+        ctx.setLineCap(.round)
+
+        let glyph = radius * 0.42
+        switch kind {
+        case .xmark:
+            ctx.move(to: CGPoint(x: center.x - glyph, y: center.y - glyph))
+            ctx.addLine(to: CGPoint(x: center.x + glyph, y: center.y + glyph))
+            ctx.move(to: CGPoint(x: center.x + glyph, y: center.y - glyph))
+            ctx.addLine(to: CGPoint(x: center.x - glyph, y: center.y + glyph))
+        case .plus:
+            ctx.move(to: CGPoint(x: center.x - glyph, y: center.y))
+            ctx.addLine(to: CGPoint(x: center.x + glyph, y: center.y))
+            ctx.move(to: CGPoint(x: center.x, y: center.y - glyph))
+            ctx.addLine(to: CGPoint(x: center.x, y: center.y + glyph))
+        case .minus:
+            ctx.move(to: CGPoint(x: center.x - glyph, y: center.y))
+            ctx.addLine(to: CGPoint(x: center.x + glyph, y: center.y))
+        }
+
+        ctx.strokePath()
+        ctx.restoreGState()
+    }
+
+    private func counterSelectionAction(at point: CGPoint, counter: CounterObject) -> SelectionAction? {
+        if counterDeleteButtonRect(for: counter).contains(point) {
+            return .delete
+        }
+        if counterStepButtonRect(for: counter, increment: false).contains(point) {
+            return .decrementCounter
+        }
+        if counterStepButtonRect(for: counter, increment: true).contains(point) {
+            return .incrementCounter
+        }
+        return nil
+    }
+
     private func liveTextHandleCenters(boxFrame: CGRect) -> [(ResizeHandle, CGPoint)] {
         [
             (.topLeft, CGPoint(x: boxFrame.minX, y: boxFrame.minY)),
@@ -508,9 +664,18 @@ final class AnnotationCanvasNSView: NSView {
         case .rectangle: ctx.stroke(rect)
         case .ellipse: ctx.strokeEllipse(in: rect)
         case .pixelate: ctx.setFillColor(CGColor(gray: 0.5, alpha: 0.3)); ctx.fill(rect)
+        case .counter:
+            let tip = counterTip(from: start, to: end, radius: currentStyle.lineWidth)
+            CounterObject(center: start, tip: tip, number: nextCounterNumber(), radius: currentStyle.lineWidth, style: currentStyle)
+                .render(in: ctx)
         default: break
         }
         ctx.restoreGState()
+    }
+
+    private func counterTip(from start: CGPoint, to end: CGPoint, radius: CGFloat) -> CGPoint? {
+        let distance = hypot(end.x - start.x, end.y - start.y)
+        return distance >= radius + CounterObject.arrowClearance ? end : nil
     }
 
     // MARK: - Mouse Handling
@@ -555,6 +720,30 @@ final class AnnotationCanvasNSView: NSView {
         resizeOriginalFreehandPoints = nil
         resizeOriginalEndpoints = nil
         resizeOriginalLineControlPoint = nil
+
+        if let selected = doc.selectedObject as? CounterObject,
+           let action = counterSelectionAction(at: point, counter: selected) {
+            isDragging = false
+            dragStart = nil
+            dragCurrent = nil
+            switch action {
+            case .delete:
+                doc.removeSelected()
+            case .incrementCounter:
+                doc.beginDrag()
+                selected.number += 1
+            case .decrementCounter:
+                guard selected.number > 1 else {
+                    needsDisplay = true
+                    return
+                }
+                doc.beginDrag()
+                selected.number -= 1
+            }
+            needsDisplay = true
+            onDocumentChanged?()
+            return
+        }
 
         if let selected = doc.selectedObject,
            let handle = handleHitTest(point: point, object: selected) {
@@ -674,6 +863,11 @@ final class AnnotationCanvasNSView: NSView {
         let dy = dragCurrent.y - dragStart.y
 
         guard let obj = document?.objects.first(where: { $0.id == id }) else { return }
+        if let counter = obj as? CounterObject, handle == .counterTip {
+            counter.tip = counterTip(from: counter.center, to: dragCurrent, radius: counter.radius)
+            return
+        }
+
         if let pathObject = obj as? any PathEditableAnnotation {
             guard let endpoints = resizeOriginalEndpoints else { return }
             switch handle {
@@ -711,7 +905,7 @@ final class AnnotationCanvasNSView: NSView {
         case .bottomRight:
             newRect.size.width = originalBounds.width + dx
             newRect.size.height = originalBounds.height + dy
-        case .pathStart, .pathEnd, .pathControl:
+        case .pathStart, .pathEnd, .pathControl, .counterTip:
             return
         }
 
@@ -880,7 +1074,8 @@ final class AnnotationCanvasNSView: NSView {
                 }
             case .counter:
                 let number = nextCounterNumber()
-                let counter = CounterObject(center: end, number: number, radius: currentStyle.lineWidth, style: currentStyle)
+                let tip = counterTip(from: start, to: end, radius: currentStyle.lineWidth)
+                let counter = CounterObject(center: start, tip: tip, number: number, radius: currentStyle.lineWidth, style: currentStyle)
                 doc.addObject(counter)
             case .select:
                 break

--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -161,8 +161,9 @@ final class AnnotationCanvasNSView: NSView {
     // MARK: - Handle Hit Testing
 
     private func handleHitTest(point: CGPoint, object: any AnnotationObject) -> ResizeHandle? {
-        if let counter = object as? CounterObject {
-            return counterHandleHitTest(point: point, counter: counter)
+        if let counter = object as? CounterObject,
+           let handle = counterHandleHitTest(point: point, counter: counter) {
+            return handle
         }
 
         if let pathObject = object as? any PathEditableAnnotation {

--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -722,6 +722,28 @@ final class AnnotationCanvasNSView: NSView {
         resizeOriginalEndpoints = nil
         resizeOriginalLineControlPoint = nil
 
+        if let selected = doc.selectedObject,
+           let handle = handleHitTest(point: point, object: selected) {
+            activeResizeHandle = handle
+            resizeOriginalBounds = selected.bounds
+            resizeOriginalFreehandPoints = (selected as? FreehandObject)?.points
+            if let arrow = selected as? ArrowObject {
+                resizeOriginalEndpoints = (arrow.start, arrow.end)
+                resizeOriginalLineControlPoint = arrow.controlPoint ?? pathMidpoint(arrow)
+            } else if let line = selected as? LineObject {
+                resizeOriginalEndpoints = (line.start, line.end)
+                resizeOriginalLineControlPoint = line.controlPoint ?? pathMidpoint(line)
+            }
+            if let text = selected as? TextObject {
+                resizeOriginalTextFontSize = text.fontSize
+            }
+            dragObjectID = selected.id
+            doc.beginDrag()
+            cursorForHandle(handle).set()
+            needsDisplay = true
+            return
+        }
+
         if let selected = doc.selectedObject as? CounterObject,
            let action = counterSelectionAction(at: point, counter: selected) {
             isDragging = false
@@ -743,28 +765,6 @@ final class AnnotationCanvasNSView: NSView {
             }
             needsDisplay = true
             onDocumentChanged?()
-            return
-        }
-
-        if let selected = doc.selectedObject,
-           let handle = handleHitTest(point: point, object: selected) {
-            activeResizeHandle = handle
-            resizeOriginalBounds = selected.bounds
-            resizeOriginalFreehandPoints = (selected as? FreehandObject)?.points
-            if let arrow = selected as? ArrowObject {
-                resizeOriginalEndpoints = (arrow.start, arrow.end)
-                resizeOriginalLineControlPoint = arrow.controlPoint ?? pathMidpoint(arrow)
-            } else if let line = selected as? LineObject {
-                resizeOriginalEndpoints = (line.start, line.end)
-                resizeOriginalLineControlPoint = line.controlPoint ?? pathMidpoint(line)
-            }
-            if let text = selected as? TextObject {
-                resizeOriginalTextFontSize = text.fontSize
-            }
-            dragObjectID = selected.id
-            doc.beginDrag()
-            cursorForHandle(handle).set()
-            needsDisplay = true
             return
         }
 

--- a/Packages/AnnotationKit/Sources/AnnotationKit/Objects/CounterObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/Objects/CounterObject.swift
@@ -7,29 +7,84 @@ public final class CounterObject: AnnotationObject, @unchecked Sendable {
     public let id = ObjectID()
     public var style: StrokeStyle
     public var center: CGPoint
+    public var tip: CGPoint?
     public var radius: CGFloat
     public var number: Int
 
-    public init(center: CGPoint, number: Int, radius: CGFloat = 20, style: StrokeStyle = StrokeStyle()) {
+    public static let arrowClearance: CGFloat = 6
+
+    public init(center: CGPoint, tip: CGPoint? = nil, number: Int, radius: CGFloat = 20, style: StrokeStyle = StrokeStyle()) {
         self.center = center
+        self.tip = tip
         self.number = number
         self.radius = radius
         self.style = style
     }
 
+    public var hasArrow: Bool {
+        guard let tip else { return false }
+        return hypot(tip.x - center.x, tip.y - center.y) >= radius + Self.arrowClearance
+    }
+
+    private var arrowLineWidth: CGFloat {
+        max(2, min(style.lineWidth, radius * 0.28))
+    }
+
+    private var arrowHeadLength: CGFloat {
+        max(10, arrowLineWidth * 3)
+    }
+
     public var bounds: CGRect {
-        CGRect(x: center.x - radius, y: center.y - radius, width: radius * 2, height: radius * 2)
+        let circle = CGRect(x: center.x - radius, y: center.y - radius, width: radius * 2, height: radius * 2)
+        guard hasArrow, let tip else { return circle }
+        return circle.union(CGRect(
+            x: tip.x - arrowHeadLength,
+            y: tip.y - arrowHeadLength,
+            width: arrowHeadLength * 2,
+            height: arrowHeadLength * 2
+        ))
     }
 
     public func hitTest(point: CGPoint, threshold: CGFloat) -> Bool {
         let distance = hypot(point.x - center.x, point.y - center.y)
-        return distance <= radius + threshold
+        if distance <= radius + threshold {
+            return true
+        }
+        guard hasArrow, let tip else { return false }
+        return AnnotationGeometry.distanceToSegment(point: point, start: center, end: tip)
+            <= threshold + arrowLineWidth / 2
     }
 
     public func render(in ctx: CGContext) {
-        let circleRect = bounds
+        let circleRect = CGRect(x: center.x - radius, y: center.y - radius, width: radius * 2, height: radius * 2)
 
         ctx.saveGState()
+        if hasArrow, let tip {
+            ctx.setStrokeColor(style.color.cgColor)
+            ctx.setLineWidth(arrowLineWidth)
+            ctx.setLineCap(.round)
+            ctx.move(to: center)
+            ctx.addLine(to: tip)
+            ctx.strokePath()
+
+            let angle = atan2(tip.y - center.y, tip.x - center.x)
+            let headAngle: CGFloat = .pi / 6
+            let hl = arrowHeadLength
+            let p1 = CGPoint(
+                x: tip.x - hl * cos(angle - headAngle),
+                y: tip.y - hl * sin(angle - headAngle)
+            )
+            let p2 = CGPoint(
+                x: tip.x - hl * cos(angle + headAngle),
+                y: tip.y - hl * sin(angle + headAngle)
+            )
+            ctx.move(to: tip)
+            ctx.addLine(to: p1)
+            ctx.move(to: tip)
+            ctx.addLine(to: p2)
+            ctx.strokePath()
+        }
+
         ctx.setFillColor(style.color.cgColor)
         ctx.fillEllipse(in: circleRect)
         ctx.setStrokeColor(CGColor(gray: 0, alpha: 0.25))
@@ -60,9 +115,11 @@ public final class CounterObject: AnnotationObject, @unchecked Sendable {
     public func move(by delta: CGSize) {
         center.x += delta.width
         center.y += delta.height
+        tip?.x += delta.width
+        tip?.y += delta.height
     }
 
     public func copy() -> any AnnotationObject {
-        CounterObject(center: center, number: number, radius: radius, style: style)
+        CounterObject(center: center, tip: tip, number: number, radius: radius, style: style)
     }
 }

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/CounterObjectTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/CounterObjectTests.swift
@@ -67,4 +67,86 @@ struct CounterObjectTests {
         #expect(c1.number == 1)
         #expect(c2.number == 42)
     }
+
+    @Test("Counter can include an arrow tip in bounds and hit testing")
+    func arrowTipGeometry() {
+        let counter = CounterObject(
+            center: CGPoint(x: 40, y: 40),
+            tip: CGPoint(x: 120, y: 40),
+            number: 1,
+            radius: 14,
+            style: StrokeStyle(lineWidth: 4)
+        )
+
+        #expect(counter.hasArrow)
+        #expect(counter.bounds.maxX >= 120)
+        #expect(counter.hitTest(point: CGPoint(x: 85, y: 40), threshold: 2))
+    }
+
+    @Test("Counter ignores arrow tips too close to the badge")
+    func shortArrowTipIsIgnored() {
+        let counter = CounterObject(
+            center: CGPoint(x: 40, y: 40),
+            tip: CGPoint(x: 45, y: 40),
+            number: 1,
+            radius: 14
+        )
+
+        #expect(!counter.hasArrow)
+        #expect(!counter.hitTest(point: CGPoint(x: 55, y: 40), threshold: 0))
+    }
+
+    @Test("Counter move and copy preserve arrow tip")
+    func moveAndCopyArrowTip() {
+        let counter = CounterObject(
+            center: CGPoint(x: 50, y: 50),
+            tip: CGPoint(x: 80, y: 90),
+            number: 3
+        )
+
+        counter.move(by: CGSize(width: 10, height: -5))
+        #expect(counter.center == CGPoint(x: 60, y: 45))
+        #expect(counter.tip == CGPoint(x: 90, y: 85))
+
+        guard let copied = counter.copy() as? CounterObject else {
+            Issue.record("copy() did not return CounterObject")
+            return
+        }
+        #expect(copied.tip == counter.tip)
+        #expect(copied.number == counter.number)
+    }
+
+    @Test("Counter render draws arrow outside badge")
+    func renderDrawsArrowOutsideBadge() {
+        let width = 140
+        let height = 80
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )
+
+        guard let context else {
+            Issue.record("Could not create bitmap context")
+            return
+        }
+
+        let counter = CounterObject(
+            center: CGPoint(x: 30, y: 40),
+            tip: CGPoint(x: 110, y: 40),
+            number: 1,
+            radius: 14,
+            style: StrokeStyle(color: .red, lineWidth: 4)
+        )
+
+        counter.render(in: context)
+
+        let alphaIndex = (40 * width + 100) * 4 + 3
+        #expect(pixels[alphaIndex] > 0)
+    }
 }


### PR DESCRIPTION
## Summary
- Add optional arrow tips to counter annotations, including render, hit testing, bounds, move, and copy behavior.
- Let the counter tool create a badge-only counter with a click, or a numbered arrow by dragging from the badge center to the desired direction.
- Show selected-counter chrome with a draggable tip handle, quick x delete button, and +/- number adjustment buttons.

## Notes
- Existing counter numbering remains stable: deleting a middle counter does not silently renumber other counters. New counters continue from the current maximum number, and reset to 1 when all counters are gone.
- No settings/localization changes were needed because the new controls are canvas icon chrome only.

Closes #174

## Verification
- swift test --package-path Packages/AnnotationKit
- swift test --package-path Packages/SharedKit
- xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized annotation editor and CounterObject behavior with new unit tests; no auth, persistence, or security-sensitive paths.
> 
> **Overview**
> **Counter annotations** can now include an optional **arrow** from the numbered badge: `CounterObject` gains an optional `tip`, renders the shaft and head when the drag distance clears `arrowClearance`, and extends **bounds**, **hit testing**, **move**, and **copy** to cover the arrow segment.
> 
> **Counter tool interaction** changes from placing the badge at the release point to **badge at press, arrow by drag** (short click = badge only). While dragging, the canvas shows a live counter preview.
> 
> When a counter is selected, the canvas draws dedicated **selection chrome**: a draggable **tip handle** (with a dashed guide when there is no arrow yet), plus on-canvas **delete** and **+ / −** buttons to adjust the number (decrement disabled at 1). Tip dragging updates `tip` through the same clearance rules as creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5661a34ac47413746ed70191c5903aaf5e977b54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->