### PR TITLE
Keep PiP/webcam overlay presentation placement after video recording restart

### DIFF
--- a/App/Sources/Camera/CameraPiPWindow.swift
+++ b/App/Sources/Camera/CameraPiPWindow.swift
@@ -23,11 +23,19 @@ final class CameraPiPWindow: NSPanel {
         isPresentationMode
     }
 
+    var restartRestorationState: CameraPiPRestorationState {
+        CameraPiPPlacement.restorationState(
+            currentFrame: frame,
+            storedPiPFrame: storedPiPFrame,
+            presentationModeActive: isPresentationMode
+        )
+    }
+
     init(
         cameraManager: CameraManager,
         settings: AppSettings,
         recordingFrame: CGRect? = nil,
-        restoredFrame: CGRect? = nil
+        restorationState: CameraPiPRestorationState? = nil
     ) {
         self.cameraManager = cameraManager
         self.settings = settings
@@ -35,13 +43,16 @@ final class CameraPiPWindow: NSPanel {
 
         let initialSize = Self.windowSize(shape: settings.cameraShape, settings: settings)
 
-        let screen = Self.placementScreen(for: restoredFrame) ?? NSScreen.main ?? NSScreen.screens.first!
-        let initialFrame = CameraPiPPlacement.frame(
-            restoredFrame: restoredFrame,
+        let screen = Self.placementScreen(for: restorationState?.restoredFrame ?? recordingFrame)
+            ?? NSScreen.main
+            ?? NSScreen.screens.first!
+        let initialFrame = CameraPiPPlacement.initialFrame(
+            restorationState: restorationState,
             defaultSize: initialSize,
             recordingFrame: recordingFrame,
             visibleFrame: screen.visibleFrame
         )
+        let shouldRestorePresentation = restorationState?.presentationModeActive == true && recordingFrame != nil
 
         super.init(
             contentRect: initialFrame,
@@ -56,6 +67,15 @@ final class CameraPiPWindow: NSPanel {
         self.hasShadow = false
         self.collectionBehavior = [.canJoinAllSpaces, .transient]
         self.isMovableByWindowBackground = true
+        if shouldRestorePresentation {
+            self.isPresentationMode = true
+            self.storedPiPFrame = CameraPiPPlacement.frame(
+                restoredFrame: restorationState?.restoredFrame,
+                defaultSize: initialSize,
+                recordingFrame: recordingFrame,
+                visibleFrame: screen.visibleFrame
+            )
+        }
 
         installContentView()
 

--- a/App/Sources/Camera/CameraPiPWindow.swift
+++ b/App/Sources/Camera/CameraPiPWindow.swift
@@ -23,33 +23,28 @@ final class CameraPiPWindow: NSPanel {
         isPresentationMode
     }
 
-    init(cameraManager: CameraManager, settings: AppSettings, recordingFrame: CGRect? = nil) {
+    init(
+        cameraManager: CameraManager,
+        settings: AppSettings,
+        recordingFrame: CGRect? = nil,
+        restoredFrame: CGRect? = nil
+    ) {
         self.cameraManager = cameraManager
         self.settings = settings
         self.recordingFrame = recordingFrame
 
         let initialSize = Self.windowSize(shape: settings.cameraShape, settings: settings)
 
-        let screen = NSScreen.main ?? NSScreen.screens.first!
-        let screenFrame = screen.visibleFrame
-
-        var x: CGFloat
-        var y: CGFloat
-
-        if let frame = recordingFrame {
-            x = frame.midX - initialSize.width / 2
-            y = frame.minY + 20
-        } else {
-            x = screenFrame.maxX - initialSize.width - 32
-            y = screenFrame.minY + 32
-        }
-
-        // Clamp to screen bounds
-        x = max(screenFrame.minX + 8, min(x, screenFrame.maxX - initialSize.width - 8))
-        y = max(screenFrame.minY + 8, min(y, screenFrame.maxY - initialSize.height - 8))
+        let screen = Self.placementScreen(for: restoredFrame) ?? NSScreen.main ?? NSScreen.screens.first!
+        let initialFrame = CameraPiPPlacement.frame(
+            restoredFrame: restoredFrame,
+            defaultSize: initialSize,
+            recordingFrame: recordingFrame,
+            visibleFrame: screen.visibleFrame
+        )
 
         super.init(
-            contentRect: NSRect(x: x, y: y, width: initialSize.width, height: initialSize.height),
+            contentRect: initialFrame,
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
@@ -296,6 +291,18 @@ final class CameraPiPWindow: NSPanel {
         } else {
             return CGSize(width: shorter, height: shorter / shape.aspectRatio)
         }
+    }
+
+    private static func placementScreen(for restoredFrame: CGRect?) -> NSScreen? {
+        guard let restoredFrame else { return nil }
+        return NSScreen.screens
+            .compactMap { screen -> (screen: NSScreen, area: CGFloat)? in
+                let intersection = restoredFrame.intersection(screen.visibleFrame)
+                guard !intersection.isNull, !intersection.isEmpty else { return nil }
+                return (screen, intersection.width * intersection.height)
+            }
+            .max { $0.area < $1.area }?
+            .screen
     }
 
     private func presentationFrame() -> CGRect? {

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -457,7 +457,7 @@ final class RecordingCoordinator {
         cameraEnabled: Bool,
         micEnabled: Bool,
         systemAudioEnabled: Bool,
-        restoredCameraPiPFrame: CGRect? = nil
+        restoredCameraPiPState: CameraPiPRestorationState? = nil
     ) {
         currentRecordingFormat = format
         currentCameraEnabled = cameraEnabled
@@ -480,7 +480,7 @@ final class RecordingCoordinator {
         // uses the sync `start()` — at this point we know it's granted.
         if cameraEnabled && cameraPiPWindow == nil {
             try? cameraManager.start()
-            showCameraPiP(restoredFrame: restoredCameraPiPFrame)
+            showCameraPiP(restorationState: restoredCameraPiPState)
         }
 
         let actuallyStart: @MainActor () -> Void = { [weak self] in
@@ -569,7 +569,7 @@ final class RecordingCoordinator {
 
     private func restartRecording() {
         guard let format = currentRecordingFormat else { return }
-        let restoredCameraPiPFrame = currentCameraEnabled ? cameraPiPWindow?.frame : nil
+        let restoredCameraPiPState = currentCameraEnabled ? cameraPiPWindow?.restartRestorationState : nil
 
         Task {
             do {
@@ -583,7 +583,7 @@ final class RecordingCoordinator {
                     cameraEnabled: currentCameraEnabled,
                     micEnabled: currentMicEnabled,
                     systemAudioEnabled: currentSystemAudioEnabled,
-                    restoredCameraPiPFrame: restoredCameraPiPFrame
+                    restoredCameraPiPState: restoredCameraPiPState
                 )
             } catch {
                 print("Failed to restart recording: \(error)")
@@ -936,7 +936,7 @@ final class RecordingCoordinator {
         borderWindow?.show()
     }
 
-    private func showCameraPiP(restoredFrame: CGRect? = nil) {
+    private func showCameraPiP(restorationState: CameraPiPRestorationState? = nil) {
         // Close existing PiP first to prevent duplicates
         cameraPiPWindow?.orderOut(nil)
         cameraPiPWindow?.close()
@@ -957,7 +957,7 @@ final class RecordingCoordinator {
             cameraManager: cameraManager,
             settings: settings,
             recordingFrame: recordingFrame,
-            restoredFrame: restoredFrame
+            restorationState: restorationState
         )
         cameraPiPWindow?.show()
     }

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -456,7 +456,8 @@ final class RecordingCoordinator {
         format: RecordingFormatChoice,
         cameraEnabled: Bool,
         micEnabled: Bool,
-        systemAudioEnabled: Bool
+        systemAudioEnabled: Bool,
+        restoredCameraPiPFrame: CGRect? = nil
     ) {
         currentRecordingFormat = format
         currentCameraEnabled = cameraEnabled
@@ -479,7 +480,7 @@ final class RecordingCoordinator {
         // uses the sync `start()` — at this point we know it's granted.
         if cameraEnabled && cameraPiPWindow == nil {
             try? cameraManager.start()
-            showCameraPiP()
+            showCameraPiP(restoredFrame: restoredCameraPiPFrame)
         }
 
         let actuallyStart: @MainActor () -> Void = { [weak self] in
@@ -568,6 +569,7 @@ final class RecordingCoordinator {
 
     private func restartRecording() {
         guard let format = currentRecordingFormat else { return }
+        let restoredCameraPiPFrame = currentCameraEnabled ? cameraPiPWindow?.frame : nil
 
         Task {
             do {
@@ -580,7 +582,8 @@ final class RecordingCoordinator {
                     format: format,
                     cameraEnabled: currentCameraEnabled,
                     micEnabled: currentMicEnabled,
-                    systemAudioEnabled: currentSystemAudioEnabled
+                    systemAudioEnabled: currentSystemAudioEnabled,
+                    restoredCameraPiPFrame: restoredCameraPiPFrame
                 )
             } catch {
                 print("Failed to restart recording: \(error)")
@@ -933,7 +936,7 @@ final class RecordingCoordinator {
         borderWindow?.show()
     }
 
-    private func showCameraPiP() {
+    private func showCameraPiP(restoredFrame: CGRect? = nil) {
         // Close existing PiP first to prevent duplicates
         cameraPiPWindow?.orderOut(nil)
         cameraPiPWindow?.close()
@@ -950,7 +953,12 @@ final class RecordingCoordinator {
                 height: selectedRect.height
             )
         }
-        cameraPiPWindow = CameraPiPWindow(cameraManager: cameraManager, settings: settings, recordingFrame: recordingFrame)
+        cameraPiPWindow = CameraPiPWindow(
+            cameraManager: cameraManager,
+            settings: settings,
+            recordingFrame: recordingFrame,
+            restoredFrame: restoredFrame
+        )
         cameraPiPWindow?.show()
     }
 

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/CameraPiPPlacement.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/CameraPiPPlacement.swift
@@ -1,0 +1,76 @@
+import CoreGraphics
+
+public enum CameraPiPPlacement {
+    public static let defaultScreenMargin: CGFloat = 32
+    public static let recordingBottomOffset: CGFloat = 20
+    public static let visibleMargin: CGFloat = 8
+
+    public static func frame(
+        restoredFrame: CGRect?,
+        defaultSize: CGSize,
+        recordingFrame: CGRect?,
+        visibleFrame: CGRect
+    ) -> CGRect {
+        if let restoredFrame {
+            return clampedFrame(restoredFrame, in: visibleFrame)
+        }
+
+        return clampedFrame(
+            defaultFrame(
+                size: defaultSize,
+                recordingFrame: recordingFrame,
+                visibleFrame: visibleFrame
+            ),
+            in: visibleFrame
+        )
+    }
+
+    public static func defaultFrame(
+        size: CGSize,
+        recordingFrame: CGRect?,
+        visibleFrame: CGRect
+    ) -> CGRect {
+        let origin: CGPoint
+        if let recordingFrame {
+            origin = CGPoint(
+                x: recordingFrame.midX - size.width / 2,
+                y: recordingFrame.minY + recordingBottomOffset
+            )
+        } else {
+            origin = CGPoint(
+                x: visibleFrame.maxX - size.width - defaultScreenMargin,
+                y: visibleFrame.minY + defaultScreenMargin
+            )
+        }
+
+        return CGRect(origin: origin, size: size)
+    }
+
+    public static func clampedFrame(
+        _ frame: CGRect,
+        in visibleFrame: CGRect,
+        margin: CGFloat = visibleMargin
+    ) -> CGRect {
+        var clampedFrame = frame
+        clampedFrame.origin.x = clampedOrigin(
+            value: frame.origin.x,
+            lowerBound: visibleFrame.minX + margin,
+            upperBound: visibleFrame.maxX - frame.width - margin
+        )
+        clampedFrame.origin.y = clampedOrigin(
+            value: frame.origin.y,
+            lowerBound: visibleFrame.minY + margin,
+            upperBound: visibleFrame.maxY - frame.height - margin
+        )
+        return clampedFrame
+    }
+
+    private static func clampedOrigin(
+        value: CGFloat,
+        lowerBound: CGFloat,
+        upperBound: CGFloat
+    ) -> CGFloat {
+        guard lowerBound <= upperBound else { return lowerBound }
+        return max(lowerBound, min(value, upperBound))
+    }
+}

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/CameraPiPPlacement.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/CameraPiPPlacement.swift
@@ -1,5 +1,15 @@
 import CoreGraphics
 
+public struct CameraPiPRestorationState: Equatable {
+    public let restoredFrame: CGRect
+    public let presentationModeActive: Bool
+
+    public init(restoredFrame: CGRect, presentationModeActive: Bool) {
+        self.restoredFrame = restoredFrame
+        self.presentationModeActive = presentationModeActive
+    }
+}
+
 public enum CameraPiPPlacement {
     public static let defaultScreenMargin: CGFloat = 32
     public static let recordingBottomOffset: CGFloat = 20
@@ -22,6 +32,35 @@ public enum CameraPiPPlacement {
                 visibleFrame: visibleFrame
             ),
             in: visibleFrame
+        )
+    }
+
+    public static func restorationState(
+        currentFrame: CGRect,
+        storedPiPFrame: CGRect?,
+        presentationModeActive: Bool
+    ) -> CameraPiPRestorationState {
+        CameraPiPRestorationState(
+            restoredFrame: presentationModeActive ? (storedPiPFrame ?? currentFrame) : currentFrame,
+            presentationModeActive: presentationModeActive
+        )
+    }
+
+    public static func initialFrame(
+        restorationState: CameraPiPRestorationState?,
+        defaultSize: CGSize,
+        recordingFrame: CGRect?,
+        visibleFrame: CGRect
+    ) -> CGRect {
+        if restorationState?.presentationModeActive == true, let recordingFrame {
+            return recordingFrame
+        }
+
+        return frame(
+            restoredFrame: restorationState?.restoredFrame,
+            defaultSize: defaultSize,
+            recordingFrame: recordingFrame,
+            visibleFrame: visibleFrame
         )
     }
 

--- a/Packages/SharedKit/Tests/SharedKitTests/CameraPiPPlacementTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/CameraPiPPlacementTests.swift
@@ -76,4 +76,51 @@ struct CameraPiPPlacementTests {
 
         #expect(frame == CGRect(x: 8, y: 8, width: 160, height: 120))
     }
+
+    @Test("Restart restoration keeps the stored PiP frame when presentation is active")
+    func restartRestorationKeepsStoredPiPFrameWhenPresentationIsActive() {
+        let presentationFrame = CGRect(x: 50, y: 50, width: 700, height: 500)
+        let storedPiPFrame = CGRect(x: 120, y: 140, width: 160, height: 120)
+
+        let state = CameraPiPPlacement.restorationState(
+            currentFrame: presentationFrame,
+            storedPiPFrame: storedPiPFrame,
+            presentationModeActive: true
+        )
+
+        #expect(state.restoredFrame == storedPiPFrame)
+        #expect(state.presentationModeActive)
+    }
+
+    @Test("Restart restoration keeps the current frame when presentation is inactive")
+    func restartRestorationKeepsCurrentFrameWhenPresentationIsInactive() {
+        let currentFrame = CGRect(x: 120, y: 140, width: 160, height: 120)
+
+        let state = CameraPiPPlacement.restorationState(
+            currentFrame: currentFrame,
+            storedPiPFrame: CGRect(x: 40, y: 40, width: 700, height: 500),
+            presentationModeActive: false
+        )
+
+        #expect(state.restoredFrame == currentFrame)
+        #expect(!state.presentationModeActive)
+    }
+
+    @Test("Initial frame restores presentation mode to the recording frame")
+    func initialFrameRestoresPresentationModeToRecordingFrame() {
+        let recordingFrame = CGRect(x: 100, y: 80, width: 600, height: 420)
+        let state = CameraPiPRestorationState(
+            restoredFrame: CGRect(x: 120, y: 140, width: 160, height: 120),
+            presentationModeActive: true
+        )
+
+        let frame = CameraPiPPlacement.initialFrame(
+            restorationState: state,
+            defaultSize: defaultSize,
+            recordingFrame: recordingFrame,
+            visibleFrame: visibleFrame
+        )
+
+        #expect(frame == recordingFrame)
+    }
 }

--- a/Packages/SharedKit/Tests/SharedKitTests/CameraPiPPlacementTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/CameraPiPPlacementTests.swift
@@ -1,0 +1,79 @@
+import CoreGraphics
+import Testing
+@testable import SharedKit
+
+@Suite("CameraPiPPlacement")
+struct CameraPiPPlacementTests {
+    private let visibleFrame = CGRect(x: 0, y: 0, width: 1_000, height: 800)
+    private let defaultSize = CGSize(width: 160, height: 120)
+
+    @Test("Restored frame takes precedence over default placement")
+    func restoredFrameTakesPrecedence() {
+        let restoredFrame = CGRect(x: 100, y: 200, width: 220, height: 180)
+        let recordingFrame = CGRect(x: 200, y: 100, width: 400, height: 300)
+
+        let frame = CameraPiPPlacement.frame(
+            restoredFrame: restoredFrame,
+            defaultSize: defaultSize,
+            recordingFrame: recordingFrame,
+            visibleFrame: visibleFrame
+        )
+
+        #expect(frame == restoredFrame)
+    }
+
+    @Test("Restored dimensions are preserved while origin is clamped")
+    func restoredDimensionsArePreserved() {
+        let restoredFrame = CGRect(x: 950, y: 760, width: 220, height: 180)
+
+        let frame = CameraPiPPlacement.frame(
+            restoredFrame: restoredFrame,
+            defaultSize: defaultSize,
+            recordingFrame: nil,
+            visibleFrame: visibleFrame
+        )
+
+        #expect(frame.size == restoredFrame.size)
+        #expect(frame.origin == CGPoint(x: 772, y: 612))
+    }
+
+    @Test("Default fallback uses existing recording-relative placement")
+    func defaultFallbackUsesRecordingPlacement() {
+        let recordingFrame = CGRect(x: 100, y: 50, width: 500, height: 300)
+
+        let frame = CameraPiPPlacement.frame(
+            restoredFrame: nil,
+            defaultSize: defaultSize,
+            recordingFrame: recordingFrame,
+            visibleFrame: visibleFrame
+        )
+
+        #expect(frame == CGRect(x: 270, y: 70, width: 160, height: 120))
+    }
+
+    @Test("Default fallback uses screen placement without recording frame")
+    func defaultFallbackUsesScreenPlacement() {
+        let frame = CameraPiPPlacement.frame(
+            restoredFrame: nil,
+            defaultSize: defaultSize,
+            recordingFrame: nil,
+            visibleFrame: visibleFrame
+        )
+
+        #expect(frame == CGRect(x: 808, y: 32, width: 160, height: 120))
+    }
+
+    @Test("Frames are clamped inside visible bounds")
+    func framesAreClampedInsideVisibleBounds() {
+        let restoredFrame = CGRect(x: -40, y: -30, width: 160, height: 120)
+
+        let frame = CameraPiPPlacement.frame(
+            restoredFrame: restoredFrame,
+            defaultSize: defaultSize,
+            recordingFrame: nil,
+            visibleFrame: visibleFrame
+        )
+
+        #expect(frame == CGRect(x: 8, y: 8, width: 160, height: 120))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Capso exists to give back to the macOS community and to show what a modern, modu
 
 ### Screen Recording
 - **Video (MP4)** and **GIF** recording
-- **Webcam PiP** — 4 shapes (circle, square, portrait, landscape), drag-resize, snap-to-corners
+- **Webcam PiP** — 4 shapes (circle, square, portrait, landscape), drag-resize, snap-to-corners, and restart recording without losing your PiP placement or size
 - **Camera presentation mode** — click PiP to expand fullscreen, click again to restore
 - **System audio + microphone** capture
 - **Recording controls** — pause, stop, restart, delete, timer


### PR DESCRIPTION
## What changed

Preserves the camera PiP/webcam overlay presentation when restarting a recording.

Previously, clicking restart/reset recreated the PiP window using the default placement, so a user who had moved or resized their camera overlay would see it jump back to the default position. This PR snapshots the current PiP frame before the recording UI is torn down, restores that frame for the restarted take, and clamps only the origin when needed so the overlay remains visible.

Also adds a reusable `CameraPiPPlacement` helper with targeted tests for restored-frame precedence, dimension preservation, default fallback, and visible-bound clamping.

## Related issue

None

## Screenshots / recordings

No visual changes

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass (`swift test --package-path Packages/SharedKit`)
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)