### PR TITLE
fix: use symbol format for `depends_on macos` in Homebrew tap template

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -320,7 +320,7 @@ jobs:
             desc "Open-source screenshot and screen recording for macOS"
             homepage "https://github.com/lzhgus/Capso"
 
-            depends_on macos: ">= :sequoia"
+            depends_on macos: :sequoia
 
             app "Capso.app"
 


### PR DESCRIPTION
The heredoc template in the "Update Homebrew tap" step uses the deprecated string comparison format:

```ruby
depends_on macos: ">= :sequoia"
```

This triggers a Homebrew deprecation warning:

> Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :sequoia` instead.

This was previously fixed in the tap repo (lzhgus/homebrew-tap#1), but the fix gets overwritten on every release because the workflow regenerates the cask file from this template.

**Changes:**
- Replace `depends_on macos: ">= :sequoia"` with `depends_on macos: :sequoia` in the heredoc template