### PR TITLE
Feature/annotation editor drag export

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationEditorView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorView.swift
@@ -94,8 +94,16 @@ struct AnnotationEditorView: View {
     @State private var outputSize: CGSize?
     @State private var commitEditingTrigger = 0
     @State private var dragFileStore = QuickAccessDragFileStore()
+    @State private var dragFileID = UUID()
+    @State private var dragRenderCache: DragRenderCache?
     /// Cached text line bounding boxes for smart highlighter snapping.
     @State private var textRegions: [CGRect] = []
+
+    private struct DragRenderCache {
+        let renderedImage: CGImage
+        let previewImage: NSImage
+        var fileURL: URL?
+    }
 
     private var imageWidth: CGFloat { CGFloat(sourceImage.width) }
     private var imageHeight: CGFloat { CGFloat(sourceImage.height) }
@@ -219,11 +227,14 @@ struct AnnotationEditorView: View {
     }
 
     var body: some View {
-        if isCropMode {
-            cropEditor
-        } else {
-            editorContent
+        Group {
+            if isCropMode {
+                cropEditor
+            } else {
+                editorContent
+            }
         }
+        .onDisappear { invalidateDragCache() }
     }
 
     private var cropEditor: some View {
@@ -243,7 +254,7 @@ struct AnnotationEditorView: View {
             Divider()
 
             if showBeautifyPanel {
-                BeautifyPanel(settings: $beautifySettings)
+                BeautifyPanel(settings: beautifySettingsBinding)
                 Divider()
             }
 
@@ -268,11 +279,13 @@ struct AnnotationEditorView: View {
             isEditingText: isEditingText,
             canUndo: document.canUndo,
             canRedo: document.canRedo,
-            onUndo: { document.undo(); refreshTrigger += 1 },
-            onRedo: { document.redo(); refreshTrigger += 1 },
+            onUndo: { document.undo(); handleDocumentChanged() },
+            onRedo: { document.redo(); handleDocumentChanged() },
             onSave: { save() },
             onCopy: { copy() },
             onPin: { pin() },
+            dragThumbnail: dragFallbackImage,
+            onPrepareDrag: prepareDragFile,
             onDragFileURL: dragFileURL,
             onDragPreviewImage: dragPreviewImage,
             onDragStarted: onDragStarted,
@@ -333,6 +346,7 @@ struct AnnotationEditorView: View {
             refreshTrigger: refreshTrigger,
             textRegions: textRegions,
             commitEditingTrigger: commitEditingTrigger,
+            onDocumentChanged: handleDocumentChanged,
             onSwitchToSelect: switchToSelectTool,
             onInteractionChanged: handleCanvasInteractionChanged,
             onTextEditingStarted: handleTextEditingStarted,
@@ -397,6 +411,20 @@ struct AnnotationEditorView: View {
         beautifySettings.isEnabled && beautifySettings.shadowEnabled ? 6 * zoomScale : 0
     }
 
+    private var beautifySettingsBinding: Binding<BeautifySettings> {
+        Binding(
+            get: { beautifySettings },
+            set: { newValue in
+                beautifySettings = newValue
+                invalidateDragCache()
+            }
+        )
+    }
+
+    private var dragFallbackImage: NSImage {
+        NSImage(cgImage: sourceImage, size: NSSize(width: sourceImage.width, height: sourceImage.height))
+    }
+
     private func commitCrop(newImage: CGImage?, newRect: CGRect?, newOutputSize: CGSize?) {
         if let newImage {
             sourceImage = newImage
@@ -407,6 +435,7 @@ struct AnnotationEditorView: View {
         }
         outputSize = newOutputSize
         isCropMode = false
+        invalidateDragCache()
     }
 
     private func handleCanvasAppear(size: CGSize) {
@@ -446,6 +475,11 @@ struct AnnotationEditorView: View {
         interactionState.setCanvasInteraction(isInteracting)
     }
 
+    private func handleDocumentChanged() {
+        refreshTrigger += 1
+        invalidateDragCache()
+    }
+
     private func switchToSelectTool() {
         document.clearSelection()
         currentTool = .select
@@ -471,6 +505,7 @@ struct AnnotationEditorView: View {
         isEditingText = false
         interactionState.isEditingText = false
         savedTextFontSize = Double(lineWidth)
+        invalidateDragCache()
     }
 
     private func refitToCurrentWindow() {
@@ -523,6 +558,7 @@ struct AnnotationEditorView: View {
                 obj.style = currentStyle
             }
             refreshTrigger += 1
+            invalidateDragCache()
         }
     }
 
@@ -548,29 +584,56 @@ struct AnnotationEditorView: View {
     }
 
     private func dragFileURL() -> URL? {
-        guard !isEditingText,
-              let rendered = renderedOutputImage() else {
+        guard !isEditingText else {
+            return nil
+        }
+        if let fileURL = dragRenderCache?.fileURL,
+           FileManager.default.isReadableFile(atPath: fileURL.path) {
+            return fileURL
+        }
+        guard var cache = dragRenderCache ?? makeDragRenderCache() else {
             return nil
         }
 
         do {
-            return try dragFileStore.fileURL(
-                for: rendered,
-                id: UUID(),
+            let fileURL = try dragFileStore.fileURL(
+                for: cache.renderedImage,
+                id: dragFileID,
                 preset: screenshotOutputPreset,
                 date: captureDate,
                 sourceAppName: sourceAppName,
                 sourceWindowTitle: sourceWindowTitle,
                 template: screenshotFilenameTemplate
             )
+            cache.fileURL = fileURL
+            dragRenderCache = cache
+            return fileURL
         } catch {
             return nil
         }
     }
 
     private func dragPreviewImage() -> NSImage? {
+        guard !isEditingText else { return nil }
+        return (dragRenderCache ?? makeDragRenderCache())?.previewImage
+    }
+
+    private func prepareDragFile() {
+        _ = dragFileURL()
+    }
+
+    private func makeDragRenderCache() -> DragRenderCache? {
         guard let rendered = renderedOutputImage() else { return nil }
-        return NSImage(cgImage: rendered, size: NSSize(width: rendered.width, height: rendered.height))
+        let previewImage = NSImage(cgImage: rendered, size: NSSize(width: rendered.width, height: rendered.height))
+        let cache = DragRenderCache(renderedImage: rendered, previewImage: previewImage)
+        dragRenderCache = cache
+        return cache
+    }
+
+    private func invalidateDragCache() {
+        try? dragFileStore.removeFile(for: dragFileID)
+        dragFileID = UUID()
+        dragRenderCache = nil
     }
 
     private func save() {

--- a/App/Sources/AnnotationEditor/AnnotationEditorView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorView.swift
@@ -1,4 +1,5 @@
 // App/Sources/AnnotationEditor/AnnotationEditorView.swift
+import AppKit
 import SwiftUI
 import AnnotationKit
 import OCRKit
@@ -8,9 +9,16 @@ struct AnnotationEditorView: View {
     let initialSourceImage: CGImage
     let document: AnnotationDocument
     let interactionState: AnnotationEditorInteractionState
+    let sourceAppName: String?
+    let sourceWindowTitle: String?
+    let captureDate: Date
+    let screenshotOutputPreset: ScreenshotOutputPreset
+    let screenshotFilenameTemplate: String
     let onSave: (CGImage) -> Void
     let onCopy: (CGImage) -> Void
     let onPin: (CGImage) -> Void
+    let onDragStarted: () -> Void
+    let onDragEnded: () -> Void
     let onCancel: () -> Void
 
     /// The working image shown in the canvas. Starts equal to
@@ -22,17 +30,31 @@ struct AnnotationEditorView: View {
         sourceImage: CGImage,
         document: AnnotationDocument,
         interactionState: AnnotationEditorInteractionState,
+        sourceAppName: String?,
+        sourceWindowTitle: String?,
+        captureDate: Date,
+        screenshotOutputPreset: ScreenshotOutputPreset,
+        screenshotFilenameTemplate: String,
         onSave: @escaping (CGImage) -> Void,
         onCopy: @escaping (CGImage) -> Void,
         onPin: @escaping (CGImage) -> Void,
+        onDragStarted: @escaping () -> Void,
+        onDragEnded: @escaping () -> Void,
         onCancel: @escaping () -> Void
     ) {
         self.initialSourceImage = sourceImage
         self.document = document
         self.interactionState = interactionState
+        self.sourceAppName = sourceAppName
+        self.sourceWindowTitle = sourceWindowTitle
+        self.captureDate = captureDate
+        self.screenshotOutputPreset = screenshotOutputPreset
+        self.screenshotFilenameTemplate = screenshotFilenameTemplate
         self.onSave = onSave
         self.onCopy = onCopy
         self.onPin = onPin
+        self.onDragStarted = onDragStarted
+        self.onDragEnded = onDragEnded
         self.onCancel = onCancel
         self._sourceImage = State(initialValue: sourceImage)
     }
@@ -71,6 +93,7 @@ struct AnnotationEditorView: View {
     @State private var isCropMode = false
     @State private var outputSize: CGSize?
     @State private var commitEditingTrigger = 0
+    @State private var dragFileStore = QuickAccessDragFileStore()
     /// Cached text line bounding boxes for smart highlighter snapping.
     @State private var textRegions: [CGRect] = []
 
@@ -250,6 +273,11 @@ struct AnnotationEditorView: View {
             onSave: { save() },
             onCopy: { copy() },
             onPin: { pin() },
+            onDragFileURL: dragFileURL,
+            onDragPreviewImage: dragPreviewImage,
+            onDragStarted: onDragStarted,
+            onDragEnded: onDragEnded,
+            isDragDisabled: isEditingText,
             onCancel: onCancel,
             onCrop: { isCropMode = true }
         )
@@ -517,6 +545,32 @@ struct AnnotationEditorView: View {
             return rendered
         }
         return ImageUtilities.resized(rendered, width: width, height: height) ?? rendered
+    }
+
+    private func dragFileURL() -> URL? {
+        guard !isEditingText,
+              let rendered = renderedOutputImage() else {
+            return nil
+        }
+
+        do {
+            return try dragFileStore.fileURL(
+                for: rendered,
+                id: UUID(),
+                preset: screenshotOutputPreset,
+                date: captureDate,
+                sourceAppName: sourceAppName,
+                sourceWindowTitle: sourceWindowTitle,
+                template: screenshotFilenameTemplate
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private func dragPreviewImage() -> NSImage? {
+        guard let rendered = renderedOutputImage() else { return nil }
+        return NSImage(cgImage: rendered, size: NSSize(width: rendered.width, height: rendered.height))
     }
 
     private func save() {

--- a/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
@@ -2,15 +2,22 @@
 import AppKit
 import SwiftUI
 import AnnotationKit
+import SharedKit
 
 @MainActor
 final class AnnotationEditorWindow: NSPanel {
     private let document: AnnotationDocument
     private let interactionState = AnnotationEditorInteractionState()
+    private var alphaValueBeforeDrag: CGFloat?
 
     init(
         image: CGImage,
         anchorScreen: NSScreen? = nil,
+        sourceAppName: String? = nil,
+        sourceWindowTitle: String? = nil,
+        captureDate: Date = Date(),
+        screenshotOutputPreset: ScreenshotOutputPreset,
+        screenshotFilenameTemplate: String,
         onSave: @escaping (CGImage) -> Void,
         onCopy: @escaping (CGImage) -> Void,
         onPin: @escaping (CGImage, CGRect?) -> Void,
@@ -69,6 +76,11 @@ final class AnnotationEditorWindow: NSPanel {
             sourceImage: image,
             document: document,
             interactionState: interactionState,
+            sourceAppName: sourceAppName,
+            sourceWindowTitle: sourceWindowTitle,
+            captureDate: captureDate,
+            screenshotOutputPreset: screenshotOutputPreset,
+            screenshotFilenameTemplate: screenshotFilenameTemplate,
             onSave: { [weak self] rendered in
                 onSave(rendered)
                 self?.close()
@@ -81,6 +93,12 @@ final class AnnotationEditorWindow: NSPanel {
                 onPin(rendered, self?.frame)
                 self?.close()
             },
+            onDragStarted: { [weak self] in
+                self?.hideDuringExternalDrag()
+            },
+            onDragEnded: { [weak self] in
+                self?.showAfterExternalDrag()
+            },
             onCancel: { [weak self] in
                 onClose()
                 self?.close()
@@ -88,6 +106,19 @@ final class AnnotationEditorWindow: NSPanel {
         )
 
         self.contentView = NSHostingView(rootView: view)
+    }
+
+    private func hideDuringExternalDrag() {
+        guard alphaValueBeforeDrag == nil else { return }
+        alphaValueBeforeDrag = alphaValue
+        alphaValue = 0
+        ignoresMouseEvents = true
+    }
+
+    private func showAfterExternalDrag() {
+        alphaValue = alphaValueBeforeDrag ?? 1
+        alphaValueBeforeDrag = nil
+        ignoresMouseEvents = false
     }
 
     func show() {

--- a/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
@@ -83,25 +83,37 @@ final class AnnotationEditorWindow: NSPanel {
             screenshotFilenameTemplate: screenshotFilenameTemplate,
             onSave: { [weak self] rendered in
                 onSave(rendered)
-                self?.close()
+                MainActor.assumeIsolated {
+                    self?.close()
+                }
             },
             onCopy: { [weak self] rendered in
                 onCopy(rendered)
-                self?.close()
+                MainActor.assumeIsolated {
+                    self?.close()
+                }
             },
             onPin: { [weak self] rendered in
-                onPin(rendered, self?.frame)
-                self?.close()
+                MainActor.assumeIsolated {
+                    onPin(rendered, self?.frame)
+                    self?.close()
+                }
             },
             onDragStarted: { [weak self] in
-                self?.hideDuringExternalDrag()
+                MainActor.assumeIsolated {
+                    self?.hideDuringExternalDrag()
+                }
             },
             onDragEnded: { [weak self] in
-                self?.showAfterExternalDrag()
+                MainActor.assumeIsolated {
+                    self?.showAfterExternalDrag()
+                }
             },
             onCancel: { [weak self] in
                 onClose()
-                self?.close()
+                MainActor.assumeIsolated {
+                    self?.close()
+                }
             }
         )
 

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -26,6 +26,11 @@ struct AnnotationToolbar: View {
     let onSave: () -> Void
     let onCopy: () -> Void
     let onPin: () -> Void
+    let onDragFileURL: () -> URL?
+    let onDragPreviewImage: () -> NSImage?
+    let onDragStarted: () -> Void
+    let onDragEnded: () -> Void
+    let isDragDisabled: Bool
     let onCancel: () -> Void
     let onCrop: () -> Void
 
@@ -268,6 +273,8 @@ struct AnnotationToolbar: View {
             actionButton(icon: "xmark", help: "Close", isDestructive: true, action: onCancel)
                 .keyboardShortcut(.escape, modifiers: [])
 
+            dragActionButton
+
             copyActionButton
 
             actionButton(icon: "pin", help: "Pin", action: onPin)
@@ -276,6 +283,32 @@ struct AnnotationToolbar: View {
             actionButton(icon: "square.and.arrow.down", help: "Save", isPrimary: true, action: onSave)
                 .keyboardShortcut("s", modifiers: .command)
         }
+    }
+
+    private var dragActionButton: some View {
+        ZStack {
+            actionButtonFace(
+                icon: "arrow.up.left.and.arrow.down.right.circle.fill",
+                isPrimary: false,
+                isDestructive: false
+            )
+            .opacity(isDragDisabled ? 0.45 : 1)
+
+            QuickAccessDragSourceView(
+                thumbnail: NSImage(size: NSSize(width: 1, height: 1)),
+                dragImageSize: CGSize(width: 240, height: 160),
+                fileURLProvider: onDragFileURL,
+                dragImageProvider: onDragPreviewImage,
+                onDragStarted: onDragStarted,
+                onDragEnded: onDragEnded
+            )
+            .frame(width: 34, height: 26)
+            .disabled(isDragDisabled)
+            .accessibilityHidden(true)
+        }
+        .help(isDragDisabled ? "Finish text editing before dragging" : "Drag Edited Image")
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Drag Edited Image")
     }
 
     @ViewBuilder
@@ -297,16 +330,24 @@ struct AnnotationToolbar: View {
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
-            Image(systemName: icon)
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(actionIconForeground(isPrimary: isPrimary, isDestructive: isDestructive))
-                .frame(width: 34, height: 26)
-                .background(actionButtonBackground(isPrimary: isPrimary, isDestructive: isDestructive))
-                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
-                .overlay(actionButtonStroke(isPrimary: isPrimary))
+            actionButtonFace(icon: icon, isPrimary: isPrimary, isDestructive: isDestructive)
         }
         .buttonStyle(.plain)
         .help(help)
+    }
+
+    private func actionButtonFace(
+        icon: String,
+        isPrimary: Bool,
+        isDestructive: Bool
+    ) -> some View {
+        Image(systemName: icon)
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundStyle(actionIconForeground(isPrimary: isPrimary, isDestructive: isDestructive))
+            .frame(width: 34, height: 26)
+            .background(actionButtonBackground(isPrimary: isPrimary, isDestructive: isDestructive))
+            .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .overlay(actionButtonStroke(isPrimary: isPrimary))
     }
 
     private var toolbarDivider: some View {

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -26,6 +26,8 @@ struct AnnotationToolbar: View {
     let onSave: () -> Void
     let onCopy: () -> Void
     let onPin: () -> Void
+    let dragThumbnail: NSImage
+    let onPrepareDrag: () -> Void
     let onDragFileURL: () -> URL?
     let onDragPreviewImage: () -> NSImage?
     let onDragStarted: () -> Void
@@ -288,14 +290,14 @@ struct AnnotationToolbar: View {
     private var dragActionButton: some View {
         ZStack {
             actionButtonFace(
-                icon: "arrow.up.left.and.arrow.down.right.circle.fill",
+                icon: "hand.draw",
                 isPrimary: false,
                 isDestructive: false
             )
             .opacity(isDragDisabled ? 0.45 : 1)
 
             QuickAccessDragSourceView(
-                thumbnail: NSImage(size: NSSize(width: 1, height: 1)),
+                thumbnail: dragThumbnail,
                 dragImageSize: CGSize(width: 240, height: 160),
                 fileURLProvider: onDragFileURL,
                 dragImageProvider: onDragPreviewImage,
@@ -307,6 +309,11 @@ struct AnnotationToolbar: View {
             .accessibilityHidden(true)
         }
         .help(isDragDisabled ? "Finish text editing before dragging" : "Drag Edited Image")
+        .onHover { hovering in
+            if hovering && !isDragDisabled {
+                onPrepareDrag()
+            }
+        }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Drag Edited Image")
     }

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -1378,6 +1378,11 @@ final class CaptureCoordinator {
         annotationWindow = AnnotationEditorWindow(
             image: result.image,
             anchorScreen: screen,
+            sourceAppName: result.appName,
+            sourceWindowTitle: result.windowName,
+            captureDate: result.timestamp,
+            screenshotOutputPreset: settings.screenshotOutputPreset,
+            screenshotFilenameTemplate: settings.screenshotFilenameTemplate,
             onSave: { [weak self] (rendered: CGImage) in
                 self?.saveRenderedImage(
                     rendered,

--- a/App/Sources/QuickAccess/QuickAccessDragSourceView.swift
+++ b/App/Sources/QuickAccess/QuickAccessDragSourceView.swift
@@ -6,6 +6,7 @@ struct QuickAccessDragSourceView: NSViewRepresentable {
     let thumbnail: NSImage
     let dragImageSize: CGSize
     let fileURLProvider: () -> URL?
+    let dragImageProvider: () -> NSImage?
     let onDragStarted: () -> Void
     let onDragEnded: () -> Void
 
@@ -13,12 +14,14 @@ struct QuickAccessDragSourceView: NSViewRepresentable {
         thumbnail: NSImage,
         dragImageSize: CGSize,
         fileURLProvider: @escaping () -> URL?,
+        dragImageProvider: @escaping () -> NSImage? = { nil },
         onDragStarted: @escaping () -> Void,
         onDragEnded: @escaping () -> Void
     ) {
         self.thumbnail = thumbnail
         self.dragImageSize = dragImageSize
         self.fileURLProvider = fileURLProvider
+        self.dragImageProvider = dragImageProvider
         self.onDragStarted = onDragStarted
         self.onDragEnded = onDragEnded
     }
@@ -28,6 +31,7 @@ struct QuickAccessDragSourceView: NSViewRepresentable {
             thumbnail: thumbnail,
             dragImageSize: dragImageSize,
             fileURLProvider: fileURLProvider,
+            dragImageProvider: dragImageProvider,
             onDragStarted: onDragStarted,
             onDragEnded: onDragEnded
         )
@@ -37,6 +41,7 @@ struct QuickAccessDragSourceView: NSViewRepresentable {
         nsView.thumbnail = thumbnail
         nsView.dragImageSize = dragImageSize
         nsView.fileURLProvider = fileURLProvider
+        nsView.dragImageProvider = dragImageProvider
         nsView.onDragStarted = onDragStarted
         nsView.onDragEnded = onDragEnded
     }
@@ -48,6 +53,7 @@ final class DragSourceNSView: NSView, NSDraggingSource {
     var thumbnail: NSImage
     var dragImageSize: CGSize
     var fileURLProvider: () -> URL?
+    var dragImageProvider: () -> NSImage?
     var onDragStarted: () -> Void
     var onDragEnded: () -> Void
 
@@ -58,12 +64,14 @@ final class DragSourceNSView: NSView, NSDraggingSource {
         thumbnail: NSImage,
         dragImageSize: CGSize,
         fileURLProvider: @escaping () -> URL?,
+        dragImageProvider: @escaping () -> NSImage?,
         onDragStarted: @escaping () -> Void,
         onDragEnded: @escaping () -> Void
     ) {
         self.thumbnail = thumbnail
         self.dragImageSize = dragImageSize
         self.fileURLProvider = fileURLProvider
+        self.dragImageProvider = dragImageProvider
         self.onDragStarted = onDragStarted
         self.onDragEnded = onDragEnded
         super.init(frame: .zero)
@@ -90,7 +98,7 @@ final class DragSourceNSView: NSView, NSDraggingSource {
         guard let fileURL = fileURLProvider() else { return }
 
         self.mouseDownEvent = nil
-        beginDrag(for: fileURL, from: mouseDownEvent)
+        beginDrag(for: fileURL, from: mouseDownEvent, previewImage: dragImageProvider() ?? thumbnail)
     }
 
     override func mouseUp(with event: NSEvent) {
@@ -116,9 +124,9 @@ final class DragSourceNSView: NSView, NSDraggingSource {
         onDragEnded()
     }
 
-    private func beginDrag(for fileURL: URL, from event: NSEvent) {
+    private func beginDrag(for fileURL: URL, from event: NSEvent, previewImage: NSImage) {
         let draggingItem = NSDraggingItem(pasteboardWriter: fileURL as NSURL)
-        draggingItem.setDraggingFrame(draggingFrame, contents: dragImage)
+        draggingItem.setDraggingFrame(draggingFrame, contents: dragImage(previewImage: previewImage))
 
         let session = beginDraggingSession(with: [draggingItem], event: event, source: self)
         session.animatesToStartingPositionsOnCancelOrFail = true
@@ -133,7 +141,7 @@ final class DragSourceNSView: NSView, NSDraggingSource {
         return NSRect(origin: origin, size: size)
     }
 
-    private var dragImage: NSImage {
+    private func dragImage(previewImage: NSImage) -> NSImage {
         let size = NSSize(width: dragImageSize.width, height: dragImageSize.height)
         let image = NSImage(size: size)
         image.lockFocus()
@@ -146,8 +154,8 @@ final class DragSourceNSView: NSView, NSDraggingSource {
         NSColor.black.withAlphaComponent(0.12).setFill()
         rect.fill()
 
-        thumbnail.draw(
-            in: aspectFitRect(for: thumbnail.size, in: rect),
+        previewImage.draw(
+            in: aspectFitRect(for: previewImage.size, in: rect),
             from: .zero,
             operation: .sourceOver,
             fraction: 1,


### PR DESCRIPTION
 ## What changed

Adds a quick-drag action to the annotation editor toolbar so the currently edited image can be dragged directly
into another app.

The dragged file is rendered from the current edited image, uses the configured screenshot export format and
filename template, hides the editor during the drag, and restores it after drop/cancel.

Depends on #179 for the Quick Access drag-file export foundation.

## Related issue

Refs #179

## Screenshots / recordings

<img width="3061" height="2177" alt="Capso Screenshot - Capso 2026-07-08 at 19 40 10" src="https://github.com/user-attachments/assets/e34e4158-67e9-49da-bfc3-b03acce504e7" />

## Checklist

- [ x] `xcodegen generate` run if `project.yml` or source layout changed
- [ x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [ x] Tests for any touched package pass (`swift test --package-path Packages/<Kit>`)
- [ x] No new `TODO` / `FIXME` / debug prints left behind
- [ x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [ x] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)
