### PR TITLE
feat: polish Quick Access and All-in-One UX

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -3186,6 +3186,28 @@
         }
       }
     },
+    "Off" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オフ"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "끔"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭"
+          }
+        }
+      }
+    },
     "OK" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -3205,6 +3227,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "好"
+          }
+        }
+      }
+    },
+    "On" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "オン"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "켬"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "开启"
           }
         }
       }

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -1383,6 +1383,28 @@
         }
       }
     },
+    "Box" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ボックス"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "상자"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "方框"
+          }
+        }
+      }
+    },
     "Beautify" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -4571,6 +4593,28 @@
         }
       }
     },
+    "Stroke" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ストローク"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "외곽선"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "描边"
+          }
+        }
+      }
+    },
     "System Audio" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -4613,6 +4657,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "文字"
+          }
+        }
+      }
+    },
+    "Text Style" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストスタイル"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "텍스트 스타일"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文字样式"
           }
         }
       }

--- a/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
+++ b/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
@@ -183,9 +183,11 @@ final class CaptureAllInOneAnnotationOverlay {
         let usesCompact = density != .regular
         let usesMini = density == .mini
         let showsOverflow = session?.showsOverflow ?? false
-        let showsTextOptions = session.map { $0.currentTool == .text || $0.isEditingText } ?? false
+        let height = CaptureChromeLayout.annotationToolbarHeight(
+            density: density,
+            showsOverflow: showsOverflow
+        )
         let width: CGFloat
-        let height: CGFloat
         let maxToolbarWidth = screen.visibleFrame.width - margin * 2
         if usesCompact {
             if usesMini && !showsOverflow {
@@ -195,10 +197,8 @@ final class CaptureAllInOneAnnotationOverlay {
             } else {
                 width = min(max(480, globalRect.width), min(840, maxToolbarWidth))
             }
-            height = (showsOverflow ? 102 : 58) + (showsTextOptions ? 42 : 0)
         } else {
             width = min(max(1_000, globalRect.width), min(1_000, maxToolbarWidth))
-            height = 58
         }
 
         func clampedX(width: CGFloat) -> CGFloat {
@@ -591,9 +591,14 @@ private struct AllInOneAnnotationToolbarView: View {
     @ObservedObject var session: AllInOneAnnotationSession
     @State private var hoveredTool: AnnotationTool?
     @State private var hoveredTextEffect: TextEffectAction?
+    @State private var showsTextStylePopover = false
 
     private var isFontSizeMode: Bool {
         session.currentTool == .text || session.isEditingText
+    }
+
+    private var hasActiveTextEffect: Bool {
+        session.textFillEnabled || session.textOutlineEnabled || session.textStrokeEnabled
     }
 
     var body: some View {
@@ -611,6 +616,11 @@ private struct AllInOneAnnotationToolbarView: View {
             ),
             isEnabled: !session.isEditingText
         )
+        .onChange(of: isFontSizeMode) { _, isTextMode in
+            if !isTextMode {
+                showsTextStylePopover = false
+            }
+        }
     }
 
     private var adaptiveToolbar: some View {
@@ -638,6 +648,10 @@ private struct AllInOneAnnotationToolbarView: View {
                     primaryControls
                 } else {
                     compactStatus
+                }
+
+                if isFontSizeMode && session.usesCompactToolbar {
+                    textStyleButton
                 }
 
                 if session.usesCompactToolbar {
@@ -675,10 +689,6 @@ private struct AllInOneAnnotationToolbarView: View {
                 }
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
-
-            if isFontSizeMode && session.usesCompactToolbar {
-                textEffectsRow
-            }
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
@@ -710,15 +720,15 @@ private struct AllInOneAnnotationToolbarView: View {
                     .foregroundStyle(.white.opacity(0.86))
                     .frame(minWidth: 34)
 
+                if isFontSizeMode {
+                    textStyleButton
+                }
+
                 iconButton(
                     systemName: "ellipsis",
                     help: "More tools",
                     action: { session.toggleOverflow() }
                 )
-            }
-
-            if isFontSizeMode {
-                textEffectsRow
             }
         }
         .padding(.horizontal, 12)
@@ -785,7 +795,8 @@ private struct AllInOneAnnotationToolbarView: View {
                 strokePatternControl
             }
 
-            if isFontSizeMode && !session.usesCompactToolbar {
+            if isFontSizeMode
+                && CaptureChromeLayout.showsInlineTextEffects(for: session.toolbarDensity) {
                 textEffectsInlineControls
             }
 
@@ -847,36 +858,89 @@ private struct AllInOneAnnotationToolbarView: View {
         }
     }
 
-    private var textEffectsRow: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 6) {
-                textEffectButton(
-                    title: "Fill",
-                    isActive: session.textFillEnabled,
-                    defaultsKey: "annotationTextFillEnabled"
-                ) {
-                    session.textFillEnabled.toggle()
-                    return session.textFillEnabled
-                }
-                textEffectButton(
-                    title: "Outline",
-                    isActive: session.textOutlineEnabled,
-                    defaultsKey: "annotationTextOutlineEnabled"
-                ) {
-                    session.textOutlineEnabled.toggle()
-                    return session.textOutlineEnabled
-                }
-                textEffectButton(
-                    title: "Trace",
-                    isActive: session.textStrokeEnabled,
-                    defaultsKey: "annotationTextStrokeEnabled"
-                ) {
-                    session.textStrokeEnabled.toggle()
-                    return session.textStrokeEnabled
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
+    private var textStyleButton: some View {
+        Button {
+            showsTextStylePopover.toggle()
+        } label: {
+            Image(systemName: "textformat")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 38, height: 38)
+                .background(buttonBackground(isActive: hasActiveTextEffect, isEnabled: true))
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
+        .buttonStyle(.plain)
+        .help("Text Style")
+        .accessibilityLabel(Text("Text Style"))
+        .accessibilityValue(Text(hasActiveTextEffect ? "On" : "Off"))
+        .popover(isPresented: $showsTextStylePopover, arrowEdge: .top) {
+            textStylePopover
+        }
+    }
+
+    private var textStylePopover: some View {
+        HStack(spacing: 6) {
+            textStylePopoverButton(
+                systemName: "rectangle.fill",
+                label: "Background",
+                isActive: session.textFillEnabled,
+                defaultsKey: "annotationTextFillEnabled"
+            ) {
+                session.textFillEnabled.toggle()
+                return session.textFillEnabled
+            }
+            textStylePopoverButton(
+                systemName: "rectangle",
+                label: "Box",
+                isActive: session.textOutlineEnabled,
+                defaultsKey: "annotationTextOutlineEnabled"
+            ) {
+                session.textOutlineEnabled.toggle()
+                return session.textOutlineEnabled
+            }
+            textStylePopoverButton(
+                systemName: "textformat",
+                label: "Stroke",
+                isActive: session.textStrokeEnabled,
+                defaultsKey: "annotationTextStrokeEnabled"
+            ) {
+                session.textStrokeEnabled.toggle()
+                return session.textStrokeEnabled
+            }
+        }
+        .padding(10)
+        .environment(\.colorScheme, .dark)
+    }
+
+    private func textStylePopoverButton(
+        systemName: String,
+        label: LocalizedStringKey,
+        isActive: Bool,
+        defaultsKey: String,
+        toggle: @escaping () -> Bool
+    ) -> some View {
+        Button {
+            let newValue = toggle()
+            UserDefaults.standard.set(newValue, forKey: defaultsKey)
+            session.updateSelectedStyle()
+        } label: {
+            VStack(spacing: 4) {
+                Image(systemName: systemName)
+                    .font(.system(size: 14, weight: .semibold))
+
+                Text(label)
+                    .font(.system(size: 10, weight: .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .foregroundStyle(.white)
+            .frame(width: 72, height: 48)
+            .background(buttonBackground(isActive: isActive, isEnabled: true))
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .help(label)
+        .accessibilityValue(Text(isActive ? "On" : "Off"))
     }
 
     private func textEffectIconButton(
@@ -951,28 +1015,6 @@ private struct AllInOneAnnotationToolbarView: View {
         .buttonStyle(.plain)
         .onHover { hoveredTextEffect = $0 ? kind : nil }
         .help(help)
-    }
-
-    private func textEffectButton(
-        title: LocalizedStringKey,
-        isActive: Bool,
-        defaultsKey: String,
-        toggle: @escaping () -> Bool
-    ) -> some View {
-        Button {
-            let newValue = toggle()
-            UserDefaults.standard.set(newValue, forKey: defaultsKey)
-            session.updateSelectedStyle()
-        } label: {
-            Text(title)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(.white)
-                .frame(minWidth: 54, minHeight: 26)
-                .background(optionBackground(isActive: isActive))
-                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
-        }
-        .buttonStyle(.plain)
-        .help(title)
     }
 
     private var undoRedoControls: some View {

--- a/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
+++ b/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
@@ -125,7 +125,7 @@ final class CaptureAllInOneAnnotationOverlay {
         panel.level = .screenSaver + 3
         panel.isOpaque = false
         panel.backgroundColor = .clear
-        panel.hasShadow = false
+        panel.hasShadow = true
         panel.hidesOnDeactivate = false
         panel.acceptsMouseMovedEvents = true
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
@@ -133,7 +133,7 @@ final class CaptureAllInOneAnnotationOverlay {
         let hostingView = AllInOneAnnotationToolbarHostingView(rootView: AllInOneAnnotationToolbarView(session: session))
         hostingView.wantsLayer = true
         hostingView.layer?.backgroundColor = NSColor.clear.cgColor
-        hostingView.layer?.cornerRadius = 14
+        hostingView.layer?.cornerRadius = 16
         hostingView.layer?.cornerCurve = .continuous
         hostingView.layer?.masksToBounds = true
         panel.contentView = hostingView
@@ -179,8 +179,9 @@ final class CaptureAllInOneAnnotationOverlay {
             height: selectionRect.height
         )
         let session = session
-        let usesCompact = session?.usesCompactToolbar ?? (globalRect.width < 760)
-        let usesMini = session?.usesMiniToolbar ?? (globalRect.width < 420)
+        let density = session?.toolbarDensity ?? CaptureChromeLayout.annotationDensity(for: globalRect.width)
+        let usesCompact = density != .regular
+        let usesMini = density == .mini
         let showsOverflow = session?.showsOverflow ?? false
         let showsTextOptions = session.map { $0.currentTool == .text || $0.isEditingText } ?? false
         let width: CGFloat
@@ -188,15 +189,15 @@ final class CaptureAllInOneAnnotationOverlay {
         let maxToolbarWidth = screen.visibleFrame.width - margin * 2
         if usesCompact {
             if usesMini && !showsOverflow {
-                width = min(268, maxToolbarWidth)
+                width = min(300, maxToolbarWidth)
             } else if showsOverflow {
-                width = min(760, maxToolbarWidth)
+                width = min(840, maxToolbarWidth)
             } else {
-                width = min(max(420, globalRect.width), min(760, maxToolbarWidth))
+                width = min(max(480, globalRect.width), min(840, maxToolbarWidth))
             }
             height = (showsOverflow ? 102 : 58) + (showsTextOptions ? 42 : 0)
         } else {
-            width = min(max(760, globalRect.width), min(960, maxToolbarWidth))
+            width = min(max(840, globalRect.width), min(900, maxToolbarWidth))
             height = 58
         }
 
@@ -396,12 +397,16 @@ final class AllInOneAnnotationSession: ObservableObject {
         textStrokeEnabled ? .white : nil
     }
 
+    var toolbarDensity: CaptureChromeDensity {
+        CaptureChromeLayout.annotationDensity(for: availableWidth)
+    }
+
     var usesCompactToolbar: Bool {
-        availableWidth < 760
+        toolbarDensity != .regular
     }
 
     var usesMiniToolbar: Bool {
-        availableWidth < 420
+        toolbarDensity == .mini
     }
 
     func replaceSourceImage(_ image: CGImage, displayScale: CGFloat, objectOffset: CGSize = .zero) {
@@ -679,10 +684,10 @@ private struct AllInOneAnnotationToolbarView: View {
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(toolbarBackground)
-        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(Color.white.opacity(0.18), lineWidth: 0.5)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.white.opacity(0.16), lineWidth: 0.5)
         )
         .environment(\.colorScheme, .dark)
         .animation(.spring(response: 0.20, dampingFraction: 0.88), value: session.showsOverflow)
@@ -720,18 +725,17 @@ private struct AllInOneAnnotationToolbarView: View {
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(toolbarBackground)
-        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(Color.white.opacity(0.18), lineWidth: 0.5)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.white.opacity(0.16), lineWidth: 0.5)
         )
         .environment(\.colorScheme, .dark)
     }
 
     private var toolbarBackground: some View {
-        RoundedRectangle(cornerRadius: 14, style: .continuous)
-            .fill(.regularMaterial)
-            .shadow(color: .black.opacity(0.32), radius: 18, y: 8)
+        RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .fill(.thinMaterial)
     }
 
     private var primaryTools: [AnnotationTool] {

--- a/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
+++ b/App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift
@@ -197,7 +197,7 @@ final class CaptureAllInOneAnnotationOverlay {
             }
             height = (showsOverflow ? 102 : 58) + (showsTextOptions ? 42 : 0)
         } else {
-            width = min(max(840, globalRect.width), min(900, maxToolbarWidth))
+            width = min(max(1_000, globalRect.width), min(1_000, maxToolbarWidth))
             height = 58
         }
 

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -7,7 +7,7 @@ import SwiftUI
 @MainActor
 final class CaptureAllInOneToolbarWindow {
     private static let minimumSelectionSize = CGSize(width: 24, height: 24)
-    private static let toolbarCornerRadius: CGFloat = 14
+    private static let toolbarCornerRadius: CGFloat = 16
 
     private var selectionOverlayWindow: NSPanel?
     private weak var selectionOverlayView: AllInOneSelectionOverlayView?
@@ -156,7 +156,7 @@ final class CaptureAllInOneToolbarWindow {
         panel.level = frozenImage == nil ? .screenSaver + 1 : .screenSaver + 3
         panel.isOpaque = false
         panel.backgroundColor = .clear
-        panel.hasShadow = false
+        panel.hasShadow = true
         panel.hidesOnDeactivate = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
 
@@ -301,7 +301,7 @@ final class CaptureAllInOneToolbarWindow {
         toolbarState.width = max(1, Int(screenLocalSelectionRect.width.rounded()))
         toolbarState.height = max(1, Int(screenLocalSelectionRect.height.rounded()))
         let shouldCompact = frozenImage != nil
-            && screenLocalSelectionRect.height < 520
+            && CaptureChromeLayout.startsWithCompactSideRail
         if toolbarState.isCompact != shouldCompact {
             toolbarState.isCompact = shouldCompact
             toolbarState.showsOverflow = false
@@ -690,10 +690,10 @@ private struct CaptureAllInOneToolbarView: View {
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(toolbarBackground)
-        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(Color.white.opacity(0.20), lineWidth: 0.5)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.white.opacity(0.16), lineWidth: 0.5)
         )
         .environment(\.colorScheme, .dark)
         .onHover { hovering in
@@ -743,10 +743,10 @@ private struct CaptureAllInOneToolbarView: View {
         .padding(.vertical, 10)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(toolbarBackground)
-        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(Color.white.opacity(0.20), lineWidth: 0.5)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.white.opacity(0.16), lineWidth: 0.5)
         )
         .environment(\.colorScheme, .dark)
         .animation(.spring(response: 0.20, dampingFraction: 0.88), value: state.showsOverflow)
@@ -758,10 +758,8 @@ private struct CaptureAllInOneToolbarView: View {
     }
 
     private var toolbarBackground: some View {
-        RoundedRectangle(cornerRadius: 14, style: .continuous)
-            .fill(.regularMaterial)
-            .shadow(color: .black.opacity(0.30), radius: 18, y: 8)
-            .shadow(color: .black.opacity(0.14), radius: 3, y: 1)
+        RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .fill(.thinMaterial)
     }
 
     private var divider: some View {

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -596,21 +596,18 @@ private final class CaptureAllInOneToolbarState {
         let verticalPadding: CGFloat = 20
         let rowHeight: CGFloat = 38
         let presetHeight: CGFloat = 42
-        let dimensionHeight: CGFloat = 54
         let dividerHeight: CGFloat = 5
 
-        let itemHeights: [CGFloat]
-        if isCompact && !showsOverflow {
-            itemHeights = [dimensionHeight, rowHeight, rowHeight, rowHeight, dividerHeight, rowHeight]
-        } else {
-            itemHeights = [
-                rowHeight, rowHeight, rowHeight, rowHeight, rowHeight, rowHeight, rowHeight,
-                dividerHeight,
-                dimensionHeight,
-                presetHeight,
-                rowHeight, rowHeight,
-                rowHeight
-            ]
+        var itemHeights: [CGFloat] = []
+        if !isCompact || showsOverflow {
+            itemHeights += Array(repeating: rowHeight, count: 7)
+            itemHeights.append(dividerHeight)
+            itemHeights.append(presetHeight)
+        }
+        itemHeights += Array(repeating: rowHeight, count: 4)
+        if isCompact {
+            itemHeights.append(dividerHeight)
+            itemHeights.append(rowHeight)
         }
 
         return verticalPadding
@@ -716,8 +713,6 @@ private struct CaptureAllInOneToolbarView: View {
 
                 railDivider
             }
-
-            railDimensionPill
 
             if !state.isCompact || state.showsOverflow {
                 railPresetMenu
@@ -917,27 +912,6 @@ private struct CaptureAllInOneToolbarView: View {
         .background(Color.white.opacity(0.11), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
-        )
-        .help("Selected area size")
-    }
-
-    private var railDimensionPill: some View {
-        VStack(spacing: 1) {
-            Text("\(state.width)")
-            Text("x")
-                .font(.system(size: 9, weight: .bold, design: .monospaced))
-                .foregroundStyle(.white.opacity(0.58))
-            Text("\(state.height)")
-        }
-        .font(.system(size: 11, weight: .semibold, design: .monospaced))
-        .foregroundStyle(.white)
-        .lineLimit(1)
-        .minimumScaleFactor(0.68)
-        .frame(width: 60, height: 54)
-        .background(Color.white.opacity(0.11), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .stroke(Color.white.opacity(0.08), lineWidth: 0.5)
         )
         .help("Selected area size")
@@ -1425,13 +1399,14 @@ private final class AllInOneSelectionOverlayView: NSView {
         let rect = selectionRect.standardized
 
         context.saveGState()
-        context.setFillColor(NSColor.black.withAlphaComponent(0.38).cgColor)
+        context.setFillColor(NSColor.black.withAlphaComponent(0.32).cgColor)
         context.fill(bounds)
         context.setBlendMode(.clear)
         context.fill(rect)
         context.restoreGState()
 
         drawSelectionChrome(in: context, rect: rect)
+        drawDimensionHUD(in: context, selectionRect: rect)
     }
 
     private func updateCursor(for point: CGPoint) {
@@ -1496,53 +1471,99 @@ private final class AllInOneSelectionOverlayView: NSView {
 
     private func drawSelectionChrome(in context: CGContext, rect: CGRect) {
         context.saveGState()
-        context.setStrokeColor(NSColor.white.withAlphaComponent(0.35).cgColor)
-        context.setLineWidth(1)
+        context.setStrokeColor(NSColor.black.withAlphaComponent(0.55).cgColor)
+        context.setLineWidth(3)
+        context.stroke(rect)
+        context.setStrokeColor(NSColor.white.cgColor)
+        context.setLineWidth(1.5)
         context.stroke(rect)
         context.restoreGState()
 
-        context.saveGState()
-        context.setShadow(
-            offset: .zero,
-            blur: 7,
-            color: NSColor.black.withAlphaComponent(0.55).cgColor
+        let handles = CaptureSelectionChromeLayout.visibleHandles(
+            for: rect.size,
+            isFixedSize: activePreset.isFixedSize
         )
-        context.setStrokeColor(NSColor.white.withAlphaComponent(0.95).cgColor)
-        context.setLineWidth(3)
-        context.setLineCap(.round)
+        for handle in handles {
+            let center = point(for: handle, in: rect)
+            let handleRect = CGRect(x: center.x - 3.5, y: center.y - 3.5, width: 7, height: 7)
 
-        let cornerLength = min(24, max(8, min(rect.width, rect.height) / 3))
-        let midLength = min(14, max(8, min(rect.width, rect.height) / 4))
-        let minX = rect.minX
-        let maxX = rect.maxX
-        let minY = rect.minY
-        let maxY = rect.maxY
-        let midX = rect.midX
-        let midY = rect.midY
-
-        drawCorner(context, x: minX, y: maxY, dx: cornerLength, dy: -cornerLength)
-        drawCorner(context, x: maxX, y: maxY, dx: -cornerLength, dy: -cornerLength)
-        drawCorner(context, x: minX, y: minY, dx: cornerLength, dy: cornerLength)
-        drawCorner(context, x: maxX, y: minY, dx: -cornerLength, dy: cornerLength)
-
-        context.move(to: CGPoint(x: midX - midLength / 2, y: maxY))
-        context.addLine(to: CGPoint(x: midX + midLength / 2, y: maxY))
-        context.move(to: CGPoint(x: midX - midLength / 2, y: minY))
-        context.addLine(to: CGPoint(x: midX + midLength / 2, y: minY))
-        context.move(to: CGPoint(x: minX, y: midY - midLength / 2))
-        context.addLine(to: CGPoint(x: minX, y: midY + midLength / 2))
-        context.move(to: CGPoint(x: maxX, y: midY - midLength / 2))
-        context.addLine(to: CGPoint(x: maxX, y: midY + midLength / 2))
-        context.strokePath()
-        context.restoreGState()
+            context.saveGState()
+            context.setShadow(
+                offset: .zero,
+                blur: 4,
+                color: NSColor.black.withAlphaComponent(0.55).cgColor
+            )
+            context.setFillColor(NSColor.white.cgColor)
+            context.setStrokeColor(NSColor.black.withAlphaComponent(0.65).cgColor)
+            context.setLineWidth(1)
+            context.addEllipse(in: handleRect)
+            context.drawPath(using: .fillStroke)
+            context.restoreGState()
+        }
     }
 
-    private func drawCorner(_ context: CGContext, x: CGFloat, y: CGFloat, dx: CGFloat, dy: CGFloat) {
-        context.move(to: CGPoint(x: x, y: y))
-        context.addLine(to: CGPoint(x: x + dx, y: y))
-        context.move(to: CGPoint(x: x, y: y))
-        context.addLine(to: CGPoint(x: x, y: y + dy))
+    private func point(for handle: CaptureSelectionResizeHandle, in rect: CGRect) -> CGPoint {
+        switch handle {
+        case .topLeft:
+            return CGPoint(x: rect.minX, y: rect.maxY)
+        case .top:
+            return CGPoint(x: rect.midX, y: rect.maxY)
+        case .topRight:
+            return CGPoint(x: rect.maxX, y: rect.maxY)
+        case .right:
+            return CGPoint(x: rect.maxX, y: rect.midY)
+        case .bottomRight:
+            return CGPoint(x: rect.maxX, y: rect.minY)
+        case .bottom:
+            return CGPoint(x: rect.midX, y: rect.minY)
+        case .bottomLeft:
+            return CGPoint(x: rect.minX, y: rect.minY)
+        case .left:
+            return CGPoint(x: rect.minX, y: rect.midY)
+        }
+    }
+
+    private func drawDimensionHUD(in context: CGContext, selectionRect: CGRect) {
+        let text = CaptureSelectionChromeLayout.dimensionText(for: selectionRect.size) as NSString
+        let font = NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.white,
+        ]
+        let textSize = text.size(withAttributes: attributes)
+        let horizontalPadding: CGFloat = 8
+        let verticalPadding: CGFloat = 5
+        let hudSize = CGSize(
+            width: textSize.width + horizontalPadding * 2,
+            height: textSize.height + verticalPadding * 2
+        )
+        let origin = CaptureSelectionChromeLayout.dimensionHUDOrigin(
+            selectionRect: selectionRect,
+            hudSize: hudSize,
+            in: bounds
+        )
+        let hudRect = CGRect(origin: origin, size: hudSize)
+        let hudPath = CGPath(
+            roundedRect: hudRect,
+            cornerWidth: 6,
+            cornerHeight: 6,
+            transform: nil
+        )
+
+        context.saveGState()
+        context.setFillColor(NSColor.black.withAlphaComponent(0.72).cgColor)
+        context.addPath(hudPath)
+        context.fillPath()
+        context.setStrokeColor(NSColor.white.withAlphaComponent(0.18).cgColor)
+        context.setLineWidth(0.5)
+        context.addPath(hudPath)
         context.strokePath()
+        context.restoreGState()
+
+        text.draw(
+            at: CGPoint(x: origin.x + horizontalPadding, y: origin.y + verticalPadding),
+            withAttributes: attributes
+        )
     }
 }
 

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -1143,6 +1143,7 @@ private final class AllInOneSelectionOverlayView: NSView {
         didSet {
             needsDisplay = true
             window?.invalidateCursorRects(for: self)
+            updateAccessibilityValue(postNotification: true)
         }
     }
     private let minSelectionSize: CGSize
@@ -1161,6 +1162,10 @@ private final class AllInOneSelectionOverlayView: NSView {
         self.minSelectionSize = minSelectionSize
         self.activePreset = activePreset
         super.init(frame: frame)
+        setAccessibilityElement(true)
+        setAccessibilityRole(.group)
+        setAccessibilityLabel("Selection size")
+        updateAccessibilityValue(postNotification: false)
     }
 
     required init?(coder: NSCoder) { fatalError() }
@@ -1184,6 +1189,13 @@ private final class AllInOneSelectionOverlayView: NSView {
 
     func setSelectionRect(_ selectionRect: CGRect) {
         self.selectionRect = selectionRect.standardized
+    }
+
+    private func updateAccessibilityValue(postNotification: Bool) {
+        setAccessibilityValue(CaptureSelectionChromeLayout.dimensionText(for: selectionRect.size))
+        if postNotification {
+            NSAccessibility.post(element: self, notification: .valueChanged)
+        }
     }
 
     func setActivePreset(_ preset: CapturePreset) {

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -1417,8 +1417,8 @@ private final class AllInOneSelectionOverlayView: NSView {
         context.fill(rect)
         context.restoreGState()
 
-        drawSelectionChrome(in: context, rect: rect)
         drawDimensionHUD(in: context, selectionRect: rect)
+        drawSelectionChrome(in: context, rect: rect)
     }
 
     private func updateCursor(for point: CGPoint) {

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -1417,8 +1417,9 @@ private final class AllInOneSelectionOverlayView: NSView {
         context.fill(rect)
         context.restoreGState()
 
+        drawSelectionBorder(in: context, rect: rect)
         drawDimensionHUD(in: context, selectionRect: rect)
-        drawSelectionChrome(in: context, rect: rect)
+        drawSelectionHandles(in: context, rect: rect)
     }
 
     private func updateCursor(for point: CGPoint) {
@@ -1481,7 +1482,7 @@ private final class AllInOneSelectionOverlayView: NSView {
         }
     }
 
-    private func drawSelectionChrome(in context: CGContext, rect: CGRect) {
+    private func drawSelectionBorder(in context: CGContext, rect: CGRect) {
         context.saveGState()
         context.setStrokeColor(NSColor.black.withAlphaComponent(0.55).cgColor)
         context.setLineWidth(3)
@@ -1490,7 +1491,9 @@ private final class AllInOneSelectionOverlayView: NSView {
         context.setLineWidth(1.5)
         context.stroke(rect)
         context.restoreGState()
+    }
 
+    private func drawSelectionHandles(in context: CGContext, rect: CGRect) {
         let handles = CaptureSelectionChromeLayout.visibleHandles(
             for: rect.size,
             isFixedSize: activePreset.isFixedSize

--- a/App/Sources/QuickAccess/QuickAccessView.swift
+++ b/App/Sources/QuickAccess/QuickAccessView.swift
@@ -53,19 +53,19 @@ struct QuickAccessView: View {
     }
 
     private enum HoverAction: Hashable {
-        case copy, save, drag, annotate, ocr, translate, pin, upload, linkCopied
+        case copy, save, drag, annotate, ocr, translate, pin, upload, linkCopied, overflow
     }
 
     private var isRevealed: Bool { isHovering || isFocused }
     private static let panelCornerRadius: CGFloat = 14
-    private static let thumbnailSize = CGSize(width: 268, height: 116)
+    private static let thumbnailSize = CGSize(width: 268, height: 142)
 
     private var reduceMotion: Bool {
         NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
     }
 
     var body: some View {
-        VStack(spacing: 9) {
+        VStack(spacing: 8) {
             thumbnailFrame
 
             // Caption at rest / chrome on hover share the same slot so the
@@ -76,7 +76,7 @@ struct QuickAccessView: View {
                 chromeStrip
                     .opacity(isRevealed ? 1 : 0)
             }
-            .frame(height: 50)
+            .frame(height: 34)
         }
         .padding(8)
         .background(hiddenEscapeButton)
@@ -100,6 +100,7 @@ struct QuickAccessView: View {
         }
         .onDisappear { cleanupPreparedDragFile() }
         .focusable()
+        .focusEffectDisabled()
         .focused($isFocused)
         .overlay(alignment: .bottom) {
             if case .failed(let err) = visualState {
@@ -123,7 +124,7 @@ struct QuickAccessView: View {
         ZStack(alignment: .topTrailing) {
             Image(nsImage: thumbnail)
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .aspectRatio(contentMode: .fill)
                 .frame(width: Self.thumbnailSize.width, height: Self.thumbnailSize.height)
                 .background(Color.black.opacity(0.12))
                 .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
@@ -188,88 +189,98 @@ struct QuickAccessView: View {
     // MARK: - Chrome (revealed on hover/focus)
 
     private var chromeStrip: some View {
-        VStack(spacing: 4) {
-            contextLine
-            toolbar
-        }
-    }
-
-    private var contextLine: some View {
-        HStack(alignment: .center, spacing: 8) {
-            Text(contextTitle)
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(.primary)
-            Spacer()
-            contextHintView
-        }
-        .padding(.horizontal, 4)
-        .frame(height: 20)
-    }
-
-    private var contextTitle: String {
-        guard let action = hoveredAction else { return "Quick Access" }
-        return label(action)
-    }
-
-    /// Right-aligned hint for the hovered action: a keycap-style pill
-    /// showing the shortcut (⌘S, ⌘⇧T, …) plus — for Translate — a subtle
-    /// suffix naming the target language.
-    @ViewBuilder
-    private var contextHintView: some View {
-        HStack(spacing: 5) {
-            if let key = hoveredShortcutKey {
-                ShortcutKeyPill(text: key)
-            }
-            if let suffix = hoveredHintSuffix {
-                Text(suffix)
-                    .font(.system(size: 10))
-                    .foregroundStyle(.secondary)
-            }
-        }
-    }
-
-    private var hoveredShortcutKey: String? {
-        guard let action = hoveredAction else { return nil }
-        switch action {
-        case .copy:      return "⌘C"
-        case .save:      return "⌘S"
-        case .drag:      return nil
-        case .annotate:  return "⌘E"
-        case .ocr:       return "⌘⇧O"
-        case .translate: return "⌘⇧T"
-        case .pin:       return "⌘P"
-        case .upload, .linkCopied: return nil
-        }
-    }
-
-    private var hoveredHintSuffix: String? {
-        guard hoveredAction == .translate,
-              let lang = targetLanguageDisplay, !lang.isEmpty else { return nil }
-        return "→ \(lang)"
+        toolbar
     }
 
     private var toolbar: some View {
         HStack(spacing: 2) {
-            dragTool
-            toolButton(.copy, icon: "doc.on.doc", action: onCopy)
-            toolButton(.save, icon: "square.and.arrow.down", isPrimary: true, action: onSave)
-            if shareCoordinator != nil {
-                toolDivider
-                uploadButton
+            ForEach(visibleActions, id: \.self) { action in
+                if startsNewGroup(action) {
+                    toolDivider
+                }
+                visibleTool(action)
             }
             toolDivider
-            toolButton(.annotate, icon: "pencil.tip.crop.circle", action: onAnnotate)
-            toolDivider
-            toolButton(.ocr, icon: "text.viewfinder", action: onOCR)
-            toolButton(.translate, icon: "character.bubble", action: onTranslate)
-            toolDivider
-            toolButton(.pin, icon: "pin", action: onPin)
+            overflowMenu
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel(Text("Quick Access actions"))
         .padding(.horizontal, 4)
         .padding(.vertical, 3)
         .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private var visibleActions: [QuickAccessActionKind] {
+        QuickAccessActionLayout.visibleActions(sharingAvailable: shareCoordinator != nil)
+    }
+
+    private func startsNewGroup(_ action: QuickAccessActionKind) -> Bool {
+        switch action {
+        case .upload, .annotate, .pin:
+            return true
+        case .drag, .copy, .save, .ocr, .translate:
+            return false
+        }
+    }
+
+    @ViewBuilder
+    private func visibleTool(_ action: QuickAccessActionKind) -> some View {
+        switch action {
+        case .drag:
+            dragTool
+        case .copy:
+            toolButton(.copy, icon: "doc.on.doc", action: onCopy)
+        case .save:
+            toolButton(.save, icon: "square.and.arrow.down", isPrimary: true, action: onSave)
+        case .upload:
+            if shareCoordinator != nil {
+                uploadButton
+            }
+        case .annotate:
+            toolButton(.annotate, icon: "pencil.tip.crop.circle", action: onAnnotate)
+        case .pin:
+            toolButton(.pin, icon: "pin", action: onPin)
+        case .ocr, .translate:
+            EmptyView()
+        }
+    }
+
+    private var overflowMenu: some View {
+        Menu {
+            ForEach(QuickAccessActionLayout.overflowActions, id: \.rawValue) { action in
+                overflowTool(action)
+            }
+        } label: {
+            toolFace(.overflow, icon: "ellipsis", isPrimary: false)
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .onHover { hoveredAction = $0 ? .overflow : nil }
+        .help("More actions")
+        .accessibilityLabel(Text("More actions"))
+    }
+
+    @ViewBuilder
+    private func overflowTool(_ action: QuickAccessActionKind) -> some View {
+        switch action {
+        case .ocr:
+            Button(action: onOCR) {
+                Label("Extract Text", systemImage: "text.viewfinder")
+            }
+            .keyboardShortcut("o", modifiers: [.command, .shift])
+        case .translate:
+            Button(action: onTranslate) {
+                if let targetLanguageDisplay, !targetLanguageDisplay.isEmpty {
+                    Label("Translate to \(targetLanguageDisplay)", systemImage: "character.bubble")
+                } else {
+                    Label("Translate", systemImage: "character.bubble")
+                }
+            }
+            .keyboardShortcut("t", modifiers: [.command, .shift])
+        case .drag, .copy, .save, .upload, .annotate, .pin:
+            EmptyView()
+        }
     }
 
     @ViewBuilder
@@ -541,7 +552,7 @@ struct QuickAccessView: View {
         case .ocr:       return ("o", [.command, .shift])
         case .translate: return ("t", [.command, .shift])
         case .pin:       return ("p", [.command])
-        case .upload, .linkCopied: return nil
+        case .upload, .linkCopied, .overflow: return nil
         }
     }
 
@@ -570,6 +581,7 @@ struct QuickAccessView: View {
         case .pin: return String(localized: "Pin")
         case .upload: return String(localized: "Upload to Cloud")
         case .linkCopied: return String(localized: "Link Copied!")
+        case .overflow: return String(localized: "More actions")
         }
     }
 
@@ -584,6 +596,7 @@ struct QuickAccessView: View {
         case .pin: return String(localized: "Pin to screen")
         case .upload: return String(localized: "Upload screenshot to cloud and copy link")
         case .linkCopied: return String(localized: "Link has been copied to clipboard")
+        case .overflow: return String(localized: "Show extract text and translation actions")
         }
     }
 }
@@ -632,30 +645,5 @@ private struct FailureToast: View {
         case .unknown(let detail):
             return String(localized: "Upload failed: \(detail)")
         }
-    }
-}
-
-// MARK: - Shortcut keycap pill
-
-/// Renders a keyboard shortcut (e.g. "⌘S", "⌘⇧T") as a compact, slightly
-/// tinted pill — visually distinct from surrounding secondary text, which at
-/// 9pt/secondary on ultraThinMaterial was too dim to read at a glance.
-private struct ShortcutKeyPill: View {
-    let text: String
-
-    var body: some View {
-        Text(text)
-            .font(.system(size: 10, weight: .medium, design: .monospaced))
-            .foregroundStyle(.primary.opacity(0.85))
-            .padding(.horizontal, 6)
-            .padding(.vertical, 1.5)
-            .background(
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(Color.primary.opacity(0.10))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 4)
-                    .stroke(Color.primary.opacity(0.08), lineWidth: 0.5)
-            )
     }
 }

--- a/Packages/CaptureKit/Sources/CaptureKit/CaptureChromeLayout.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/CaptureChromeLayout.swift
@@ -1,0 +1,21 @@
+import CoreGraphics
+
+public enum CaptureChromeDensity: Sendable {
+    case mini
+    case compact
+    case regular
+}
+
+public enum CaptureChromeLayout {
+    public static let startsWithCompactSideRail = true
+
+    public static func annotationDensity(for availableWidth: CGFloat) -> CaptureChromeDensity {
+        if availableWidth < 480 {
+            return .mini
+        }
+        if availableWidth < 840 {
+            return .compact
+        }
+        return .regular
+    }
+}

--- a/Packages/CaptureKit/Sources/CaptureKit/CaptureChromeLayout.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/CaptureChromeLayout.swift
@@ -13,7 +13,7 @@ public enum CaptureChromeLayout {
         if availableWidth < 480 {
             return .mini
         }
-        if availableWidth < 840 {
+        if availableWidth < 1_000 {
             return .compact
         }
         return .regular

--- a/Packages/CaptureKit/Sources/CaptureKit/CaptureChromeLayout.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/CaptureChromeLayout.swift
@@ -18,4 +18,20 @@ public enum CaptureChromeLayout {
         }
         return .regular
     }
+
+    public static func annotationToolbarHeight(
+        density: CaptureChromeDensity,
+        showsOverflow: Bool
+    ) -> CGFloat {
+        switch density {
+        case .mini, .compact:
+            return showsOverflow ? 102 : 58
+        case .regular:
+            return 58
+        }
+    }
+
+    public static func showsInlineTextEffects(for density: CaptureChromeDensity) -> Bool {
+        density == .regular
+    }
 }

--- a/Packages/CaptureKit/Sources/CaptureKit/CaptureSelectionChromeLayout.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/CaptureSelectionChromeLayout.swift
@@ -1,0 +1,41 @@
+import CoreGraphics
+
+public enum CaptureSelectionChromeLayout {
+    public static let minimumEdgeHandleDimension: CGFloat = 80
+
+    public static func visibleHandles(
+        for selectionSize: CGSize,
+        isFixedSize: Bool
+    ) -> [CaptureSelectionResizeHandle] {
+        guard !isFixedSize else { return [] }
+        let corners: [CaptureSelectionResizeHandle] = [
+            .topLeft, .topRight, .bottomRight, .bottomLeft,
+        ]
+        guard min(selectionSize.width, selectionSize.height) >= minimumEdgeHandleDimension else {
+            return corners
+        }
+        return [.topLeft, .top, .topRight, .right, .bottomRight, .bottom, .bottomLeft, .left]
+    }
+
+    public static func dimensionText(for selectionSize: CGSize) -> String {
+        "\(max(1, Int(selectionSize.width.rounded()))) × \(max(1, Int(selectionSize.height.rounded())))"
+    }
+
+    public static func dimensionHUDOrigin(
+        selectionRect: CGRect,
+        hudSize: CGSize,
+        in bounds: CGRect,
+        gap: CGFloat = 8,
+        insideInset: CGFloat = 10
+    ) -> CGPoint {
+        let clampedX = min(max(selectionRect.minX, bounds.minX), bounds.maxX - hudSize.width)
+        let aboveY = selectionRect.maxY + gap
+        if aboveY + hudSize.height <= bounds.maxY {
+            return CGPoint(x: clampedX, y: aboveY)
+        }
+        return CGPoint(
+            x: min(max(selectionRect.minX + insideInset, bounds.minX), bounds.maxX - hudSize.width),
+            y: min(max(selectionRect.maxY - hudSize.height - insideInset, bounds.minY), bounds.maxY - hudSize.height)
+        )
+    }
+}

--- a/Packages/CaptureKit/Sources/CaptureKit/CaptureSelectionChromeLayout.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/CaptureSelectionChromeLayout.swift
@@ -33,10 +33,6 @@ public enum CaptureSelectionChromeLayout {
         if aboveY + hudSize.height <= bounds.maxY {
             return CGPoint(x: clampedX, y: aboveY)
         }
-        let belowY = selectionRect.minY - gap - hudSize.height
-        if belowY >= bounds.minY {
-            return CGPoint(x: clampedX, y: belowY)
-        }
         return CGPoint(
             x: min(max(selectionRect.minX + insideInset, bounds.minX), bounds.maxX - hudSize.width),
             y: min(max(selectionRect.maxY - hudSize.height - insideInset, bounds.minY), bounds.maxY - hudSize.height)

--- a/Packages/CaptureKit/Sources/CaptureKit/CaptureSelectionChromeLayout.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/CaptureSelectionChromeLayout.swift
@@ -33,6 +33,10 @@ public enum CaptureSelectionChromeLayout {
         if aboveY + hudSize.height <= bounds.maxY {
             return CGPoint(x: clampedX, y: aboveY)
         }
+        let belowY = selectionRect.minY - gap - hudSize.height
+        if belowY >= bounds.minY {
+            return CGPoint(x: clampedX, y: belowY)
+        }
         return CGPoint(
             x: min(max(selectionRect.minX + insideInset, bounds.minX), bounds.maxX - hudSize.width),
             y: min(max(selectionRect.maxY - hudSize.height - insideInset, bounds.minY), bounds.maxY - hudSize.height)

--- a/Packages/CaptureKit/Tests/CaptureKitTests/CaptureChromeLayoutTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/CaptureChromeLayoutTests.swift
@@ -1,0 +1,26 @@
+import CoreGraphics
+import Testing
+@testable import CaptureKit
+
+@Suite("Capture chrome layout")
+struct CaptureChromeLayoutTests {
+    @Test("All-in-One side rail starts compact regardless of selection height")
+    func sideRailStartsCompact() {
+        #expect(CaptureChromeLayout.startsWithCompactSideRail)
+    }
+
+    @Test("Annotation toolbar density follows available width")
+    func annotationDensity() {
+        #expect(CaptureChromeLayout.annotationDensity(for: 360) == .mini)
+        #expect(CaptureChromeLayout.annotationDensity(for: 700) == .compact)
+        #expect(CaptureChromeLayout.annotationDensity(for: 1_000) == .regular)
+    }
+
+    @Test("Density thresholds are stable at their boundaries")
+    func densityBoundaries() {
+        #expect(CaptureChromeLayout.annotationDensity(for: 479) == .mini)
+        #expect(CaptureChromeLayout.annotationDensity(for: 480) == .compact)
+        #expect(CaptureChromeLayout.annotationDensity(for: 839) == .compact)
+        #expect(CaptureChromeLayout.annotationDensity(for: 840) == .regular)
+    }
+}

--- a/Packages/CaptureKit/Tests/CaptureKitTests/CaptureChromeLayoutTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/CaptureChromeLayoutTests.swift
@@ -20,7 +20,7 @@ struct CaptureChromeLayoutTests {
     func densityBoundaries() {
         #expect(CaptureChromeLayout.annotationDensity(for: 479) == .mini)
         #expect(CaptureChromeLayout.annotationDensity(for: 480) == .compact)
-        #expect(CaptureChromeLayout.annotationDensity(for: 839) == .compact)
-        #expect(CaptureChromeLayout.annotationDensity(for: 840) == .regular)
+        #expect(CaptureChromeLayout.annotationDensity(for: 999) == .compact)
+        #expect(CaptureChromeLayout.annotationDensity(for: 1_000) == .regular)
     }
 }

--- a/Packages/CaptureKit/Tests/CaptureKitTests/CaptureChromeLayoutTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/CaptureChromeLayoutTests.swift
@@ -23,4 +23,21 @@ struct CaptureChromeLayoutTests {
         #expect(CaptureChromeLayout.annotationDensity(for: 999) == .compact)
         #expect(CaptureChromeLayout.annotationDensity(for: 1_000) == .regular)
     }
+
+    @Test("Annotation toolbar height depends on density and overflow, not the active tool")
+    func annotationToolbarHeight() {
+        #expect(CaptureChromeLayout.annotationToolbarHeight(density: .mini, showsOverflow: false) == 58)
+        #expect(CaptureChromeLayout.annotationToolbarHeight(density: .mini, showsOverflow: true) == 102)
+        #expect(CaptureChromeLayout.annotationToolbarHeight(density: .compact, showsOverflow: false) == 58)
+        #expect(CaptureChromeLayout.annotationToolbarHeight(density: .compact, showsOverflow: true) == 102)
+        #expect(CaptureChromeLayout.annotationToolbarHeight(density: .regular, showsOverflow: false) == 58)
+        #expect(CaptureChromeLayout.annotationToolbarHeight(density: .regular, showsOverflow: true) == 58)
+    }
+
+    @Test("Only regular density renders text effects inline")
+    func inlineTextEffects() {
+        #expect(!CaptureChromeLayout.showsInlineTextEffects(for: .mini))
+        #expect(!CaptureChromeLayout.showsInlineTextEffects(for: .compact))
+        #expect(CaptureChromeLayout.showsInlineTextEffects(for: .regular))
+    }
 }

--- a/Packages/CaptureKit/Tests/CaptureKitTests/CaptureSelectionChromeLayoutTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/CaptureSelectionChromeLayoutTests.swift
@@ -47,7 +47,7 @@ struct CaptureSelectionChromeLayoutTests {
         ) == "1140 × 564")
     }
 
-    @Test("HUD prefers above and falls below near the top edge")
+    @Test("HUD prefers above and falls inside near the top edge")
     func hudPlacement() {
         let bounds = CGRect(x: 0, y: 0, width: 1_200, height: 800)
         let hud = CGSize(width: 92, height: 24)
@@ -60,10 +60,10 @@ struct CaptureSelectionChromeLayoutTests {
             selectionRect: CGRect(x: 100, y: 500, width: 500, height: 290),
             hudSize: hud,
             in: bounds
-        ) == CGPoint(x: 100, y: 468))
+        ) == CGPoint(x: 110, y: 756))
     }
 
-    @Test("Tiny selections at the top edge place the HUD below without overlap")
+    @Test("Tiny selections at the top edge use the inside top-left fallback")
     func tinyTopEdgeHUDPlacement() {
         let bounds = CGRect(x: 0, y: 0, width: 1_200, height: 800)
         let hud = CGSize(width: 92, height: 24)
@@ -74,11 +74,10 @@ struct CaptureSelectionChromeLayoutTests {
             in: bounds
         )
 
-        #expect(origin == CGPoint(x: 100, y: 744))
-        #expect(CGRect(origin: origin, size: hud).maxY <= selection.minY)
+        #expect(origin == CGPoint(x: 110, y: 766))
     }
 
-    @Test("HUD falls inside when neither outside placement fits")
+    @Test("HUD falls inside when above does not fit")
     func insideHUDPlacement() {
         #expect(CaptureSelectionChromeLayout.dimensionHUDOrigin(
             selectionRect: CGRect(x: 100, y: 4, width: 500, height: 792),

--- a/Packages/CaptureKit/Tests/CaptureKitTests/CaptureSelectionChromeLayoutTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/CaptureSelectionChromeLayoutTests.swift
@@ -18,6 +18,18 @@ struct CaptureSelectionChromeLayoutTests {
             for: CGSize(width: 79, height: 180),
             isFixedSize: false
         ) == [.topLeft, .topRight, .bottomRight, .bottomLeft])
+        #expect(CaptureSelectionChromeLayout.visibleHandles(
+            for: CGSize(width: 180, height: 79),
+            isFixedSize: false
+        ) == [.topLeft, .topRight, .bottomRight, .bottomLeft])
+    }
+
+    @Test("The 80-by-80 boundary exposes all eight resize handles")
+    func handleThresholdBoundary() {
+        #expect(CaptureSelectionChromeLayout.visibleHandles(
+            for: CGSize(width: 80, height: 80),
+            isFixedSize: false
+        ) == [.topLeft, .top, .topRight, .right, .bottomRight, .bottom, .bottomLeft, .left])
     }
 
     @Test("Fixed-size selections hide resize handles")
@@ -35,7 +47,7 @@ struct CaptureSelectionChromeLayoutTests {
         ) == "1140 × 564")
     }
 
-    @Test("HUD prefers above and falls back inside near the top edge")
+    @Test("HUD prefers above and falls below near the top edge")
     func hudPlacement() {
         let bounds = CGRect(x: 0, y: 0, width: 1_200, height: 800)
         let hud = CGSize(width: 92, height: 24)
@@ -48,6 +60,30 @@ struct CaptureSelectionChromeLayoutTests {
             selectionRect: CGRect(x: 100, y: 500, width: 500, height: 290),
             hudSize: hud,
             in: bounds
-        ) == CGPoint(x: 110, y: 756))
+        ) == CGPoint(x: 100, y: 468))
+    }
+
+    @Test("Tiny selections at the top edge place the HUD below without overlap")
+    func tinyTopEdgeHUDPlacement() {
+        let bounds = CGRect(x: 0, y: 0, width: 1_200, height: 800)
+        let hud = CGSize(width: 92, height: 24)
+        let selection = CGRect(x: 100, y: 776, width: 120, height: 24)
+        let origin = CaptureSelectionChromeLayout.dimensionHUDOrigin(
+            selectionRect: selection,
+            hudSize: hud,
+            in: bounds
+        )
+
+        #expect(origin == CGPoint(x: 100, y: 744))
+        #expect(CGRect(origin: origin, size: hud).maxY <= selection.minY)
+    }
+
+    @Test("HUD falls inside when neither outside placement fits")
+    func insideHUDPlacement() {
+        #expect(CaptureSelectionChromeLayout.dimensionHUDOrigin(
+            selectionRect: CGRect(x: 100, y: 4, width: 500, height: 792),
+            hudSize: CGSize(width: 92, height: 24),
+            in: CGRect(x: 0, y: 0, width: 1_200, height: 800)
+        ) == CGPoint(x: 110, y: 762))
     }
 }

--- a/Packages/CaptureKit/Tests/CaptureKitTests/CaptureSelectionChromeLayoutTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/CaptureSelectionChromeLayoutTests.swift
@@ -1,0 +1,53 @@
+import CoreGraphics
+import Testing
+@testable import CaptureKit
+
+@Suite("Capture selection chrome layout")
+struct CaptureSelectionChromeLayoutTests {
+    @Test("Regular selections expose all eight resize handles")
+    func regularHandles() {
+        #expect(CaptureSelectionChromeLayout.visibleHandles(
+            for: CGSize(width: 320, height: 180),
+            isFixedSize: false
+        ).count == 8)
+    }
+
+    @Test("Small selections keep only corner handles")
+    func smallHandles() {
+        #expect(CaptureSelectionChromeLayout.visibleHandles(
+            for: CGSize(width: 79, height: 180),
+            isFixedSize: false
+        ) == [.topLeft, .topRight, .bottomRight, .bottomLeft])
+    }
+
+    @Test("Fixed-size selections hide resize handles")
+    func fixedHandles() {
+        #expect(CaptureSelectionChromeLayout.visibleHandles(
+            for: CGSize(width: 320, height: 180),
+            isFixedSize: true
+        ).isEmpty)
+    }
+
+    @Test("Dimension text uses the multiplication sign")
+    func dimensionText() {
+        #expect(CaptureSelectionChromeLayout.dimensionText(
+            for: CGSize(width: 1_139.6, height: 563.7)
+        ) == "1140 × 564")
+    }
+
+    @Test("HUD prefers above and falls back inside near the top edge")
+    func hudPlacement() {
+        let bounds = CGRect(x: 0, y: 0, width: 1_200, height: 800)
+        let hud = CGSize(width: 92, height: 24)
+        #expect(CaptureSelectionChromeLayout.dimensionHUDOrigin(
+            selectionRect: CGRect(x: 100, y: 100, width: 500, height: 300),
+            hudSize: hud,
+            in: bounds
+        ) == CGPoint(x: 100, y: 408))
+        #expect(CaptureSelectionChromeLayout.dimensionHUDOrigin(
+            selectionRect: CGRect(x: 100, y: 500, width: 500, height: 290),
+            hudSize: hud,
+            in: bounds
+        ) == CGPoint(x: 110, y: 756))
+    }
+}

--- a/Packages/SharedKit/Sources/SharedKit/QuickAccessActionLayout.swift
+++ b/Packages/SharedKit/Sources/SharedKit/QuickAccessActionLayout.swift
@@ -1,0 +1,23 @@
+public enum QuickAccessActionKind: String, CaseIterable, Sendable {
+    case drag
+    case copy
+    case save
+    case upload
+    case annotate
+    case ocr
+    case translate
+    case pin
+}
+
+public enum QuickAccessActionLayout {
+    public static func visibleActions(sharingAvailable: Bool) -> [QuickAccessActionKind] {
+        var actions: [QuickAccessActionKind] = [.drag, .copy, .save]
+        if sharingAvailable {
+            actions.append(.upload)
+        }
+        actions.append(contentsOf: [.annotate, .pin])
+        return actions
+    }
+
+    public static let overflowActions: [QuickAccessActionKind] = [.ocr, .translate]
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/QuickAccessActionLayoutTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/QuickAccessActionLayoutTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import SharedKit
+
+@Suite("Quick Access action layout")
+struct QuickAccessActionLayoutTests {
+    @Test("Core workflow remains one click without cloud sharing")
+    func visibleActionsWithoutSharing() {
+        #expect(QuickAccessActionLayout.visibleActions(sharingAvailable: false) == [
+            .drag,
+            .copy,
+            .save,
+            .annotate,
+            .pin,
+        ])
+    }
+
+    @Test("Cloud sharing adds Upload while intelligence actions stay in overflow")
+    func visibleActionsWithSharing() {
+        #expect(QuickAccessActionLayout.visibleActions(sharingAvailable: true) == [
+            .drag,
+            .copy,
+            .save,
+            .upload,
+            .annotate,
+            .pin,
+        ])
+        #expect(QuickAccessActionLayout.overflowActions == [.ocr, .translate])
+    }
+}

--- a/docs/superpowers/plans/2026-07-11-all-in-one-selection-polish.md
+++ b/docs/superpowers/plans/2026-07-11-all-in-one-selection-polish.md
@@ -26,7 +26,7 @@
 **Interfaces:**
 - Produces: `CaptureSelectionChromeLayout.visibleHandles(for:isFixedSize:) -> [CaptureSelectionResizeHandle]`
 - Produces: `CaptureSelectionChromeLayout.dimensionText(for:) -> String`
-- Produces: `CaptureSelectionChromeLayout.dimensionHUDOrigin(selectionRect:hudSize:in:gap:insideInset:) -> CGPoint`, which tries above, then below, then inside the selection.
+- Produces: `CaptureSelectionChromeLayout.dimensionHUDOrigin(selectionRect:hudSize:in:gap:insideInset:) -> CGPoint`, which tries above and otherwise falls back inside the selection.
 
 - [ ] **Step 1: Write failing policy tests**
 
@@ -68,7 +68,7 @@ struct CaptureSelectionChromeLayoutTests {
         ) == "1140 × 564")
     }
 
-    @Test("HUD prefers above and falls below near the top edge")
+    @Test("HUD prefers above and falls inside near the top edge")
     func hudPlacement() {
         let bounds = CGRect(x: 0, y: 0, width: 1_200, height: 800)
         let hud = CGSize(width: 92, height: 24)
@@ -81,10 +81,10 @@ struct CaptureSelectionChromeLayoutTests {
             selectionRect: CGRect(x: 100, y: 500, width: 500, height: 290),
             hudSize: hud,
             in: bounds
-        ) == CGPoint(x: 100, y: 468))
+        ) == CGPoint(x: 110, y: 756))
     }
 
-    @Test("Tiny selections at the top edge place the HUD below without overlap")
+    @Test("Tiny selections at the top edge use the inside top-left fallback")
     func tinyTopEdgeHUDPlacement() {
         let bounds = CGRect(x: 0, y: 0, width: 1_200, height: 800)
         let hud = CGSize(width: 92, height: 24)
@@ -95,11 +95,10 @@ struct CaptureSelectionChromeLayoutTests {
             in: bounds
         )
 
-        #expect(origin == CGPoint(x: 100, y: 744))
-        #expect(CGRect(origin: origin, size: hud).maxY <= selection.minY)
+        #expect(origin == CGPoint(x: 110, y: 766))
     }
 
-    @Test("HUD falls inside when neither outside placement fits")
+    @Test("HUD falls inside when above does not fit")
     func insideHUDPlacement() {
         #expect(CaptureSelectionChromeLayout.dimensionHUDOrigin(
             selectionRect: CGRect(x: 100, y: 4, width: 500, height: 792),
@@ -154,10 +153,6 @@ public enum CaptureSelectionChromeLayout {
         if aboveY + hudSize.height <= bounds.maxY {
             return CGPoint(x: clampedX, y: aboveY)
         }
-        let belowY = selectionRect.minY - gap - hudSize.height
-        if belowY >= bounds.minY {
-            return CGPoint(x: clampedX, y: belowY)
-        }
         return CGPoint(
             x: min(max(selectionRect.minX + insideInset, bounds.minX), bounds.maxX - hudSize.width),
             y: min(max(selectionRect.maxY - hudSize.height - insideInset, bounds.minY), bounds.maxY - hudSize.height)
@@ -207,11 +202,11 @@ if isCompact {
 
 - [ ] **Step 2: Replace bracket drawing with the new border and handles**
 
-In `drawSelectionChrome`, draw a subtle dark under-stroke, a 1.5-point white border, and one circular handle for each value returned by `visibleHandles`. Use a private `point(for:in:)` switch to map handles to corners and edge midpoints. Each handle is a 7-point white circle with a 1-point dark stroke and a soft black shadow.
+In `drawSelectionChrome`, draw a subtle dark under-stroke, a 1.5-point white border, and one circular handle for each value returned by `visibleHandles`. Use a private `point(for:in:)` switch to map handles to corners and edge midpoints. Each handle is a 7-point white circle with a 1-point dark stroke and a soft black shadow. Call this after drawing the HUD so the handles render above an inside HUD on tiny selections.
 
 - [ ] **Step 3: Draw the dimension HUD**
 
-Add `drawDimensionHUD(in:selectionRect:)`. Measure `CaptureSelectionChromeLayout.dimensionText(for:)` with `NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold)`, add 8-point horizontal and 5-point vertical padding, obtain the origin from `dimensionHUDOrigin`, then draw a rounded black 72%-opacity background, a 0.5-point white 18%-opacity stroke, and white text.
+Add `drawDimensionHUD(in:selectionRect:)`. Measure `CaptureSelectionChromeLayout.dimensionText(for:)` with `NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold)`, add 8-point horizontal and 5-point vertical padding, obtain the origin from `dimensionHUDOrigin`, then draw a rounded black 72%-opacity background, a 0.5-point white 18%-opacity stroke, and white text. In `draw(_:)`, render the HUD before `drawSelectionChrome`.
 
 - [ ] **Step 4: Reduce backdrop opacity**
 

--- a/docs/superpowers/plans/2026-07-11-all-in-one-selection-polish.md
+++ b/docs/superpowers/plans/2026-07-11-all-in-one-selection-polish.md
@@ -26,7 +26,7 @@
 **Interfaces:**
 - Produces: `CaptureSelectionChromeLayout.visibleHandles(for:isFixedSize:) -> [CaptureSelectionResizeHandle]`
 - Produces: `CaptureSelectionChromeLayout.dimensionText(for:) -> String`
-- Produces: `CaptureSelectionChromeLayout.dimensionHUDOrigin(selectionRect:hudSize:in:gap:insideInset:) -> CGPoint`
+- Produces: `CaptureSelectionChromeLayout.dimensionHUDOrigin(selectionRect:hudSize:in:gap:insideInset:) -> CGPoint`, which tries above, then below, then inside the selection.
 
 - [ ] **Step 1: Write failing policy tests**
 
@@ -68,7 +68,7 @@ struct CaptureSelectionChromeLayoutTests {
         ) == "1140 × 564")
     }
 
-    @Test("HUD prefers above and falls back inside near the top edge")
+    @Test("HUD prefers above and falls below near the top edge")
     func hudPlacement() {
         let bounds = CGRect(x: 0, y: 0, width: 1_200, height: 800)
         let hud = CGSize(width: 92, height: 24)
@@ -81,7 +81,31 @@ struct CaptureSelectionChromeLayoutTests {
             selectionRect: CGRect(x: 100, y: 500, width: 500, height: 290),
             hudSize: hud,
             in: bounds
-        ) == CGPoint(x: 110, y: 756))
+        ) == CGPoint(x: 100, y: 468))
+    }
+
+    @Test("Tiny selections at the top edge place the HUD below without overlap")
+    func tinyTopEdgeHUDPlacement() {
+        let bounds = CGRect(x: 0, y: 0, width: 1_200, height: 800)
+        let hud = CGSize(width: 92, height: 24)
+        let selection = CGRect(x: 100, y: 776, width: 120, height: 24)
+        let origin = CaptureSelectionChromeLayout.dimensionHUDOrigin(
+            selectionRect: selection,
+            hudSize: hud,
+            in: bounds
+        )
+
+        #expect(origin == CGPoint(x: 100, y: 744))
+        #expect(CGRect(origin: origin, size: hud).maxY <= selection.minY)
+    }
+
+    @Test("HUD falls inside when neither outside placement fits")
+    func insideHUDPlacement() {
+        #expect(CaptureSelectionChromeLayout.dimensionHUDOrigin(
+            selectionRect: CGRect(x: 100, y: 4, width: 500, height: 792),
+            hudSize: CGSize(width: 92, height: 24),
+            in: CGRect(x: 0, y: 0, width: 1_200, height: 800)
+        ) == CGPoint(x: 110, y: 762))
     }
 }
 ```
@@ -129,6 +153,10 @@ public enum CaptureSelectionChromeLayout {
         let aboveY = selectionRect.maxY + gap
         if aboveY + hudSize.height <= bounds.maxY {
             return CGPoint(x: clampedX, y: aboveY)
+        }
+        let belowY = selectionRect.minY - gap - hudSize.height
+        if belowY >= bounds.minY {
+            return CGPoint(x: clampedX, y: belowY)
         }
         return CGPoint(
             x: min(max(selectionRect.minX + insideInset, bounds.minX), bounds.maxX - hudSize.width),

--- a/docs/superpowers/plans/2026-07-11-all-in-one-selection-polish.md
+++ b/docs/superpowers/plans/2026-07-11-all-in-one-selection-polish.md
@@ -1,0 +1,230 @@
+# All-in-One Selection Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the heavy All-in-One selection brackets with adaptive circular handles, move size feedback into a floating HUD, and shorten the default side rail.
+
+**Architecture:** Add a pure `CaptureSelectionChromeLayout` policy to CaptureKit for visible handles, dimension text, and HUD placement. Keep Core Graphics drawing in the existing AppKit overlay and keep all capture geometry and hit-testing unchanged.
+
+**Tech Stack:** Swift 6.0, CoreGraphics, AppKit, Swift Testing, XcodeGen/Xcode build.
+
+## Global Constraints
+
+- Target macOS 15.0 or later.
+- Preserve the existing 26-point resize hit targets, cursors, presets, capture actions, and shortcuts.
+- Fixed-size presets must not display resize handles.
+- Do not change Quick Access or annotation tool behavior in this pass.
+
+---
+
+### Task 1: Testable Selection Chrome Policy
+
+**Files:**
+- Create: `Packages/CaptureKit/Sources/CaptureKit/CaptureSelectionChromeLayout.swift`
+- Create: `Packages/CaptureKit/Tests/CaptureKitTests/CaptureSelectionChromeLayoutTests.swift`
+
+**Interfaces:**
+- Produces: `CaptureSelectionChromeLayout.visibleHandles(for:isFixedSize:) -> [CaptureSelectionResizeHandle]`
+- Produces: `CaptureSelectionChromeLayout.dimensionText(for:) -> String`
+- Produces: `CaptureSelectionChromeLayout.dimensionHUDOrigin(selectionRect:hudSize:in:gap:insideInset:) -> CGPoint`
+
+- [ ] **Step 1: Write failing policy tests**
+
+```swift
+import CoreGraphics
+import Testing
+@testable import CaptureKit
+
+@Suite("Capture selection chrome layout")
+struct CaptureSelectionChromeLayoutTests {
+    @Test("Regular selections expose all eight resize handles")
+    func regularHandles() {
+        #expect(CaptureSelectionChromeLayout.visibleHandles(
+            for: CGSize(width: 320, height: 180),
+            isFixedSize: false
+        ).count == 8)
+    }
+
+    @Test("Small selections keep only corner handles")
+    func smallHandles() {
+        #expect(CaptureSelectionChromeLayout.visibleHandles(
+            for: CGSize(width: 79, height: 180),
+            isFixedSize: false
+        ) == [.topLeft, .topRight, .bottomRight, .bottomLeft])
+    }
+
+    @Test("Fixed-size selections hide resize handles")
+    func fixedHandles() {
+        #expect(CaptureSelectionChromeLayout.visibleHandles(
+            for: CGSize(width: 320, height: 180),
+            isFixedSize: true
+        ).isEmpty)
+    }
+
+    @Test("Dimension text uses the multiplication sign")
+    func dimensionText() {
+        #expect(CaptureSelectionChromeLayout.dimensionText(
+            for: CGSize(width: 1_139.6, height: 563.7)
+        ) == "1140 × 564")
+    }
+
+    @Test("HUD prefers above and falls back inside near the top edge")
+    func hudPlacement() {
+        let bounds = CGRect(x: 0, y: 0, width: 1_200, height: 800)
+        let hud = CGSize(width: 92, height: 24)
+        #expect(CaptureSelectionChromeLayout.dimensionHUDOrigin(
+            selectionRect: CGRect(x: 100, y: 100, width: 500, height: 300),
+            hudSize: hud,
+            in: bounds
+        ) == CGPoint(x: 100, y: 408))
+        #expect(CaptureSelectionChromeLayout.dimensionHUDOrigin(
+            selectionRect: CGRect(x: 100, y: 500, width: 500, height: 290),
+            hudSize: hud,
+            in: bounds
+        ) == CGPoint(x: 110, y: 756))
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and verify the missing policy fails**
+
+Run: `rtk test swift test --package-path Packages/CaptureKit --filter CaptureSelectionChromeLayoutTests`
+
+Expected: FAIL because `CaptureSelectionChromeLayout` does not exist.
+
+- [ ] **Step 3: Implement the minimal policy**
+
+```swift
+import CoreGraphics
+
+public enum CaptureSelectionChromeLayout {
+    public static let minimumEdgeHandleDimension: CGFloat = 80
+
+    public static func visibleHandles(
+        for selectionSize: CGSize,
+        isFixedSize: Bool
+    ) -> [CaptureSelectionResizeHandle] {
+        guard !isFixedSize else { return [] }
+        let corners: [CaptureSelectionResizeHandle] = [
+            .topLeft, .topRight, .bottomRight, .bottomLeft,
+        ]
+        guard min(selectionSize.width, selectionSize.height) >= minimumEdgeHandleDimension else {
+            return corners
+        }
+        return [.topLeft, .top, .topRight, .right, .bottomRight, .bottom, .bottomLeft, .left]
+    }
+
+    public static func dimensionText(for selectionSize: CGSize) -> String {
+        "\(max(1, Int(selectionSize.width.rounded()))) × \(max(1, Int(selectionSize.height.rounded())))"
+    }
+
+    public static func dimensionHUDOrigin(
+        selectionRect: CGRect,
+        hudSize: CGSize,
+        in bounds: CGRect,
+        gap: CGFloat = 8,
+        insideInset: CGFloat = 10
+    ) -> CGPoint {
+        let clampedX = min(max(selectionRect.minX, bounds.minX), bounds.maxX - hudSize.width)
+        let aboveY = selectionRect.maxY + gap
+        if aboveY + hudSize.height <= bounds.maxY {
+            return CGPoint(x: clampedX, y: aboveY)
+        }
+        return CGPoint(
+            x: min(max(selectionRect.minX + insideInset, bounds.minX), bounds.maxX - hudSize.width),
+            y: min(max(selectionRect.maxY - hudSize.height - insideInset, bounds.minY), bounds.maxY - hudSize.height)
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Run the filtered and full CaptureKit tests**
+
+Run: `rtk test swift test --package-path Packages/CaptureKit --filter CaptureSelectionChromeLayoutTests`
+
+Expected: PASS.
+
+Run: `rtk test swift test --package-path Packages/CaptureKit`
+
+Expected: all CaptureKit tests pass.
+
+### Task 2: AppKit Selection Chrome and Dimension HUD
+
+**Files:**
+- Modify: `App/Sources/Capture/CaptureAllInOneToolbarWindow.swift:590-620`
+- Modify: `App/Sources/Capture/CaptureAllInOneToolbarWindow.swift:695-755`
+- Modify: `App/Sources/Capture/CaptureAllInOneToolbarWindow.swift:1423-1545`
+
+**Interfaces:**
+- Consumes all three `CaptureSelectionChromeLayout` methods from Task 1.
+- Preserves `CaptureSelectionGeometry.hitTarget`, `hitSlop`, and cursor behavior.
+
+- [ ] **Step 1: Remove the rail dimension card and calculate exact rail contents**
+
+Remove `railDimensionPill` from `sideRail`, delete that private view, and replace `preferredRailHeight` item construction with:
+
+```swift
+var itemHeights: [CGFloat] = []
+if !isCompact || showsOverflow {
+    itemHeights += Array(repeating: rowHeight, count: 7)
+    itemHeights.append(dividerHeight)
+    itemHeights.append(presetHeight)
+}
+itemHeights += Array(repeating: rowHeight, count: 4)
+if isCompact {
+    itemHeights.append(dividerHeight)
+    itemHeights.append(rowHeight)
+}
+```
+
+- [ ] **Step 2: Replace bracket drawing with the new border and handles**
+
+In `drawSelectionChrome`, draw a subtle dark under-stroke, a 1.5-point white border, and one circular handle for each value returned by `visibleHandles`. Use a private `point(for:in:)` switch to map handles to corners and edge midpoints. Each handle is a 7-point white circle with a 1-point dark stroke and a soft black shadow.
+
+- [ ] **Step 3: Draw the dimension HUD**
+
+Add `drawDimensionHUD(in:selectionRect:)`. Measure `CaptureSelectionChromeLayout.dimensionText(for:)` with `NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold)`, add 8-point horizontal and 5-point vertical padding, obtain the origin from `dimensionHUDOrigin`, then draw a rounded black 72%-opacity background, a 0.5-point white 18%-opacity stroke, and white text.
+
+- [ ] **Step 4: Reduce backdrop opacity**
+
+Change the outside fill from black at `0.38` opacity to `0.32` and leave the selected region clear.
+
+- [ ] **Step 5: Build the full app**
+
+Run: `rtk err xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug -derivedDataPath build/DerivedData build`
+
+Expected: exit code 0 with no new errors.
+
+### Task 3: Verification and Visual Review
+
+**Files:**
+- No source changes expected unless verification exposes a concrete defect.
+
+- [ ] **Step 1: Run focused package suites**
+
+Run in parallel:
+
+```bash
+rtk test swift test --package-path Packages/CaptureKit
+rtk test swift test --package-path Packages/SharedKit
+```
+
+Expected: both suites pass.
+
+- [ ] **Step 2: Check the patch**
+
+Run: `rtk git diff --check`
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 3: Launch one test instance**
+
+Close existing Capso processes, launch `build/DerivedData/Build/Products/Debug/Capso.app`, and verify that only that executable remains running.
+
+- [ ] **Step 4: Visually inspect three sizes**
+
+Create small, medium, and large All-in-One selections. Confirm that small selections have four corner handles, regular selections have eight handles, fixed-size presets have no resize handles, the dimension HUD never leaves the screen, and the side rail does not overlap the annotation toolbar.
+
+- [ ] **Step 5: Capture review screenshots**
+
+Save screenshots under `/tmp/capso-all-in-one-selection-polish/` and include the small, medium, and large states in the handoff.

--- a/docs/superpowers/plans/2026-07-11-all-in-one-text-toolbar.md
+++ b/docs/superpowers/plans/2026-07-11-all-in-one-text-toolbar.md
@@ -1,0 +1,229 @@
+# All-in-One Text Toolbar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep mini and compact All-in-One Text toolbars at a stable height and move Background, Box, and Stroke into a dedicated Text Style popover.
+
+**Architecture:** Put density-dependent toolbar height in the existing pure CaptureKit chrome policy, then consume it from the AppKit panel frame. Keep text-effect state in `AllInOneAnnotationSession`; replace the compact-only text row with a SwiftUI popover while retaining regular inline controls.
+
+**Tech Stack:** Swift 6.0, SwiftUI, AppKit, CoreGraphics, Swift Testing.
+
+## Global Constraints
+
+- Target macOS 15.0 or later.
+- Mini is 300 by 58 points when collapsed.
+- Compact is 58 points high when collapsed and 102 points high when More is expanded.
+- Regular is 1,000 by 58 points.
+- Selecting or editing Text must not add toolbar height.
+- Preserve text rendering, font-size range, UserDefaults keys, annotation shortcuts, right-side actions, and selection geometry.
+
+---
+
+### Task 1: Testable Annotation Toolbar Height Policy
+
+**Files:**
+- Modify: `Packages/CaptureKit/Sources/CaptureKit/CaptureChromeLayout.swift`
+- Modify: `Packages/CaptureKit/Tests/CaptureKitTests/CaptureChromeLayoutTests.swift`
+
+**Interfaces:**
+- Produces: `CaptureChromeLayout.annotationToolbarHeight(density:showsOverflow:) -> CGFloat`
+- Produces: `CaptureChromeLayout.showsInlineTextEffects(for:) -> Bool`
+
+- [ ] **Step 1: Write failing policy tests**
+
+```swift
+@Test("Annotation toolbar height depends on density and overflow, not the active tool")
+func annotationToolbarHeight() {
+    #expect(CaptureChromeLayout.annotationToolbarHeight(density: .mini, showsOverflow: false) == 58)
+    #expect(CaptureChromeLayout.annotationToolbarHeight(density: .mini, showsOverflow: true) == 102)
+    #expect(CaptureChromeLayout.annotationToolbarHeight(density: .compact, showsOverflow: false) == 58)
+    #expect(CaptureChromeLayout.annotationToolbarHeight(density: .compact, showsOverflow: true) == 102)
+    #expect(CaptureChromeLayout.annotationToolbarHeight(density: .regular, showsOverflow: false) == 58)
+    #expect(CaptureChromeLayout.annotationToolbarHeight(density: .regular, showsOverflow: true) == 58)
+}
+
+@Test("Only regular density renders text effects inline")
+func inlineTextEffects() {
+    #expect(!CaptureChromeLayout.showsInlineTextEffects(for: .mini))
+    #expect(!CaptureChromeLayout.showsInlineTextEffects(for: .compact))
+    #expect(CaptureChromeLayout.showsInlineTextEffects(for: .regular))
+}
+```
+
+- [ ] **Step 2: Run the filtered tests and verify the missing APIs fail**
+
+Run: `rtk test swift test --package-path Packages/CaptureKit --filter CaptureChromeLayoutTests`
+
+Expected: FAIL because the two policy methods do not exist.
+
+- [ ] **Step 3: Implement the minimal policy**
+
+```swift
+public static func annotationToolbarHeight(
+    density: CaptureChromeDensity,
+    showsOverflow: Bool
+) -> CGFloat {
+    switch density {
+    case .mini, .compact:
+        return showsOverflow ? 102 : 58
+    case .regular:
+        return 58
+    }
+}
+
+public static func showsInlineTextEffects(for density: CaptureChromeDensity) -> Bool {
+    density == .regular
+}
+```
+
+- [ ] **Step 4: Run filtered and full CaptureKit tests**
+
+Run: `rtk test swift test --package-path Packages/CaptureKit --filter CaptureChromeLayoutTests`
+
+Expected: PASS.
+
+Run: `rtk test swift test --package-path Packages/CaptureKit`
+
+Expected: all CaptureKit tests pass.
+
+### Task 2: Stable Text Toolbar and Style Popover
+
+**Files:**
+- Modify: `App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift:172-210`
+- Modify: `App/Sources/Capture/CaptureAllInOneAnnotationOverlay.swift:586-990`
+- Modify: `App/Resources/Localizable.xcstrings`
+
+**Interfaces:**
+- Consumes: `CaptureChromeLayout.annotationToolbarHeight(density:showsOverflow:)`
+- Consumes: `CaptureChromeLayout.showsInlineTextEffects(for:)`
+- Preserves: `annotationTextFillEnabled`, `annotationTextOutlineEnabled`, and `annotationTextStrokeEnabled` UserDefaults keys.
+
+- [ ] **Step 1: Make the panel frame independent of Text mode**
+
+Delete the `showsTextOptions` height adjustment and calculate height with:
+
+```swift
+let height = CaptureChromeLayout.annotationToolbarHeight(
+    density: density,
+    showsOverflow: showsOverflow
+)
+```
+
+Keep existing width calculations for mini, compact, and regular densities.
+
+- [ ] **Step 2: Remove the compact text-effects row**
+
+Delete both `if isFontSizeMode { textEffectsRow }` insertions from `adaptiveToolbar` and `miniToolbar`, then delete the unused `textEffectsRow` and `textEffectButton` helpers.
+
+- [ ] **Step 3: Add stable Text Style state and placement**
+
+Add:
+
+```swift
+@State private var showsTextStylePopover = false
+
+private var hasActiveTextEffect: Bool {
+    session.textFillEnabled || session.textOutlineEnabled || session.textStrokeEnabled
+}
+```
+
+In mini, place `textStyleButton` after the font-size value and before More when `isFontSizeMode`.
+
+In compact, place `textStyleButton` after `compactStatus` and before More when `isFontSizeMode`.
+
+Regular continues to render `textEffectsInlineControls` inside `primaryControls` when `CaptureChromeLayout.showsInlineTextEffects(for: session.toolbarDensity)` is true.
+
+- [ ] **Step 4: Implement the Text Style button and popover**
+
+```swift
+private var textStyleButton: some View {
+    Button {
+        showsTextStylePopover.toggle()
+    } label: {
+        Image(systemName: "textformat")
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundStyle(.white)
+            .frame(width: 38, height: 38)
+            .background(buttonBackground(isActive: hasActiveTextEffect, isEnabled: true))
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+    .buttonStyle(.plain)
+    .help("Text Style")
+    .accessibilityLabel(Text("Text Style"))
+    .accessibilityValue(Text(hasActiveTextEffect ? "On" : "Off"))
+    .popover(isPresented: $showsTextStylePopover, arrowEdge: .top) {
+        textStylePopover
+    }
+}
+```
+
+The popover is one horizontal `HStack(spacing: 6)` with three 72-by-48 toggle buttons. Use `rectangle.fill` / Background, `rectangle` / Box, and `textformat` / Stroke. Each action must toggle its existing session property, persist its existing UserDefaults key, and call `session.updateSelectedStyle()`.
+
+- [ ] **Step 5: Dismiss Text Style when Text mode ends**
+
+Attach:
+
+```swift
+.onChange(of: isFontSizeMode) { _, isTextMode in
+    if !isTextMode {
+        showsTextStylePopover = false
+    }
+}
+```
+
+- [ ] **Step 6: Add localized labels**
+
+Reuse the existing `Background` entry. Add `Box`, `Stroke`, and `Text Style` to `Localizable.xcstrings` with these translations:
+
+| Key | ja | ko | zh-Hans |
+|---|---|---|---|
+| Box | ボックス | 상자 | 方框 |
+| Stroke | ストローク | 외곽선 | 描边 |
+| Text Style | テキストスタイル | 텍스트 스타일 | 文字样式 |
+
+- [ ] **Step 7: Build the app**
+
+Run: `rtk err xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug -derivedDataPath build/DerivedData build`
+
+Expected: exit code 0 with no new errors.
+
+### Task 3: Regression and Visual Verification
+
+**Files:**
+- No source changes expected unless verification exposes a concrete defect.
+
+- [ ] **Step 1: Run package suites**
+
+Run in parallel:
+
+```bash
+rtk test swift test --package-path Packages/CaptureKit
+rtk test swift test --package-path Packages/SharedKit
+```
+
+Expected: both suites pass.
+
+- [ ] **Step 2: Check branch state**
+
+Run: `rtk git diff --check` and `rtk git status --short`.
+
+Expected: clean output.
+
+- [ ] **Step 3: Launch one current test instance**
+
+Close other Capso processes and launch `build/DerivedData/Build/Products/Debug/Capso.app`. Verify only that executable remains running.
+
+- [ ] **Step 4: Verify mini, compact, and regular Text layouts**
+
+- Mini below 480 points: one 58-point row with Text, color, size, Style, and More.
+- Compact from 480 through 999 points: one 58-point collapsed row; More produces exactly two rows and 102-point height.
+- Regular from 1,000 points: one 58-point row with inline text effects.
+- Switching between Text and other tools never changes the frame height.
+
+- [ ] **Step 5: Verify effect behavior**
+
+Create and select text, then toggle Background, Box, and Stroke. Confirm immediate visual updates, persistence, active state, popover dismissal on tool switch, and VoiceOver labels.
+
+- [ ] **Step 6: Capture review screenshots**
+
+Save mini, compact, compact-expanded, regular, and open-popover screenshots under `/tmp/capso-text-toolbar-polish/`.

--- a/docs/superpowers/specs/2026-07-11-all-in-one-selection-polish-design.md
+++ b/docs/superpowers/specs/2026-07-11-all-in-one-selection-polish-design.md
@@ -28,7 +28,8 @@ Selection polish is the best next step because it is high-frequency, self-contai
 
 - Move the dimensions out of the narrow right rail and into a compact floating HUD attached to the selection.
 - Use a single-line monospaced label such as `1140 × 564`.
-- Prefer placement eight points above the selection's top-left corner. If there is not enough room above, place it eight points below the selection. Use the inside top-left fallback only when neither outside placement fits.
+- Prefer placement eight points above the selection's top-left corner. If there is not enough room above, place it just inside the top-left corner.
+- Draw the border and resize handles after the HUD so the handles remain visible above an inside HUD on tiny selections.
 - Keep the HUD visible while the All-in-One selection is active so size feedback remains discoverable before and during resizing.
 
 ### Side Rail
@@ -50,7 +51,7 @@ This keeps visual thresholds testable without moving drawing code out of the App
 ## Testing
 
 - Unit-test the 80-point handle threshold on both axes.
-- Unit-test HUD placement above the selection, below it when the top edge blocks the preferred placement, and inside only when neither outside placement fits.
+- Unit-test HUD placement above the selection and its inside fallback near the top screen edge.
 - Run the full CaptureKit and SharedKit test suites.
 - Build the macOS app with Swift 6 strict concurrency checks.
 - Manually verify small, medium, and large selections in the running app and capture screenshots for review.

--- a/docs/superpowers/specs/2026-07-11-all-in-one-selection-polish-design.md
+++ b/docs/superpowers/specs/2026-07-11-all-in-one-selection-polish-design.md
@@ -1,0 +1,62 @@
+# All-in-One Selection Polish Design
+
+## Goal
+
+Make the frozen All-in-One selection feel precise and calm at every selection size. The work should improve the selection chrome and size feedback without changing capture behavior, keyboard shortcuts, presets, or annotation tools.
+
+## Priority and Alternatives
+
+Three follow-up directions were considered:
+
+1. **Selection polish (chosen):** refine the border, resize affordances, dimension feedback, and side-rail density. This affects every All-in-One use and directly addresses the roughness visible while resizing selections.
+2. **Annotation toolbar consolidation:** unify the full editor, inline editor, and All-in-One annotation toolbars. This has broader consistency value but is a larger architectural and visual change.
+3. **Recording controls polish:** refine pre-recording and in-recording status. This is valuable but applies to a lower-frequency workflow than screenshot selection.
+
+Selection polish is the best next step because it is high-frequency, self-contained, and easy to evaluate visually.
+
+## Interaction Design
+
+### Selection Border
+
+- Replace the thick L-shaped corner brackets and midpoint ticks with one crisp, continuous white border.
+- Add eight compact circular resize handles for regular selections: four corners and four edge midpoints.
+- For selections narrower or shorter than 80 points, show only the four corner handles so the chrome does not overwhelm the content.
+- Fixed-size presets show the border and dimension HUD but no resize handles because the selection can only move.
+- Keep the existing 26-point invisible hit targets and existing resize cursors. The visual handles must not make resizing harder.
+
+### Dimension HUD
+
+- Move the dimensions out of the narrow right rail and into a compact floating HUD attached to the selection.
+- Use a single-line monospaced label such as `1140 × 564`.
+- Prefer placement eight points above the selection's top-left corner. If there is not enough room, place it just inside the top-left corner.
+- Keep the HUD visible while the All-in-One selection is active so size feedback remains discoverable before and during resizing.
+
+### Side Rail
+
+- Remove the stacked width / `x` / height card.
+- Recalculate the rail height without the dimension card, making the default compact rail visibly shorter.
+- Preserve Copy, Save, Pin, Close, and More exactly as they work now.
+
+### Backdrop
+
+- Reduce the outside dimming slightly so the selected content remains the dominant visual element without making the surrounding context disappear.
+
+## Architecture
+
+Add a small pure layout policy in CaptureKit for adaptive handle visibility and dimension-HUD placement. The AppKit overlay consumes that policy for drawing. Capture geometry, hit-testing, presets, and toolbar actions stay unchanged.
+
+This keeps visual thresholds testable without moving drawing code out of the App target.
+
+## Testing
+
+- Unit-test the 80-point handle threshold on both axes.
+- Unit-test HUD placement above the selection and its inside fallback near the top screen edge.
+- Run the full CaptureKit and SharedKit test suites.
+- Build the macOS app with Swift 6 strict concurrency checks.
+- Manually verify small, medium, and large selections in the running app and capture screenshots for review.
+
+## Non-Goals
+
+- No new capture mode or confirmation step.
+- No changes to annotation tools, Quick Access, presets, or keyboard shortcuts.
+- No refactor of the three annotation toolbar implementations in this pass.

--- a/docs/superpowers/specs/2026-07-11-all-in-one-selection-polish-design.md
+++ b/docs/superpowers/specs/2026-07-11-all-in-one-selection-polish-design.md
@@ -28,7 +28,7 @@ Selection polish is the best next step because it is high-frequency, self-contai
 
 - Move the dimensions out of the narrow right rail and into a compact floating HUD attached to the selection.
 - Use a single-line monospaced label such as `1140 × 564`.
-- Prefer placement eight points above the selection's top-left corner. If there is not enough room, place it just inside the top-left corner.
+- Prefer placement eight points above the selection's top-left corner. If there is not enough room above, place it eight points below the selection. Use the inside top-left fallback only when neither outside placement fits.
 - Keep the HUD visible while the All-in-One selection is active so size feedback remains discoverable before and during resizing.
 
 ### Side Rail
@@ -50,7 +50,7 @@ This keeps visual thresholds testable without moving drawing code out of the App
 ## Testing
 
 - Unit-test the 80-point handle threshold on both axes.
-- Unit-test HUD placement above the selection and its inside fallback near the top screen edge.
+- Unit-test HUD placement above the selection, below it when the top edge blocks the preferred placement, and inside only when neither outside placement fits.
 - Run the full CaptureKit and SharedKit test suites.
 - Build the macOS app with Swift 6 strict concurrency checks.
 - Manually verify small, medium, and large selections in the running app and capture screenshots for review.

--- a/docs/superpowers/specs/2026-07-11-all-in-one-text-toolbar-design.md
+++ b/docs/superpowers/specs/2026-07-11-all-in-one-text-toolbar-design.md
@@ -1,0 +1,86 @@
+# All-in-One Text Toolbar Responsive Design
+
+## Goal
+
+Keep the All-in-One annotation toolbar visually stable when Text is selected. Text-specific controls must remain discoverable without adding a second text-only row or creating a three-row toolbar when compact overflow is open.
+
+## Problem
+
+The current mini and compact layouts append a full-width `Fill / Outline / Trace` row whenever Text is active. Compact overflow adds another row between the primary tools and text effects. This creates two or three unrelated alignment systems inside one toolbar, leaves a large empty region beside the three text effects, and makes the toolbar height jump when the selected tool changes.
+
+## Alternatives Considered
+
+1. **Stable toolbar with Text Style popover (chosen):** keep mini and compact toolbars at their normal height and open the three text effects from one dedicated Style button.
+2. **Redesigned secondary text row:** group effects into a centered segmented control. More discoverable, but still changes toolbar height and produces three rows with compact overflow.
+3. **Detached text inspector:** move text settings into a second floating panel. Flexible but creates another window-placement and collision system.
+
+The popover approach is the smallest coherent design and preserves direct access without making Text structurally different from every other annotation tool.
+
+## Responsive Rules
+
+### Mini: selection width below 480 points
+
+- Toolbar remains 300 by 58 points.
+- Show current Text glyph, current color, font-size value, Text Style button, and More button.
+- Do not render a second text-effects row.
+
+### Compact: selection width from 480 through 999 points
+
+- Toolbar width continues to clamp to the existing 520–840-point range.
+- Show the six primary tools, compact color/font-size status, Text Style button, and More button.
+- More may add the existing overflow row for secondary tools, full colors, slider, and Undo/Redo.
+- Text Style remains in the primary row; opening More never adds a third row.
+
+### Regular: selection width 1,000 points or wider
+
+- Keep the existing 1,000-point single-row toolbar.
+- Keep the three text-effect icon toggles inline beside the font-size slider.
+- Keep the complete tool set, color palette, and Undo/Redo visible.
+
+## Text Style Popover
+
+- The button uses the `textformat` symbol and an active accent background when any text effect is enabled.
+- The popover contains three horizontal toggles with an icon and label:
+  - **Background** — toggles the existing text fill color.
+  - **Box** — toggles the existing text box outline.
+  - **Stroke** — toggles the existing glyph stroke.
+- Active effects use the same accent treatment as active toolbar tools.
+- Each toggle updates the selected text immediately, persists the existing UserDefaults key, and retains its existing accessibility help.
+- Switching away from Text dismisses the popover.
+
+## Toolbar Sizing
+
+- Selecting or editing Text must not change the toolbar frame height.
+- Mini remains 58 points high.
+- Compact remains 58 points high when collapsed and 102 points high when More is expanded.
+- Regular remains 58 points high.
+- Button hit targets remain fixed; icons and labels do not continuously scale with the selection.
+
+## Architecture
+
+- Extend the existing CaptureKit chrome policy with a pure toolbar-height function so Text cannot reintroduce a layout-dependent height adjustment.
+- Keep text-effect state and behavior in `AllInOneAnnotationSession` unchanged.
+- Replace `textEffectsRow` with one popover-producing SwiftUI control in `AllInOneAnnotationToolbarView`.
+- Keep regular inline text-effect controls and the right-side All-in-One action rail unchanged.
+
+## Accessibility
+
+- The Style button exposes the label `Text Style` and indicates whether effects are enabled.
+- Each popover toggle exposes its visible label and active state.
+- Keyboard annotation shortcuts remain unchanged while text editing is inactive.
+
+## Verification
+
+- Unit-test toolbar heights for mini, compact collapsed, compact expanded, and regular densities.
+- Verify selecting Text never changes the panel height at any density.
+- Verify mini, compact, and regular layouts in the running app.
+- Verify compact Text with More expanded has exactly two rows.
+- Verify Background, Box, and Stroke update newly created and selected text.
+- Verify switching away from Text dismisses the popover.
+- Run CaptureKit and SharedKit tests and a full macOS app build.
+
+## Non-Goals
+
+- No change to text rendering, colors, font-size range, selection geometry, right-side actions, or annotation shortcuts.
+- No detached inspector window.
+- No continuous scaling of button hit targets or typography.


### PR DESCRIPTION
## Summary

- polish Quick Access preview, rounded chrome, and adaptive action layout
- refine All-in-One selection outlines, handles, HUD layering, and responsive toolbar density
- keep compact Text mode on one row with a Text Style popover for Background, Box, and Stroke
- add layout-policy tests and localized accessibility state

## Why

Several fixed-size chrome layers and toolbar rows looked crowded at smaller selection sizes. The selection outline could also pass through HUD surfaces, and rounded Quick Access content still revealed faint square edges. These changes make the capture flow more consistent across tiny, compact, and regular sizes while leaving room for additional actions such as Take Screenshot.

## User impact

Quick Access and All-in-One now keep cleaner rounded surfaces, stable toolbar heights, visible selection handles, and more predictable controls across different capture sizes. The standalone Annotation Editor is intentionally unchanged.

## Validation

- `xcodegen generate`
- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug -derivedDataPath build/DerivedData CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO build`
- `swift test --package-path Packages/SharedKit`
- `swift test --package-path Packages/AnnotationKit`
- `swift test --package-path Packages/CaptureKit`
- `swift test --package-path Packages/RecordingKit`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and layout-policy changes only; capture geometry and hit-testing are preserved per plan, with new unit tests for thresholds.
> 
> **Overview**
> Polishes **Quick Access** and **All-in-One** capture chrome with shared layout policies, updated visuals, and more predictable responsive toolbars.
> 
> **Quick Access** uses a taller fill thumbnail, a shorter action strip, and `QuickAccessActionLayout` so primary actions stay on the bar while OCR and Translate move into a **More** menu; hover shortcut pills and the context line are removed. Focus ring styling is disabled on the panel.
> 
> **All-in-One selection** replaces corner brackets with a crisp border, adaptive circular resize handles, and a floating dimension HUD driven by `CaptureSelectionChromeLayout`; the side rail drops the stacked size card and defaults compact via `CaptureChromeLayout`. Overlay dimming is slightly lighter and selection size is exposed to accessibility.
> 
> **Annotation toolbar** density (mini / compact / regular) and fixed heights come from `CaptureChromeLayout`; mini and compact **Text** mode no longer add an extra row—Background, Box, and Stroke open from a **Text Style** popover (regular width keeps inline toggles). Toolbars use 16pt corners, thin material, and panel shadows.
> 
> Unit tests cover the new CaptureKit and SharedKit layout helpers; design/plan docs are added under `docs/superpowers/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b164d4dfe5d90d64b71c6a1771dd8f9f9add04b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->