### PR TITLE
Fix camera PiP presentation mode

### DIFF
--- a/App/Sources/Camera/CameraPiPWindow.swift
+++ b/App/Sources/Camera/CameraPiPWindow.swift
@@ -15,9 +15,19 @@ final class CameraPiPWindow: NSPanel {
     private var isResizing = false
     private let recordingFrame: CGRect?
     private var isPresentationMode = false
+    private var isPresentationTransitioning = false
+    private var allowsPresentationFrameOutsideVisibleArea = false
     private var storedPiPFrame: CGRect?
     private var mouseDownPoint: NSPoint?
     private let clickThreshold: CGFloat = 5
+    private let defaultWindowLevel: NSWindow.Level = .floating
+    private let presentationWindowLevel = NSWindow.Level.statusBar + 1
+    private let defaultCollectionBehavior: NSWindow.CollectionBehavior = [.canJoinAllSpaces, .transient]
+    private let presentationCollectionBehavior: NSWindow.CollectionBehavior = [
+        .canJoinAllSpaces,
+        .fullScreenAuxiliary,
+        .transient
+    ]
 
     var presentationModeActive: Bool {
         isPresentationMode
@@ -61,11 +71,11 @@ final class CameraPiPWindow: NSPanel {
             defer: false
         )
 
-        self.level = .floating
+        self.level = defaultWindowLevel
         self.isOpaque = false
         self.backgroundColor = .clear
         self.hasShadow = false
-        self.collectionBehavior = [.canJoinAllSpaces, .transient]
+        self.collectionBehavior = defaultCollectionBehavior
         self.isMovableByWindowBackground = true
         if shouldRestorePresentation {
             self.isPresentationMode = true
@@ -75,6 +85,7 @@ final class CameraPiPWindow: NSPanel {
                 recordingFrame: recordingFrame,
                 visibleFrame: screen.visibleFrame
             )
+            applyPresentationWindowMode()
         }
 
         installContentView()
@@ -91,6 +102,8 @@ final class CameraPiPWindow: NSPanel {
     func show() { makeKeyAndOrderFront(nil) }
 
     func togglePresentationMode() {
+        guard !isPresentationTransitioning else { return }
+
         if isPresentationMode {
             exitPresentationMode()
             return
@@ -100,6 +113,8 @@ final class CameraPiPWindow: NSPanel {
 
         storedPiPFrame = frame
         isPresentationMode = true
+        isPresentationTransitioning = true
+        applyPresentationWindowMode()
 
         // Animate to fill the recording area.
         NSAnimationContext.runAnimationGroup { context in
@@ -108,18 +123,22 @@ final class CameraPiPWindow: NSPanel {
             self.animator().setFrame(targetFrame, display: true)
         } completionHandler: {
             self.installContentView()
+            self.isPresentationTransitioning = false
         }
     }
 
     func exitPresentationMode() {
+        guard !isPresentationTransitioning else { return }
         guard isPresentationMode else { return }
         guard let storedPiPFrame else {
             isPresentationMode = false
             installContentView()
+            restoreDefaultWindowMode()
             return
         }
 
         isPresentationMode = false
+        isPresentationTransitioning = true
 
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.28
@@ -128,6 +147,8 @@ final class CameraPiPWindow: NSPanel {
         } completionHandler: {
             self.installContentView()
             self.storedPiPFrame = nil
+            self.isPresentationTransitioning = false
+            self.restoreDefaultWindowMode()
         }
     }
 
@@ -229,6 +250,8 @@ final class CameraPiPWindow: NSPanel {
     }
 
     @objc private func handleWindowMoved() {
+        guard !isPresentationMode && !isPresentationTransitioning else { return }
+
         // Skip snap if Cmd is held
         let modifiers = NSEvent.modifierFlags
         if modifiers.contains(.command) { return }
@@ -287,6 +310,14 @@ final class CameraPiPWindow: NSPanel {
 
     override var canBecomeKey: Bool { true }
 
+    override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
+        if allowsPresentationFrameOutsideVisibleArea {
+            return frameRect
+        }
+
+        return super.constrainFrameRect(frameRect, to: screen)
+    }
+
     /// Re-read settings and update the window's size + content view.
     func applySettings() {
         let newSize = Self.windowSize(shape: settings.cameraShape, settings: settings)
@@ -327,6 +358,18 @@ final class CameraPiPWindow: NSPanel {
 
     private func presentationFrame() -> CGRect? {
         recordingFrame
+    }
+
+    private func applyPresentationWindowMode() {
+        level = presentationWindowLevel
+        collectionBehavior = presentationCollectionBehavior
+        allowsPresentationFrameOutsideVisibleArea = true
+    }
+
+    private func restoreDefaultWindowMode() {
+        level = defaultWindowLevel
+        collectionBehavior = defaultCollectionBehavior
+        allowsPresentationFrameOutsideVisibleArea = false
     }
 
     private func installContentView() {


### PR DESCRIPTION
## Summary
- Raise the camera PiP window level while presentation mode is active so it can cover recording regions that touch the menu bar area.
- Skip normal PiP edge-snapping while presentation mode is active or transitioning.
- Ignore repeated presentation toggle clicks while the expand/collapse animation is in flight.

## Root Cause
Presentation mode reused the normal PiP window behavior. When the expanded camera frame moved near the top screen edge, the normal snap-to-visible-frame behavior could pull the window down from the selected recording area. Rapid repeated clicks could also start overlapping expand/collapse animations and let stale completion handlers mutate the same presentation state.

## Validation
- `swift test --package-path Packages/SharedKit`
- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug -derivedDataPath build/DerivedData build`
- Manual debug build smoke test by maintainer: top-edge presentation mode and rapid expand/collapse clicking

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized macOS window/PiP UI behavior with no auth, data, or recording pipeline changes.
> 
> **Overview**
> Fixes camera PiP **presentation mode** so the expanded window can align with the full **recording region** (including near the menu bar) and doesn’t fight normal PiP behaviors during expand/collapse.
> 
> While presentation is active, the panel uses a higher **window level** (`statusBar + 1`), **fullScreenAuxiliary** collection behavior, and bypasses **visible-frame constraining** via `constrainFrameRect` and `allowsPresentationFrameOutsideVisibleArea`. **Edge snapping** on move is disabled during presentation and while a transition is in flight.
> 
> **Expand/collapse** toggles are ignored while `isPresentationTransitioning` is true, and default window level/behavior is restored when exiting presentation (including restore-on-init paths).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d20c72fd70c2ca8d6b5b6c708c9f9ef02fd37ad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->