### PR TITLE
Feature/history card drag edit

### DIFF
--- a/App/Sources/History/HistoryCoordinator.swift
+++ b/App/Sources/History/HistoryCoordinator.swift
@@ -1,6 +1,7 @@
 // App/Sources/History/HistoryCoordinator.swift
 import AppKit
 import AVFoundation
+import ImageIO
 import Observation
 import CaptureKit
 import ExportKit
@@ -24,6 +25,8 @@ final class HistoryCoordinator {
     private var annotationWindow: AnnotationEditorWindow?
     private var pinnedControllers: [PinnedScreenshotController] = []
     private let dragFileStore = QuickAccessDragFileStore()
+    private var dragFileURLs: [UUID: URL] = [:]
+    private var dragPreparationTasks: [UUID: Task<Void, Never>] = [:]
 
     init(settings: AppSettings) {
         self.settings = settings
@@ -290,6 +293,7 @@ final class HistoryCoordinator {
             try store.delete(id: entry.id)
             let entryDir = store.entriesDirectory.appendingPathComponent(entry.id.uuidString, isDirectory: true)
             try? FileManager.default.removeItem(at: entryDir)
+            clearDragFileCache(for: entry)
             loadEntries()
         } catch {
             print("Failed to delete history entry: \(error)")
@@ -300,6 +304,7 @@ final class HistoryCoordinator {
         guard let store else { return }
         do {
             try HistoryCleanup.clearAll(store: store)
+            clearDragFileCaches()
             loadEntries()
         } catch {
             print("Failed to clear history: \(error)")
@@ -323,26 +328,91 @@ final class HistoryCoordinator {
     }
 
     func loadFullImage(for entry: HistoryEntry) -> CGImage? {
-        guard let url = fullImageURL(for: entry),
-              let image = NSImage(contentsOf: url),
-              let cgImage = ImageUtilities.cgImage(from: image) else { return nil }
-        return cgImage
+        guard let url = fullImageURL(for: entry) else { return nil }
+        return Self.loadCGImage(from: url)
+    }
+
+    func prepareDragFile(for entry: HistoryEntry) {
+        guard isScreenshot(entry) else { return }
+        if let cachedURL = dragFileURLs[entry.id] {
+            if FileManager.default.isReadableFile(atPath: cachedURL.path) {
+                return
+            }
+            dragFileURLs[entry.id] = nil
+        }
+
+        guard dragFileURLs[entry.id] == nil,
+              dragPreparationTasks[entry.id] == nil,
+              let fullURL = fullImageURL(for: entry) else { return }
+
+        let id = entry.id
+        let preset = settings.screenshotOutputPreset
+        let date = entry.createdAt
+        let sourceAppName = entry.sourceAppName
+        let sourceWindowTitle = entry.sourceWindowTitle
+        let template = settings.screenshotFilenameTemplate
+
+        dragPreparationTasks[id] = Task { [weak self] in
+            let preparedURL = await Task.detached(priority: .utility) { () -> URL? in
+                guard let image = Self.loadCGImage(from: fullURL) else { return nil }
+                let store = QuickAccessDragFileStore()
+                return try? store.fileURL(
+                    for: image,
+                    id: id,
+                    preset: preset,
+                    date: date,
+                    sourceAppName: sourceAppName,
+                    sourceWindowTitle: sourceWindowTitle,
+                    template: template
+                )
+            }.value
+            let wasCancelled = Task.isCancelled
+
+            await MainActor.run {
+                guard let self else {
+                    if let preparedURL {
+                        try? FileManager.default.removeItem(at: preparedURL)
+                    }
+                    return
+                }
+
+                self.dragPreparationTasks[id] = nil
+                guard let preparedURL else { return }
+                if wasCancelled || self.dragFileURLs[id] != nil {
+                    try? FileManager.default.removeItem(at: preparedURL)
+                    return
+                }
+                self.dragFileURLs[id] = preparedURL
+            }
+        }
     }
 
     func dragFileURL(for entry: HistoryEntry) -> URL? {
-        guard isScreenshot(entry),
-              let image = loadFullImage(for: entry) else { return nil }
+        guard isScreenshot(entry) else { return nil }
+        if let cachedURL = dragFileURLs[entry.id] {
+            if FileManager.default.isReadableFile(atPath: cachedURL.path) {
+                return cachedURL
+            }
+            dragFileURLs[entry.id] = nil
+        }
+
+        dragPreparationTasks[entry.id]?.cancel()
+        dragPreparationTasks[entry.id] = nil
+
+        guard let image = loadFullImage(for: entry) else { return nil }
 
         do {
-            return try dragFileStore.fileURL(
+            let fileURL = try dragFileStore.fileURL(
                 for: image,
-                id: UUID(),
+                id: entry.id,
                 preset: settings.screenshotOutputPreset,
                 date: entry.createdAt,
                 sourceAppName: entry.sourceAppName,
                 sourceWindowTitle: entry.sourceWindowTitle,
                 template: settings.screenshotFilenameTemplate
             )
+            dragFileURLs[entry.id] = fileURL
+            return fileURL
         } catch {
             return nil
         }
@@ -355,14 +425,23 @@ final class HistoryCoordinator {
         let screen = NSScreen.screens.first { NSMouseInRect(NSEvent.mouseLocation, $0.frame, false) }
             ?? NSScreen.main
 
+        annotationWindow?.close()
+        annotationWindow = nil
         let window = AnnotationEditorWindow(
             image: image,
             anchorScreen: screen,
+            sourceAppName: entry.sourceAppName,
+            sourceWindowTitle: entry.sourceWindowTitle,
+            captureDate: entry.createdAt,
+            screenshotOutputPreset: settings.screenshotOutputPreset,
+            screenshotFilenameTemplate: settings.screenshotFilenameTemplate,
             onSave: { [weak self] rendered in
                 self?.replaceImage(for: entry, with: rendered)
+                self?.annotationWindow = nil
             },
             onCopy: { [weak self] rendered in
                 self?.copyImageToClipboard(rendered)
+                self?.annotationWindow = nil
             },
             onPin: { [weak self] rendered, frame in
                 self?.pinImage(
@@ -372,8 +451,11 @@ final class HistoryCoordinator {
                     sourceWindowTitle: entry.sourceWindowTitle,
                     date: entry.createdAt
                 )
+                self?.annotationWindow = nil
             },
-            onClose: {}
+            onClose: { [weak self] in
+                self?.annotationWindow = nil
+            }
         )
         annotationWindow = window
         window.show()
@@ -406,10 +488,12 @@ final class HistoryCoordinator {
                     fullImageFileName: entry.fullImageFileName,
                     annotationFileName: entry.annotationFileName,
                     fileSize: Int64(pngData.count),
+                    // The edited bitmap no longer matches any existing uploaded object.
                     cloudURL: nil
                 )
                 try store.update(updated)
                 await MainActor.run {
+                    self.clearDragFileCache(for: entry)
                     self.loadEntries()
                 }
             } catch {
@@ -425,6 +509,35 @@ final class HistoryCoordinator {
         case .recording, .gif:
             return false
         }
+    }
+
+    nonisolated private static func loadCGImage(from url: URL) -> CGImage? {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else { return nil }
+        return CGImageSourceCreateImageAtIndex(source, 0, nil)
+    }
+
+    private func clearDragFileCache(for entry: HistoryEntry) {
+        clearDragFileCache(for: entry.id)
+    }
+
+    private func clearDragFileCache(for id: UUID) {
+        dragPreparationTasks[id]?.cancel()
+        dragPreparationTasks[id] = nil
+        if let fileURL = dragFileURLs.removeValue(forKey: id) {
+            try? FileManager.default.removeItem(at: fileURL)
+        }
+        try? dragFileStore.removeFile(for: id)
+    }
+
+    private func clearDragFileCaches() {
+        for task in dragPreparationTasks.values {
+            task.cancel()
+        }
+        dragPreparationTasks.removeAll()
+        for fileURL in dragFileURLs.values {
+            try? FileManager.default.removeItem(at: fileURL)
+        }
+        dragFileURLs.removeAll()
     }
 
     private func copyImageToClipboard(_ image: CGImage) {

--- a/App/Sources/History/HistoryCoordinator.swift
+++ b/App/Sources/History/HistoryCoordinator.swift
@@ -21,6 +21,9 @@ final class HistoryCoordinator {
     var shareCoordinator: ShareCoordinator?
 
     private var historyWindow: HistoryWindow?
+    private var annotationWindow: AnnotationEditorWindow?
+    private var pinnedControllers: [PinnedScreenshotController] = []
+    private let dragFileStore = QuickAccessDragFileStore()
 
     init(settings: AppSettings) {
         self.settings = settings
@@ -321,15 +324,175 @@ final class HistoryCoordinator {
 
     func loadFullImage(for entry: HistoryEntry) -> CGImage? {
         guard let url = fullImageURL(for: entry),
-              let data = try? Data(contentsOf: url),
-              let provider = CGDataProvider(data: data as CFData),
-              let image = CGImage(
-                  pngDataProviderSource: provider,
-                  decode: nil,
-                  shouldInterpolate: true,
-                  intent: .defaultIntent
-              ) else { return nil }
-        return image
+              let image = NSImage(contentsOf: url),
+              let cgImage = ImageUtilities.cgImage(from: image) else { return nil }
+        return cgImage
+    }
+
+    func dragFileURL(for entry: HistoryEntry) -> URL? {
+        guard isScreenshot(entry),
+              let image = loadFullImage(for: entry) else { return nil }
+
+        do {
+            return try dragFileStore.fileURL(
+                for: image,
+                id: UUID(),
+                preset: settings.screenshotOutputPreset,
+                date: entry.createdAt,
+                sourceAppName: entry.sourceAppName,
+                sourceWindowTitle: entry.sourceWindowTitle,
+                template: settings.screenshotFilenameTemplate
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    func editEntry(_ entry: HistoryEntry) {
+        guard isScreenshot(entry),
+              let image = loadFullImage(for: entry) else { return }
+
+        let screen = NSScreen.screens.first { NSMouseInRect(NSEvent.mouseLocation, $0.frame, false) }
+            ?? NSScreen.main
+
+        let window = AnnotationEditorWindow(
+            image: image,
+            anchorScreen: screen,
+            onSave: { [weak self] rendered in
+                self?.replaceImage(for: entry, with: rendered)
+            },
+            onCopy: { [weak self] rendered in
+                self?.copyImageToClipboard(rendered)
+            },
+            onPin: { [weak self] rendered, frame in
+                self?.pinImage(
+                    rendered,
+                    anchor: frame,
+                    sourceAppName: entry.sourceAppName,
+                    sourceWindowTitle: entry.sourceWindowTitle,
+                    date: entry.createdAt
+                )
+            },
+            onClose: {}
+        )
+        annotationWindow = window
+        window.show()
+    }
+
+    private func replaceImage(for entry: HistoryEntry, with image: CGImage) {
+        guard isScreenshot(entry),
+              let store,
+              let fullURL = fullImageURL(for: entry),
+              let thumbnailURL = thumbnailURL(for: entry) else { return }
+
+        Task.detached(priority: .utility) {
+            guard let pngData = ImageUtilities.pngData(from: image) else { return }
+            do {
+                try pngData.write(to: fullURL, options: [.atomic])
+                if let thumbnailData = ThumbnailGenerator.generateThumbnail(from: image) {
+                    try thumbnailData.write(to: thumbnailURL, options: [.atomic])
+                }
+
+                let updated = HistoryEntry(
+                    id: entry.id,
+                    createdAt: entry.createdAt,
+                    captureMode: entry.captureMode,
+                    imageWidth: image.width,
+                    imageHeight: image.height,
+                    sourceAppName: entry.sourceAppName,
+                    sourceAppBundleID: entry.sourceAppBundleID,
+                    sourceWindowTitle: entry.sourceWindowTitle,
+                    thumbnailFileName: entry.thumbnailFileName,
+                    fullImageFileName: entry.fullImageFileName,
+                    annotationFileName: entry.annotationFileName,
+                    fileSize: Int64(pngData.count),
+                    cloudURL: nil
+                )
+                try store.update(updated)
+                await MainActor.run {
+                    self.loadEntries()
+                }
+            } catch {
+                return
+            }
+        }
+    }
+
+    private func isScreenshot(_ entry: HistoryEntry) -> Bool {
+        switch entry.captureMode {
+        case .area, .fullscreen, .window:
+            return true
+        case .recording, .gif:
+            return false
+        }
+    }
+
+    private func copyImageToClipboard(_ image: CGImage) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.writeObjects([ImageUtilities.nsImage(from: image)])
+    }
+
+    private func pinImage(
+        _ image: CGImage,
+        anchor: CGRect?,
+        sourceAppName: String?,
+        sourceWindowTitle: String?,
+        date: Date
+    ) {
+        let controller = PinnedScreenshotController(
+            image: image,
+            anchorRect: anchor,
+            onCopy: { [weak self] in
+                self?.copyImageToClipboard(image)
+            },
+            onSave: { [weak self] in
+                self?.saveImageToExportLocation(
+                    image,
+                    sourceAppName: sourceAppName,
+                    sourceWindowTitle: sourceWindowTitle,
+                    date: date
+                )
+            },
+            onDidClose: { [weak self] controllerID in
+                self?.pinnedControllers.removeAll { $0.id == controllerID }
+            }
+        )
+        pinnedControllers.append(controller)
+        controller.show()
+    }
+
+    private func saveImageToExportLocation(
+        _ image: CGImage,
+        sourceAppName: String?,
+        sourceWindowTitle: String?,
+        date: Date
+    ) {
+        let preset = settings.screenshotOutputPreset
+        let data: Data? = switch preset.fileFormat {
+        case .png:
+            ImageUtilities.pngData(from: image)
+        case .jpeg:
+            ImageUtilities.jpegData(from: image, quality: preset.jpegQuality ?? 0.85)
+        case .mp4, .gif, .mov:
+            nil
+        }
+        guard let data else { return }
+
+        let directory = settings.screenshotMonthlyFolders
+            ? FileNaming.monthlyDirectory(in: settings.exportLocation)
+            : settings.exportLocation
+        let url = FileNaming.generateFileURL(
+            in: directory,
+            type: .screenshot,
+            format: preset.fileFormat,
+            date: date,
+            sourceAppName: sourceAppName,
+            sourceWindowTitle: sourceWindowTitle,
+            template: settings.screenshotFilenameTemplate
+        )
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try? data.write(to: url)
     }
 
     func copyToClipboard(_ entry: HistoryEntry) {

--- a/App/Sources/History/HistoryItemView.swift
+++ b/App/Sources/History/HistoryItemView.swift
@@ -190,7 +190,7 @@ struct HistoryItemView: View {
 
     private func dragActionButton(thumbnail: NSImage) -> some View {
         ZStack {
-            actionButtonFace("arrow.up.left.and.arrow.down.right.circle.fill")
+            actionButtonFace("hand.draw")
             QuickAccessDragSourceView(
                 thumbnail: thumbnail,
                 dragImageSize: CGSize(width: 180, height: 112),
@@ -202,6 +202,7 @@ struct HistoryItemView: View {
             .accessibilityHidden(true)
         }
         .help(String(localized: "Drag Screenshot"))
+        .onAppear { coordinator.prepareDragFile(for: entry) }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(Text("Drag Screenshot"))
     }

--- a/App/Sources/History/HistoryItemView.swift
+++ b/App/Sources/History/HistoryItemView.swift
@@ -50,6 +50,15 @@ struct HistoryItemView: View {
         }
     }
 
+    private var isScreenshot: Bool {
+        switch entry.captureMode {
+        case .area, .fullscreen, .window:
+            return true
+        case .recording, .gif:
+            return false
+        }
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             ZStack(alignment: .topTrailing) {
@@ -72,13 +81,9 @@ struct HistoryItemView: View {
 
                 // Hover action buttons
                 if isHovered {
-                    HStack(spacing: 4) {
-                        actionButton("doc.on.doc") { coordinator.copyToClipboard(entry) }
-                        actionButton("square.and.arrow.down") { coordinator.saveToFile(entry) }
-                        cloudActionButton
-                    }
-                    .transition(.opacity.combined(with: .scale(scale: 0.9)))
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                    hoverActionButtons
+                        .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
                 }
 
                 // Cloud upload failure toast overlay
@@ -139,6 +144,9 @@ struct HistoryItemView: View {
         .animation(.easeInOut(duration: 0.15), value: isHovered)
         .onHover { isHovered = $0 }
         .onAppear { loadThumbnail() }
+        .onChange(of: entry.fileSize) { _, _ in loadThumbnail() }
+        .onChange(of: entry.imageWidth) { _, _ in loadThumbnail() }
+        .onChange(of: entry.imageHeight) { _, _ in loadThumbnail() }
         .contextMenu { contextMenu }
         .sheet(isPresented: $showDeleteConfirm) {
             DeleteConfirmSheet(
@@ -157,7 +165,46 @@ struct HistoryItemView: View {
         }
     }
 
-    // MARK: - Cloud Action Button
+    // MARK: - Hover Action Buttons
+
+    private var hoverActionButtons: some View {
+        HStack(spacing: 4) {
+            if isScreenshot, let thumbnailImage {
+                dragActionButton(thumbnail: thumbnailImage)
+            }
+
+            actionButton("doc.on.doc") { coordinator.copyToClipboard(entry) }
+                .help(String(localized: "Copy to Clipboard"))
+
+            actionButton("square.and.arrow.down") { coordinator.saveToFile(entry) }
+                .help(String(localized: "Save to..."))
+
+            if isScreenshot {
+                actionButton("pencil.tip.crop.circle") { coordinator.editEntry(entry) }
+                    .help(String(localized: "Edit"))
+            }
+
+            cloudActionButton
+        }
+    }
+
+    private func dragActionButton(thumbnail: NSImage) -> some View {
+        ZStack {
+            actionButtonFace("arrow.up.left.and.arrow.down.right.circle.fill")
+            QuickAccessDragSourceView(
+                thumbnail: thumbnail,
+                dragImageSize: CGSize(width: 180, height: 112),
+                fileURLProvider: { coordinator.dragFileURL(for: entry) },
+                onDragStarted: {},
+                onDragEnded: {}
+            )
+            .frame(width: 30, height: 30)
+            .accessibilityHidden(true)
+        }
+        .help(String(localized: "Drag Screenshot"))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text("Drag Screenshot"))
+    }
 
     @ViewBuilder
     private var cloudActionButton: some View {
@@ -267,24 +314,31 @@ struct HistoryItemView: View {
 
     private func actionButton(_ systemImage: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
-            Image(systemName: systemImage)
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.white.opacity(0.9))
-                .frame(width: 30, height: 30)
-                .background(.black.opacity(0.55))
-                .clipShape(RoundedRectangle(cornerRadius: 7))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 7)
-                        .strokeBorder(.white.opacity(0.12), lineWidth: 0.5)
-                )
+            actionButtonFace(systemImage)
         }
         .buttonStyle(.plain)
+    }
+
+    private func actionButtonFace(_ systemImage: String) -> some View {
+        Image(systemName: systemImage)
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(.white.opacity(0.9))
+            .frame(width: 30, height: 30)
+            .background(.black.opacity(0.55))
+            .clipShape(RoundedRectangle(cornerRadius: 7))
+            .overlay(
+                RoundedRectangle(cornerRadius: 7)
+                    .strokeBorder(.white.opacity(0.12), lineWidth: 0.5)
+            )
     }
 
     @ViewBuilder
     private var contextMenu: some View {
         Button("Copy to Clipboard") { coordinator.copyToClipboard(entry) }
         Button("Save to...") { coordinator.saveToFile(entry) }
+        if isScreenshot {
+            Button("Edit") { coordinator.editEntry(entry) }
+        }
 
         if let cloudURL = entry.cloudURL {
             Button(String(localized: "Copy Cloud Link")) {


### PR DESCRIPTION
## What changed

Adds hover actions to screenshot history items for dragging and editing screenshots.

Screenshot cards now expose a drag action that exports the screenshot using the configured screenshot format and
filename template, plus an edit action that opens the annotation editor. Saved edits replace the stored history
image and refresh the thumbnail/metadata.

Depends on #179 for the Quick Access drag-file export foundation.

## Related issue

Refs #179

## Screenshots / recordings

<img width="1789" height="1453" alt="Capso Screenshot - Capso 2026-07-08 at 19 43 00" src="https://github.com/user-attachments/assets/c2e469d3-1045-4273-a268-a9fecd6a6e8a" />

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass (`swift test --package-path Packages/<Kit>`)
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)
