### PR TITLE
feat: multi-window capture (Shift multi-select)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,13 @@ jobs:
 
       - name: Test RecordingKit
         run: swift test --package-path Packages/RecordingKit
+
+      - name: Test Capso app interactions
+        run: |
+          xcodebuild test -project Capso.xcodeproj \
+            -scheme Capso \
+            -configuration Debug \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            -only-testing:CapsoTests

--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -28,6 +28,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let updateManager = UpdateManager()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // A hosted unit-test bundle only needs the AppKit run loop. Avoid
+        // registering global shortcuts, touching real settings, or starting
+        // coordinators in the separate test-host process.
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            return
+        }
+
         Self.shared = self
         DiagnosticLogger.installUncaughtExceptionHandler()
 

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -402,6 +402,10 @@ final class CaptureCoordinator {
                 // see `StoredCaptureSelection` docs for the rationale.
                 self?.performWindowCapture(windowID: windowID)
             }
+            overlay.onWindowsSelected = { [weak self] windowIDs in
+                self?.dismissOverlay()
+                self?.performMultiWindowCapture(windowIDs: windowIDs)
+            }
             overlay.onCancelled = { [weak self] in
                 self?.pendingSourceApplication = nil
                 self?.dismissOverlay()
@@ -440,6 +444,10 @@ final class CaptureCoordinator {
             overlay.onWindowSelected = { [weak self] windowID in
                 self?.dismissOverlay()
                 self?.performWindowCapture(windowID: windowID)
+            }
+            overlay.onWindowsSelected = { [weak self] windowIDs in
+                self?.dismissOverlay()
+                self?.performMultiWindowCapture(windowIDs: windowIDs)
             }
             overlay.onCancelled = { [weak self] in
                 self?.pendingSourceApplication = nil
@@ -705,6 +713,10 @@ final class CaptureCoordinator {
                 self?.dismissOverlay()
                 self?.performWindowCapture(windowID: windowID)
             }
+            overlay.onWindowsSelected = { [weak self] windowIDs in
+                self?.dismissOverlay()
+                self?.performMultiWindowCapture(windowIDs: windowIDs)
+            }
             overlay.onCancelled = { [weak self] in
                 self?.pendingSourceApplication = nil
                 self?.dismissOverlay()
@@ -787,6 +799,22 @@ final class CaptureCoordinator {
                 handleCaptureResult(result)
             } catch {
                 print("Window capture failed: \(error)")
+            }
+        }
+    }
+
+    /// Capture multiple windows and composite them at their screen positions.
+    /// Skips the single-window frosted-glass treatment — it doesn't apply to a scene.
+    private func performMultiWindowCapture(windowIDs: [CGWindowID]) {
+        Task {
+            do {
+                let result = try await ScreenCaptureManager.captureWindows(
+                    windowIDs: windowIDs,
+                    showsCursor: settings.screenshotShowsCursor
+                )
+                handleCaptureResult(result)
+            } catch {
+                print("Multi-window capture failed: \(error)")
             }
         }
     }

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -378,7 +378,11 @@ final class CaptureCoordinator {
         dismissOverlay()
         dismissAllInOneToolbar()
         for screen in NSScreen.screens {
-            let overlay = CaptureOverlayWindow(screen: screen, settings: settings)
+            let overlay = CaptureOverlayWindow(
+                screen: screen,
+                settings: settings,
+                handlesGlobalKeyEvents: overlayWindows.isEmpty
+            )
             overlay.onAreaSelected = { [weak self] rect, screen in
                 self?.dismissOverlay()
                 if let areaSelected {
@@ -430,7 +434,11 @@ final class CaptureCoordinator {
         )
 
         for (screen, _) in frozenScreens {
-            let overlay = CaptureOverlayWindow(screen: screen, settings: settings)
+            let overlay = CaptureOverlayWindow(
+                screen: screen,
+                settings: settings,
+                handlesGlobalKeyEvents: overlayWindows.isEmpty
+            )
             overlay.onAreaSelected = { [weak self] rect, screen in
                 guard let self else { return }
                 self.dismissSelectionOverlays()
@@ -698,7 +706,11 @@ final class CaptureCoordinator {
 
         // Step 2: Create transparent overlay windows (top layer) for selection
         for (screen, frozenImage) in frozenScreens {
-            let overlay = CaptureOverlayWindow(screen: screen, settings: settings)
+            let overlay = CaptureOverlayWindow(
+                screen: screen,
+                settings: settings,
+                handlesGlobalKeyEvents: overlayWindows.isEmpty
+            )
             overlay.onAreaSelected = { [weak self] rect, screen in
                 guard let self else { return }
                 self.dismissOverlay()

--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -9,6 +9,9 @@ extension Notification.Name {
     static let openPreferencesTab = Notification.Name("openPreferencesTab")
     static let openScreenshotSettings = Notification.Name("openScreenshotSettings")
     static let capturePresetChanged = Notification.Name("capturePresetChanged")
+    /// Syncs multi-window selection across per-screen capture overlays.
+    /// `userInfo["windowIDs"]` is `[NSNumber]` of `CGWindowID` values.
+    static let multiWindowSelectionChanged = Notification.Name("multiWindowSelectionChanged")
     /// Posted by PreferencesWindow when the window is already open and the
     /// caller wants the visible Preferences UI to switch to a specific tab.
     /// Only PreferencesView observes this — NOT AppDelegate (which would cause
@@ -25,6 +28,8 @@ enum CaptureOverlayMode {
 final class CaptureOverlayView: NSView {
     var onSelectionComplete: ((CGRect) -> Void)?
     var onWindowSelected: ((CGWindowID) -> Void)?
+    /// Fired when Shift is released with one or more windows multi-selected.
+    var onWindowsSelected: (([CGWindowID]) -> Void)?
     var onCancel: (() -> Void)?
     var onSpaceToggle: (() -> Void)?
 
@@ -49,6 +54,10 @@ final class CaptureOverlayView: NSView {
     private var hoveredWindowFrame: CGRect = .zero
     private var hoveredWindowName: String = ""
     private var availableWindows: [WindowInfo] = []
+    /// Ordered by selection time; capture reorders to front-to-back z-order.
+    private var selectedWindowIDs: [CGWindowID] = []
+    private var isShiftHeld = false
+    private var isApplyingRemoteMultiWindowSelection = false
 
     private var cursorHidden = false
 
@@ -76,6 +85,7 @@ final class CaptureOverlayView: NSView {
     private var presetMenuMap: [Int: CapturePreset] = [:]
 
     nonisolated(unsafe) private var presetObserver: Any?
+    nonisolated(unsafe) private var multiWindowSelectionObserver: Any?
 
     init(
         frame: NSRect,
@@ -96,6 +106,23 @@ final class CaptureOverlayView: NSView {
             owner: self,
             userInfo: nil
         ))
+
+        multiWindowSelectionObserver = NotificationCenter.default.addObserver(
+            forName: .multiWindowSelectionChanged,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            let ids: [CGWindowID] = (note.userInfo?["windowIDs"] as? [NSNumber])?
+                .map { CGWindowID(truncating: $0) } ?? []
+            let isFromSelf = note.object as AnyObject? === self
+            MainActor.assumeIsolated {
+                guard let self, !isFromSelf else { return }
+                self.isApplyingRemoteMultiWindowSelection = true
+                self.selectedWindowIDs = ids
+                self.isApplyingRemoteMultiWindowSelection = false
+                self.needsDisplay = true
+            }
+        }
 
         // Listen for preset changes from other overlay views (multi-screen sync)
         guard !self.presetsDisabled else { return }
@@ -127,6 +154,9 @@ final class CaptureOverlayView: NSView {
         if let presetObserver {
             NotificationCenter.default.removeObserver(presetObserver)
         }
+        if let multiWindowSelectionObserver {
+            NotificationCenter.default.removeObserver(multiWindowSelectionObserver)
+        }
     }
 
     @available(*, unavailable)
@@ -138,6 +168,8 @@ final class CaptureOverlayView: NSView {
         dragEnd = .zero
         hoveredWindowID = nil
         currentMouseLocation = nil
+        selectedWindowIDs = []
+        isShiftHeld = false
         needsDisplay = true
     }
 
@@ -409,33 +441,122 @@ final class CaptureOverlayView: NSView {
         context.setFillColor(overlayColor.cgColor)
         context.fill(bounds)
 
-        // If a window is hovered, clear it and highlight with rounded corners
-        if hoveredWindowID != nil {
-            let viewRect = screenRectToViewRect(hoveredWindowFrame)
-            let cornerRadius: CGFloat = 10 // macOS window corner radius
+        let selectedSet = Set(selectedWindowIDs)
 
-            let roundedPath = CGPath(roundedRect: viewRect, cornerWidth: cornerRadius, cornerHeight: cornerRadius, transform: nil)
-
-            // Clear the window area (rounded)
-            context.setBlendMode(.clear)
-            context.addPath(roundedPath)
-            context.fillPath()
-            context.setBlendMode(.normal)
-
-            // Highlight border (rounded)
-            context.setStrokeColor(windowBorderColor.cgColor)
-            context.setLineWidth(3.0)
-            context.addPath(roundedPath)
-            context.strokePath()
-
-            // Subtle fill (rounded)
-            context.setFillColor(windowHighlightColor.cgColor)
-            context.addPath(roundedPath)
-            context.fillPath()
-
-            // Window name label
-            drawWindowLabel(name: hoveredWindowName, for: viewRect, in: context)
+        // Keep multi-selected windows punched out and highlighted.
+        for window in availableWindows where selectedSet.contains(window.id) {
+            highlightWindow(
+                frame: window.frame,
+                name: displayName(for: window),
+                showLabel: false,
+                in: context
+            )
         }
+
+        // Hover highlight (and label) for the window under the cursor.
+        if let hoveredID = hoveredWindowID {
+            if selectedSet.contains(hoveredID) {
+                let viewRect = screenRectToViewRect(hoveredWindowFrame)
+                drawWindowLabel(name: hoveredWindowName, for: viewRect, in: context)
+            } else {
+                highlightWindow(
+                    frame: hoveredWindowFrame,
+                    name: hoveredWindowName,
+                    showLabel: true,
+                    in: context
+                )
+            }
+        }
+
+        if selectedWindowIDs.count >= 1 {
+            drawMultiWindowCountBadge(count: selectedWindowIDs.count, in: context)
+        } else {
+            drawWindowSelectionHintBadge(in: context)
+        }
+    }
+
+    private func highlightWindow(
+        frame: CGRect,
+        name: String,
+        showLabel: Bool,
+        in context: CGContext
+    ) {
+        let viewRect = screenRectToViewRect(frame)
+        let cornerRadius: CGFloat = 10
+        let roundedPath = CGPath(
+            roundedRect: viewRect,
+            cornerWidth: cornerRadius,
+            cornerHeight: cornerRadius,
+            transform: nil
+        )
+
+        context.setBlendMode(.clear)
+        context.addPath(roundedPath)
+        context.fillPath()
+        context.setBlendMode(.normal)
+
+        context.setStrokeColor(windowBorderColor.cgColor)
+        context.setLineWidth(3.0)
+        context.addPath(roundedPath)
+        context.strokePath()
+
+        context.setFillColor(windowHighlightColor.cgColor)
+        context.addPath(roundedPath)
+        context.fillPath()
+
+        if showLabel {
+            drawWindowLabel(name: name, for: viewRect, in: context)
+        }
+    }
+
+    private func displayName(for window: WindowInfo) -> String {
+        if window.appName.isEmpty || window.title == window.appName {
+            return window.title
+        }
+        return "\(window.appName) — \(window.title)"
+    }
+
+    private func drawWindowSelectionHintBadge(in context: CGContext) {
+        drawBottomHintBadge(
+            text: String(localized: "Hold ⇧ and click to select multiple windows"),
+            in: context
+        )
+    }
+
+    private func drawMultiWindowCountBadge(count: Int, in context: CGContext) {
+        drawBottomHintBadge(
+            text: String(localized: "\(count) windows selected — release ⇧ to capture"),
+            in: context
+        )
+    }
+
+    private func drawBottomHintBadge(text: String, in context: CGContext) {
+        let font = NSFont.systemFont(ofSize: 13, weight: .medium)
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: dimensionTextColor
+        ]
+        let size = (text as NSString).size(withAttributes: attributes)
+        let paddingH: CGFloat = 12
+        let paddingV: CGFloat = 8
+        let badgeWidth = size.width + paddingH * 2
+        let badgeHeight = size.height + paddingV * 2
+
+        let visibleRect = visibleScreenRectInViewCoordinates()
+        let badgeX = visibleRect.midX - badgeWidth / 2
+        let badgeY = visibleRect.minY + 24
+        let bgRect = CGRect(x: badgeX, y: badgeY, width: badgeWidth, height: badgeHeight)
+
+        context.setFillColor(dimensionBgColor.cgColor)
+        let path = CGPath(roundedRect: bgRect, cornerWidth: 8, cornerHeight: 8, transform: nil)
+        context.addPath(path)
+        context.fillPath()
+
+        let textPoint = NSPoint(
+            x: badgeX + paddingH,
+            y: badgeY + (badgeHeight - size.height) / 2
+        )
+        (text as NSString).draw(at: textPoint, withAttributes: attributes)
     }
 
     private func drawWindowLabel(name: String, for rect: CGRect, in context: CGContext) {
@@ -689,8 +810,12 @@ final class CaptureOverlayView: NSView {
 
         case .windowSelection:
             if let windowID = hoveredWindowID {
-                restoreCursor()
-                onWindowSelected?(windowID)
+                if event.modifierFlags.contains(.shift) {
+                    toggleWindowSelection(windowID)
+                } else {
+                    restoreCursor()
+                    onWindowSelected?(windowID)
+                }
             }
         }
     }
@@ -832,7 +957,9 @@ final class CaptureOverlayView: NSView {
 
     override func keyDown(with event: NSEvent) {
         if event.keyCode == 53 { // ESC
-            cancelOverlay()
+            if !handleEscapeKey() {
+                cancelOverlay()
+            }
         } else if event.keyCode == 49 { // Space
             requestSpaceToggle()
         } else if event.keyCode == 15 { // R key
@@ -843,6 +970,21 @@ final class CaptureOverlayView: NSView {
         }
     }
 
+    override func flagsChanged(with event: NSEvent) {
+        handleFlagsChanged(event)
+        super.flagsChanged(with: event)
+    }
+
+    /// Shared entry for both the view's `flagsChanged` and the window's local
+    /// flags monitor so Shift-release confirmation stays reliable.
+    func handleFlagsChanged(_ event: NSEvent) {
+        let shiftNow = event.modifierFlags.contains(.shift)
+        if isShiftHeld && !shiftNow {
+            confirmMultiWindowSelectionIfNeeded()
+        }
+        isShiftHeld = shiftNow
+    }
+
     override var acceptsFirstResponder: Bool { true }
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
@@ -850,6 +992,65 @@ final class CaptureOverlayView: NSView {
     func requestSpaceToggle() {
         guard !isDragging, onSpaceToggle != nil else { return }
         onSpaceToggle?()
+    }
+
+    /// Returns `true` when Esc cleared a multi-window selection instead of cancelling.
+    @discardableResult
+    func handleEscapeKey() -> Bool {
+        guard case .windowSelection = mode, !selectedWindowIDs.isEmpty else { return false }
+        clearMultiWindowSelection()
+        return true
+    }
+
+    private func toggleWindowSelection(_ windowID: CGWindowID) {
+        if let index = selectedWindowIDs.firstIndex(of: windowID) {
+            selectedWindowIDs.remove(at: index)
+        } else {
+            selectedWindowIDs.append(windowID)
+        }
+        // Keep Shift-held tracking in sync even if flagsChanged hasn't fired yet.
+        isShiftHeld = true
+        broadcastMultiWindowSelection()
+        needsDisplay = true
+    }
+
+    private func clearMultiWindowSelection() {
+        guard !selectedWindowIDs.isEmpty else { return }
+        selectedWindowIDs = []
+        broadcastMultiWindowSelection()
+        needsDisplay = true
+    }
+
+    private func broadcastMultiWindowSelection() {
+        guard !isApplyingRemoteMultiWindowSelection else { return }
+        NotificationCenter.default.post(
+            name: .multiWindowSelectionChanged,
+            object: self,
+            userInfo: [
+                "windowIDs": selectedWindowIDs.map { NSNumber(value: $0) }
+            ]
+        )
+    }
+
+    /// Confirm multi-window capture when Shift is released with a non-empty set.
+    /// IDs are reordered to match `availableWindows` front-to-back z-order.
+    private func confirmMultiWindowSelectionIfNeeded() {
+        guard case .windowSelection = mode, !selectedWindowIDs.isEmpty else { return }
+        // Multi-screen overlays each install a flags monitor; only the key
+        // window should fire the capture callback.
+        if let window, !window.isKeyWindow { return }
+
+        let selectedSet = Set(selectedWindowIDs)
+        var ordered = availableWindows.map(\.id).filter { selectedSet.contains($0) }
+        for id in selectedWindowIDs where !ordered.contains(id) {
+            ordered.append(id)
+        }
+
+        // Clear first so a second flags delivery (view + monitor) is a no-op.
+        selectedWindowIDs = []
+        broadcastMultiWindowSelection()
+        restoreCursor()
+        onWindowsSelected?(ordered)
     }
 
     private func cancelCurrentSelection() {

--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -28,7 +28,7 @@ enum CaptureOverlayMode {
 final class CaptureOverlayView: NSView {
     var onSelectionComplete: ((CGRect) -> Void)?
     var onWindowSelected: ((CGWindowID) -> Void)?
-    /// Fired when Shift is released with one or more windows multi-selected.
+    /// Fired when Shift is released with two or more windows selected.
     var onWindowsSelected: (([CGWindowID]) -> Void)?
     var onCancel: (() -> Void)?
     var onSpaceToggle: (() -> Void)?
@@ -1067,7 +1067,11 @@ final class CaptureOverlayView: NSView {
         selectedWindowIDs = []
         broadcastMultiWindowSelection()
         restoreCursor()
-        onWindowsSelected?(ordered)
+        if ordered.count == 1, let windowID = ordered.first {
+            onWindowSelected?(windowID)
+        } else {
+            onWindowsSelected?(ordered)
+        }
     }
 
     private func cancelCurrentSelection() {

--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -990,11 +990,11 @@ final class CaptureOverlayView: NSView {
 
     /// Shared entry for both the view's `flagsChanged` and the window's local
     /// flags monitor so Shift-release confirmation stays reliable.
-    func handleFlagsChanged(_ event: NSEvent) {
+    func handleFlagsChanged(_ event: NSEvent, allowsNonKeyConfirmation: Bool = false) {
         guard allowsMultiWindowSelection else { return }
         let shiftNow = event.modifierFlags.contains(.shift)
-        if isShiftHeld && !shiftNow {
-            confirmMultiWindowSelectionIfNeeded()
+        if (isShiftHeld || allowsNonKeyConfirmation) && !shiftNow {
+            confirmMultiWindowSelectionIfNeeded(allowsNonKeyConfirmation: allowsNonKeyConfirmation)
         }
         isShiftHeld = shiftNow
     }
@@ -1051,11 +1051,12 @@ final class CaptureOverlayView: NSView {
 
     /// Confirm multi-window capture when Shift is released with a non-empty set.
     /// IDs are reordered to match `availableWindows` front-to-back z-order.
-    private func confirmMultiWindowSelectionIfNeeded() {
+    private func confirmMultiWindowSelectionIfNeeded(allowsNonKeyConfirmation: Bool = false) {
         guard case .windowSelection = mode, !selectedWindowIDs.isEmpty else { return }
         // Multi-screen overlays each install a flags monitor; only the key
-        // window should fire the capture callback.
-        if let window, !window.isKeyWindow { return }
+        // window should fire the local callback. The single global monitor
+        // owner may confirm when the app is frontmost elsewhere and none is key.
+        if !allowsNonKeyConfirmation, let window, !window.isKeyWindow { return }
 
         let selectedSet = Set(selectedWindowIDs)
         var ordered = availableWindows.map(\.id).filter { selectedSet.contains($0) }

--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -816,13 +816,20 @@ final class CaptureOverlayView: NSView {
 
         case .windowSelection:
             if let windowID = hoveredWindowID {
-                if allowsMultiWindowSelection, event.modifierFlags.contains(.shift) {
-                    toggleWindowSelection(windowID)
-                } else {
-                    restoreCursor()
-                    onWindowSelected?(windowID)
-                }
+                handleWindowClick(windowID, modifierFlags: event.modifierFlags)
             }
+        }
+    }
+
+    func handleWindowClick(
+        _ windowID: CGWindowID,
+        modifierFlags: NSEvent.ModifierFlags
+    ) {
+        if allowsMultiWindowSelection, modifierFlags.contains(.shift) {
+            toggleWindowSelection(windowID)
+        } else {
+            restoreCursor()
+            onWindowSelected?(windowID)
         }
     }
 

--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -38,6 +38,9 @@ final class CaptureOverlayView: NSView {
     /// When true, preset features (badge, R-key, right-click menu, ratio lock) are disabled.
     /// Used by OCR and Recording overlays which always use freeform selection.
     private let presetsDisabled: Bool
+    /// Screenshot window capture supports Shift multi-select; recording keeps
+    /// its existing single-window behavior even though it shares this view.
+    private let allowsMultiWindowSelection: Bool
 
     private var mode: CaptureOverlayMode = .area
     private var isDragging = false
@@ -57,7 +60,6 @@ final class CaptureOverlayView: NSView {
     /// Ordered by selection time; capture reorders to front-to-back z-order.
     private var selectedWindowIDs: [CGWindowID] = []
     private var isShiftHeld = false
-    private var isApplyingRemoteMultiWindowSelection = false
 
     private var cursorHidden = false
 
@@ -91,13 +93,15 @@ final class CaptureOverlayView: NSView {
         frame: NSRect,
         settings: AppSettings,
         safeAreaTopInset: CGFloat,
-        presetsDisabled: Bool = false
+        presetsDisabled: Bool = false,
+        allowsMultiWindowSelection: Bool = true
     ) {
         self.settings = settings
         self.safeAreaTopInset = safeAreaTopInset
         // Presets are disabled when explicitly requested (OCR/Recording) or when
         // the user has turned off the feature in Settings.
         self.presetsDisabled = presetsDisabled || !settings.capturePresetsEnabled
+        self.allowsMultiWindowSelection = allowsMultiWindowSelection
         self.activePreset = self.presetsDisabled ? .freeform : settings.capturePreset
         super.init(frame: frame)
         addTrackingArea(NSTrackingArea(
@@ -107,20 +111,20 @@ final class CaptureOverlayView: NSView {
             userInfo: nil
         ))
 
-        multiWindowSelectionObserver = NotificationCenter.default.addObserver(
-            forName: .multiWindowSelectionChanged,
-            object: nil,
-            queue: .main
-        ) { [weak self] note in
-            let ids: [CGWindowID] = (note.userInfo?["windowIDs"] as? [NSNumber])?
-                .map { CGWindowID(truncating: $0) } ?? []
-            let isFromSelf = note.object as AnyObject? === self
-            MainActor.assumeIsolated {
-                guard let self, !isFromSelf else { return }
-                self.isApplyingRemoteMultiWindowSelection = true
-                self.selectedWindowIDs = ids
-                self.isApplyingRemoteMultiWindowSelection = false
-                self.needsDisplay = true
+        if allowsMultiWindowSelection {
+            multiWindowSelectionObserver = NotificationCenter.default.addObserver(
+                forName: .multiWindowSelectionChanged,
+                object: nil,
+                queue: .main
+            ) { [weak self] note in
+                let ids: [CGWindowID] = (note.userInfo?["windowIDs"] as? [NSNumber])?
+                    .map { CGWindowID(truncating: $0) } ?? []
+                let isFromSelf = note.object as AnyObject? === self
+                MainActor.assumeIsolated {
+                    guard let self, !isFromSelf else { return }
+                    self.selectedWindowIDs = ids
+                    self.needsDisplay = true
+                }
             }
         }
 
@@ -468,10 +472,12 @@ final class CaptureOverlayView: NSView {
             }
         }
 
-        if selectedWindowIDs.count >= 1 {
-            drawMultiWindowCountBadge(count: selectedWindowIDs.count, in: context)
-        } else {
-            drawWindowSelectionHintBadge(in: context)
+        if allowsMultiWindowSelection {
+            if selectedWindowIDs.count >= 1 {
+                drawMultiWindowCountBadge(count: selectedWindowIDs.count, in: context)
+            } else {
+                drawWindowSelectionHintBadge(in: context)
+            }
         }
     }
 
@@ -810,7 +816,7 @@ final class CaptureOverlayView: NSView {
 
         case .windowSelection:
             if let windowID = hoveredWindowID {
-                if event.modifierFlags.contains(.shift) {
+                if allowsMultiWindowSelection, event.modifierFlags.contains(.shift) {
                     toggleWindowSelection(windowID)
                 } else {
                     restoreCursor()
@@ -978,6 +984,7 @@ final class CaptureOverlayView: NSView {
     /// Shared entry for both the view's `flagsChanged` and the window's local
     /// flags monitor so Shift-release confirmation stays reliable.
     func handleFlagsChanged(_ event: NSEvent) {
+        guard allowsMultiWindowSelection else { return }
         let shiftNow = event.modifierFlags.contains(.shift)
         if isShiftHeld && !shiftNow {
             confirmMultiWindowSelectionIfNeeded()
@@ -997,7 +1004,11 @@ final class CaptureOverlayView: NSView {
     /// Returns `true` when Esc cleared a multi-window selection instead of cancelling.
     @discardableResult
     func handleEscapeKey() -> Bool {
-        guard case .windowSelection = mode, !selectedWindowIDs.isEmpty else { return false }
+        guard allowsMultiWindowSelection,
+              case .windowSelection = mode,
+              !selectedWindowIDs.isEmpty else {
+            return false
+        }
         clearMultiWindowSelection()
         return true
     }
@@ -1022,7 +1033,6 @@ final class CaptureOverlayView: NSView {
     }
 
     private func broadcastMultiWindowSelection() {
-        guard !isApplyingRemoteMultiWindowSelection else { return }
         NotificationCenter.default.post(
             name: .multiWindowSelectionChanged,
             object: self,

--- a/App/Sources/Capture/CaptureOverlayWindow.swift
+++ b/App/Sources/Capture/CaptureOverlayWindow.swift
@@ -17,7 +17,12 @@ final class CaptureOverlayWindow: NSPanel {
     private var localEscMonitor: Any?
     private var localFlagsMonitor: Any?
 
-    init(screen: NSScreen, settings: AppSettings, presetsDisabled: Bool = false) {
+    init(
+        screen: NSScreen,
+        settings: AppSettings,
+        presetsDisabled: Bool = false,
+        allowsMultiWindowSelection: Bool = true
+    ) {
         self.settings = settings
         super.init(
             contentRect: screen.frame,
@@ -46,7 +51,8 @@ final class CaptureOverlayWindow: NSPanel {
             frame: NSRect(origin: .zero, size: screen.frame.size),
             settings: settings,
             safeAreaTopInset: screen.safeAreaInsets.top,
-            presetsDisabled: presetsDisabled
+            presetsDisabled: presetsDisabled,
+            allowsMultiWindowSelection: allowsMultiWindowSelection
         )
         overlayView.onSelectionComplete = { [weak self] rect in
             guard let self, let screen = self.screen else { return }
@@ -112,7 +118,9 @@ final class CaptureOverlayWindow: NSPanel {
             switch event.keyCode {
             case 53:
                 DispatchQueue.main.async {
-                    guard let self else { return }
+                    // Global monitors are app-wide, so every display overlay
+                    // receives this event. Only the key overlay may act on it.
+                    guard let self, self.isKeyWindow else { return }
                     if self.overlayView.handleEscapeKey() { return }
                     self.onCancelled?()
                 }
@@ -126,15 +134,18 @@ final class CaptureOverlayWindow: NSPanel {
         }
         // Local monitor: catches ESC/Space when our window is key.
         localEscMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            // Local monitors are also app-wide. Leave events for other
+            // display overlays untouched so one key press is handled once.
+            guard let self, event.window === self else { return event }
             switch event.keyCode {
             case 53:
-                if self?.overlayView.handleEscapeKey() == true {
+                if self.overlayView.handleEscapeKey() {
                     return nil
                 }
-                self?.onCancelled?()
+                self.onCancelled?()
                 return nil
             case 49:
-                self?.overlayView.requestSpaceToggle()
+                self.overlayView.requestSpaceToggle()
                 return nil
             default:
                 return event

--- a/App/Sources/Capture/CaptureOverlayWindow.swift
+++ b/App/Sources/Capture/CaptureOverlayWindow.swift
@@ -12,6 +12,7 @@ final class CaptureOverlayWindow: NSPanel {
     var onSpaceToggle: (() -> Void)?
 
     private let settings: AppSettings
+    private let handlesGlobalKeyEvents: Bool
     private let allowsMultiWindowSelection: Bool
     private var overlayView: CaptureOverlayView!
     private var globalEscMonitor: Any?
@@ -21,10 +22,12 @@ final class CaptureOverlayWindow: NSPanel {
     init(
         screen: NSScreen,
         settings: AppSettings,
+        handlesGlobalKeyEvents: Bool,
         presetsDisabled: Bool = false,
         allowsMultiWindowSelection: Bool = true
     ) {
         self.settings = settings
+        self.handlesGlobalKeyEvents = handlesGlobalKeyEvents
         self.allowsMultiWindowSelection = allowsMultiWindowSelection
         super.init(
             contentRect: screen.frame,
@@ -115,23 +118,14 @@ final class CaptureOverlayWindow: NSPanel {
     }
 
     private func installKeyMonitor() {
-        // Global monitor: catches ESC/Space even when another app is frontmost.
-        globalEscMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            switch event.keyCode {
-            case 53:
+        // A single display overlay owns the global monitor so app-wide events
+        // are handled once, including when another app is frontmost and no
+        // capture overlay is key.
+        if handlesGlobalKeyEvents {
+            globalEscMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
                 DispatchQueue.main.async {
-                    // Global monitors are app-wide, so every display overlay
-                    // receives this event. Only the key overlay may act on it.
-                    guard let self, self.isKeyWindow else { return }
-                    if self.overlayView.handleEscapeKey() { return }
-                    self.onCancelled?()
+                    self?.handleGlobalKeyEvent(event)
                 }
-            case 49:
-                DispatchQueue.main.async {
-                    self?.overlayView.requestSpaceToggle()
-                }
-            default:
-                break
             }
         }
         // Local monitor: catches ESC/Space when our window is key.
@@ -145,6 +139,19 @@ final class CaptureOverlayWindow: NSPanel {
                 self?.overlayView.handleFlagsChanged(event)
                 return event
             }
+        }
+    }
+
+    func handleGlobalKeyEvent(_ event: NSEvent) {
+        guard handlesGlobalKeyEvents else { return }
+        switch event.keyCode {
+        case 53:
+            if overlayView.handleEscapeKey() { return }
+            onCancelled?()
+        case 49:
+            overlayView.requestSpaceToggle()
+        default:
+            break
         }
     }
 

--- a/App/Sources/Capture/CaptureOverlayWindow.swift
+++ b/App/Sources/Capture/CaptureOverlayWindow.swift
@@ -16,6 +16,7 @@ final class CaptureOverlayWindow: NSPanel {
     private let allowsMultiWindowSelection: Bool
     private var overlayView: CaptureOverlayView!
     private var globalEscMonitor: Any?
+    private var globalFlagsMonitor: Any?
     private var localEscMonitor: Any?
     private var localFlagsMonitor: Any?
 
@@ -127,6 +128,13 @@ final class CaptureOverlayWindow: NSPanel {
                     self?.handleGlobalKeyEvent(event)
                 }
             }
+            if allowsMultiWindowSelection {
+                globalFlagsMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+                    DispatchQueue.main.async {
+                        self?.handleGlobalFlagsChanged(event)
+                    }
+                }
+            }
         }
         // Local monitor: catches ESC/Space when our window is key.
         localEscMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
@@ -140,6 +148,15 @@ final class CaptureOverlayWindow: NSPanel {
                 return event
             }
         }
+    }
+
+    func handleGlobalFlagsChanged(_ event: NSEvent) {
+        let isShiftKey = event.keyCode == 56 || event.keyCode == 60
+        guard handlesGlobalKeyEvents,
+              allowsMultiWindowSelection,
+              isShiftKey,
+              !event.modifierFlags.contains(.shift) else { return }
+        overlayView.handleFlagsChanged(event, allowsNonKeyConfirmation: true)
     }
 
     func handleGlobalKeyEvent(_ event: NSEvent) {
@@ -178,6 +195,10 @@ final class CaptureOverlayWindow: NSPanel {
         if let globalEscMonitor {
             NSEvent.removeMonitor(globalEscMonitor)
             self.globalEscMonitor = nil
+        }
+        if let globalFlagsMonitor {
+            NSEvent.removeMonitor(globalFlagsMonitor)
+            self.globalFlagsMonitor = nil
         }
         if let localEscMonitor {
             NSEvent.removeMonitor(localEscMonitor)

--- a/App/Sources/Capture/CaptureOverlayWindow.swift
+++ b/App/Sources/Capture/CaptureOverlayWindow.swift
@@ -7,6 +7,7 @@ import SharedKit
 final class CaptureOverlayWindow: NSPanel {
     var onAreaSelected: ((CGRect, NSScreen) -> Void)?
     var onWindowSelected: ((CGWindowID) -> Void)?
+    var onWindowsSelected: (([CGWindowID]) -> Void)?
     var onCancelled: (() -> Void)?
     var onSpaceToggle: (() -> Void)?
 
@@ -14,6 +15,7 @@ final class CaptureOverlayWindow: NSPanel {
     private var overlayView: CaptureOverlayView!
     private var globalEscMonitor: Any?
     private var localEscMonitor: Any?
+    private var localFlagsMonitor: Any?
 
     init(screen: NSScreen, settings: AppSettings, presetsDisabled: Bool = false) {
         self.settings = settings
@@ -52,6 +54,9 @@ final class CaptureOverlayWindow: NSPanel {
         }
         overlayView.onWindowSelected = { [weak self] windowID in
             self?.onWindowSelected?(windowID)
+        }
+        overlayView.onWindowsSelected = { [weak self] windowIDs in
+            self?.onWindowsSelected?(windowIDs)
         }
         overlayView.onCancel = { [weak self] in
             self?.onCancelled?()
@@ -107,7 +112,9 @@ final class CaptureOverlayWindow: NSPanel {
             switch event.keyCode {
             case 53:
                 DispatchQueue.main.async {
-                    self?.onCancelled?()
+                    guard let self else { return }
+                    if self.overlayView.handleEscapeKey() { return }
+                    self.onCancelled?()
                 }
             case 49:
                 DispatchQueue.main.async {
@@ -121,6 +128,9 @@ final class CaptureOverlayWindow: NSPanel {
         localEscMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             switch event.keyCode {
             case 53:
+                if self?.overlayView.handleEscapeKey() == true {
+                    return nil
+                }
                 self?.onCancelled?()
                 return nil
             case 49:
@@ -129,6 +139,12 @@ final class CaptureOverlayWindow: NSPanel {
             default:
                 return event
             }
+        }
+        // Ensure Shift release confirms multi-window capture even if the view
+        // is not first responder (e.g. after clicking across screens).
+        localFlagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+            self?.overlayView.handleFlagsChanged(event)
+            return event
         }
     }
 
@@ -140,6 +156,10 @@ final class CaptureOverlayWindow: NSPanel {
         if let localEscMonitor {
             NSEvent.removeMonitor(localEscMonitor)
             self.localEscMonitor = nil
+        }
+        if let localFlagsMonitor {
+            NSEvent.removeMonitor(localFlagsMonitor)
+            self.localFlagsMonitor = nil
         }
     }
 }

--- a/App/Sources/Capture/CaptureOverlayWindow.swift
+++ b/App/Sources/Capture/CaptureOverlayWindow.swift
@@ -12,6 +12,7 @@ final class CaptureOverlayWindow: NSPanel {
     var onSpaceToggle: (() -> Void)?
 
     private let settings: AppSettings
+    private let allowsMultiWindowSelection: Bool
     private var overlayView: CaptureOverlayView!
     private var globalEscMonitor: Any?
     private var localEscMonitor: Any?
@@ -24,6 +25,7 @@ final class CaptureOverlayWindow: NSPanel {
         allowsMultiWindowSelection: Bool = true
     ) {
         self.settings = settings
+        self.allowsMultiWindowSelection = allowsMultiWindowSelection
         super.init(
             contentRect: screen.frame,
             styleMask: [.borderless, .nonactivatingPanel],
@@ -134,27 +136,33 @@ final class CaptureOverlayWindow: NSPanel {
         }
         // Local monitor: catches ESC/Space when our window is key.
         localEscMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            // Local monitors are also app-wide. Leave events for other
-            // display overlays untouched so one key press is handled once.
-            guard let self, event.window === self else { return event }
-            switch event.keyCode {
-            case 53:
-                if self.overlayView.handleEscapeKey() {
-                    return nil
-                }
-                self.onCancelled?()
-                return nil
-            case 49:
-                self.overlayView.requestSpaceToggle()
-                return nil
-            default:
-                return event
-            }
+            self?.handleLocalKeyEvent(event) ?? event
         }
         // Ensure Shift release confirms multi-window capture even if the view
         // is not first responder (e.g. after clicking across screens).
-        localFlagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
-            self?.overlayView.handleFlagsChanged(event)
+        if allowsMultiWindowSelection {
+            localFlagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+                self?.overlayView.handleFlagsChanged(event)
+                return event
+            }
+        }
+    }
+
+    /// Local monitors are app-wide. Leave events for other display overlays
+    /// untouched so one key press is handled exactly once.
+    func handleLocalKeyEvent(_ event: NSEvent) -> NSEvent? {
+        guard event.windowNumber == windowNumber else { return event }
+        switch event.keyCode {
+        case 53:
+            if overlayView.handleEscapeKey() {
+                return nil
+            }
+            onCancelled?()
+            return nil
+        case 49:
+            overlayView.requestSpaceToggle()
+            return nil
+        default:
             return event
         }
     }

--- a/App/Sources/OCR/OCRCoordinator.swift
+++ b/App/Sources/OCR/OCRCoordinator.swift
@@ -42,7 +42,12 @@ final class OCRCoordinator {
     private func showOverlayForOCR() {
         dismissOverlay()
         for screen in NSScreen.screens {
-            let overlay = CaptureOverlayWindow(screen: screen, settings: settings, presetsDisabled: true)
+            let overlay = CaptureOverlayWindow(
+                screen: screen,
+                settings: settings,
+                handlesGlobalKeyEvents: overlayWindows.isEmpty,
+                presetsDisabled: true
+            )
             overlay.onAreaSelected = { [weak self] rect, screen in
                 self?.dismissOverlay()
                 self?.performInstantOCR(rect: rect, screen: screen)

--- a/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
@@ -40,6 +40,8 @@ struct ShortcutSettingsView: View {
         ContextualShortcut(id: "all-in-one-save", scope: "All-in-One", action: "Save selected area", shortcut: "⌘S"),
         ContextualShortcut(id: "all-in-one-pin", scope: "All-in-One", action: "Pin selected area", shortcut: "⌘P"),
         ContextualShortcut(id: "all-in-one-cancel", scope: "All-in-One", action: "Cancel", shortcut: "Esc"),
+        ContextualShortcut(id: "window-multi-select", scope: "Window Capture", action: "Select multiple windows", shortcut: "⇧ + click"),
+        ContextualShortcut(id: "window-multi-confirm", scope: "Window Capture", action: "Capture selected windows", shortcut: "Release ⇧"),
         ContextualShortcut(id: "quick-access-copy", scope: "Quick Access", action: "Copy", shortcut: "⌘C"),
         ContextualShortcut(id: "quick-access-save", scope: "Quick Access", action: "Save", shortcut: "⌘S"),
         ContextualShortcut(id: "quick-access-annotate", scope: "Quick Access", action: "Annotate", shortcut: "⌘E"),

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -125,6 +125,7 @@ final class RecordingCoordinator {
             let overlay = CaptureOverlayWindow(
                 screen: screen,
                 settings: settings,
+                handlesGlobalKeyEvents: overlayWindows.isEmpty,
                 presetsDisabled: true,
                 allowsMultiWindowSelection: false
             )

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -122,7 +122,12 @@ final class RecordingCoordinator {
         dismissOverlay()
 
         for screen in NSScreen.screens {
-            let overlay = CaptureOverlayWindow(screen: screen, settings: settings, presetsDisabled: true)
+            let overlay = CaptureOverlayWindow(
+                screen: screen,
+                settings: settings,
+                presetsDisabled: true,
+                allowsMultiWindowSelection: false
+            )
             overlay.onAreaSelected = { [weak self] rect, screen in
                 self?.dismissOverlay()
                 self?.handleAreaSelected(rect: rect, screen: screen)

--- a/App/Sources/Translation/TranslationCoordinator.swift
+++ b/App/Sources/Translation/TranslationCoordinator.swift
@@ -81,7 +81,12 @@ final class TranslationCoordinator {
     private func beginCaptureFlow() {
         dismissOverlay()
         for screen in NSScreen.screens {
-            let overlay = CaptureOverlayWindow(screen: screen, settings: settings, presetsDisabled: true)
+            let overlay = CaptureOverlayWindow(
+                screen: screen,
+                settings: settings,
+                handlesGlobalKeyEvents: overlayWindows.isEmpty,
+                presetsDisabled: true
+            )
             overlay.onAreaSelected = { [weak self] rect, screen in
                 self?.dismissOverlay()
                 self?.captureAndPerform(rect: rect, screen: screen)

--- a/App/Tests/CaptureOverlayInteractionTests.swift
+++ b/App/Tests/CaptureOverlayInteractionTests.swift
@@ -5,23 +5,10 @@ import SharedKit
 
 @MainActor
 final class CaptureOverlayInteractionTests: XCTestCase {
-    private var defaultsSuiteName: String!
-    private var settings: AppSettings!
-
-    override func setUp() {
-        super.setUp()
-        defaultsSuiteName = "CaptureOverlayInteractionTests.\(UUID().uuidString)"
-        settings = AppSettings(defaults: UserDefaults(suiteName: defaultsSuiteName)!)
-    }
-
-    override func tearDown() {
-        UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName)
-        settings = nil
-        defaultsSuiteName = nil
-        super.tearDown()
-    }
-
     func testEscapeEventClearsMultiSelectionWithoutCancellingOtherDisplayOverlay() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+
         let screen = try XCTUnwrap(NSScreen.main)
         let firstWindow = CaptureOverlayWindow(screen: screen, settings: settings)
         let secondWindow = CaptureOverlayWindow(screen: screen, settings: settings)
@@ -51,6 +38,9 @@ final class CaptureOverlayInteractionTests: XCTestCase {
     }
 
     func testRecordingWindowSelectionTreatsShiftClickAsSingleSelection() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+
         let screen = try XCTUnwrap(NSScreen.main)
         let hostWindow = NSWindow(
             contentRect: screen.frame,
@@ -74,6 +64,11 @@ final class CaptureOverlayInteractionTests: XCTestCase {
 
         XCTAssertEqual(selectedWindowID, 42)
         XCTAssertFalse(view.handleEscapeKey(), "Shift-click must not leave recording in multi-select state")
+    }
+
+    private func makeSettings() -> (AppSettings, String) {
+        let suiteName = "CaptureOverlayInteractionTests.\(UUID().uuidString)"
+        return (AppSettings(defaults: UserDefaults(suiteName: suiteName)!), suiteName)
     }
 
     private func makeEscapeEvent(windowNumber: Int) throws -> NSEvent {

--- a/App/Tests/CaptureOverlayInteractionTests.swift
+++ b/App/Tests/CaptureOverlayInteractionTests.swift
@@ -88,6 +88,56 @@ final class CaptureOverlayInteractionTests: XCTestCase {
         XCTAssertEqual(cancellationCount, 1)
     }
 
+    func testGlobalShiftReleaseConfirmsSelectionWhenNoOverlayIsKey() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+
+        let screen = try XCTUnwrap(NSScreen.main)
+        let firstWindow = CaptureOverlayWindow(
+            screen: screen,
+            settings: settings,
+            handlesGlobalKeyEvents: true
+        )
+        let secondWindow = CaptureOverlayWindow(
+            screen: screen,
+            settings: settings,
+            handlesGlobalKeyEvents: false
+        )
+        let firstView = try XCTUnwrap(firstWindow.contentView as? CaptureOverlayView)
+        let secondView = try XCTUnwrap(secondWindow.contentView as? CaptureOverlayView)
+
+        firstView.setMode(.windowSelection([]))
+        secondView.setMode(.windowSelection([]))
+        NotificationCenter.default.post(
+            name: .multiWindowSelectionChanged,
+            object: self,
+            userInfo: [
+                "windowIDs": [
+                    NSNumber(value: CGWindowID(42)),
+                    NSNumber(value: CGWindowID(43))
+                ]
+            ]
+        )
+
+        var capturedSelections: [[CGWindowID]] = []
+        firstWindow.onWindowsSelected = { capturedSelections.append($0) }
+        secondWindow.onWindowsSelected = { capturedSelections.append($0) }
+
+        XCTAssertFalse(firstWindow.isKeyWindow)
+        XCTAssertFalse(secondWindow.isKeyWindow)
+
+        let commandChanged = try makeFlagsChangedEvent(modifierFlags: .command, keyCode: 55)
+        firstWindow.handleGlobalFlagsChanged(commandChanged)
+        secondWindow.handleGlobalFlagsChanged(commandChanged)
+        XCTAssertTrue(capturedSelections.isEmpty)
+
+        let shiftReleased = try makeFlagsChangedEvent(modifierFlags: [])
+        firstWindow.handleGlobalFlagsChanged(shiftReleased)
+        secondWindow.handleGlobalFlagsChanged(shiftReleased)
+
+        XCTAssertEqual(capturedSelections, [[42, 43]])
+    }
+
     func testRecordingWindowSelectionTreatsShiftClickAsSingleSelection() throws {
         let (settings, defaultsSuiteName) = makeSettings()
         defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
@@ -160,7 +210,10 @@ final class CaptureOverlayInteractionTests: XCTestCase {
         ))
     }
 
-    private func makeFlagsChangedEvent(modifierFlags: NSEvent.ModifierFlags) throws -> NSEvent {
+    private func makeFlagsChangedEvent(
+        modifierFlags: NSEvent.ModifierFlags,
+        keyCode: UInt16 = 56
+    ) throws -> NSEvent {
         try XCTUnwrap(NSEvent.keyEvent(
             with: .flagsChanged,
             location: .zero,
@@ -171,7 +224,7 @@ final class CaptureOverlayInteractionTests: XCTestCase {
             characters: "",
             charactersIgnoringModifiers: "",
             isARepeat: false,
-            keyCode: 56
+            keyCode: keyCode
         ))
     }
 }

--- a/App/Tests/CaptureOverlayInteractionTests.swift
+++ b/App/Tests/CaptureOverlayInteractionTests.swift
@@ -1,0 +1,93 @@
+import AppKit
+import XCTest
+@testable import Capso
+import SharedKit
+
+@MainActor
+final class CaptureOverlayInteractionTests: XCTestCase {
+    private var defaultsSuiteName: String!
+    private var settings: AppSettings!
+
+    override func setUp() {
+        super.setUp()
+        defaultsSuiteName = "CaptureOverlayInteractionTests.\(UUID().uuidString)"
+        settings = AppSettings(defaults: UserDefaults(suiteName: defaultsSuiteName)!)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName)
+        settings = nil
+        defaultsSuiteName = nil
+        super.tearDown()
+    }
+
+    func testEscapeEventClearsMultiSelectionWithoutCancellingOtherDisplayOverlay() throws {
+        let screen = try XCTUnwrap(NSScreen.main)
+        let firstWindow = CaptureOverlayWindow(screen: screen, settings: settings)
+        let secondWindow = CaptureOverlayWindow(screen: screen, settings: settings)
+        let firstView = try XCTUnwrap(firstWindow.contentView as? CaptureOverlayView)
+        let secondView = try XCTUnwrap(secondWindow.contentView as? CaptureOverlayView)
+
+        firstView.setMode(.windowSelection([]))
+        secondView.setMode(.windowSelection([]))
+        NotificationCenter.default.post(
+            name: .multiWindowSelectionChanged,
+            object: self,
+            userInfo: ["windowIDs": [NSNumber(value: CGWindowID(42))]]
+        )
+
+        var cancellationCount = 0
+        firstWindow.onCancelled = { cancellationCount += 1 }
+        secondWindow.onCancelled = { cancellationCount += 1 }
+
+        let firstEscape = try makeEscapeEvent(windowNumber: firstWindow.windowNumber)
+        XCTAssertNil(firstWindow.handleLocalKeyEvent(firstEscape))
+        XCTAssertTrue(secondWindow.handleLocalKeyEvent(firstEscape) === firstEscape)
+        XCTAssertEqual(cancellationCount, 0)
+
+        let secondEscape = try makeEscapeEvent(windowNumber: secondWindow.windowNumber)
+        XCTAssertNil(secondWindow.handleLocalKeyEvent(secondEscape))
+        XCTAssertEqual(cancellationCount, 1)
+    }
+
+    func testRecordingWindowSelectionTreatsShiftClickAsSingleSelection() throws {
+        let screen = try XCTUnwrap(NSScreen.main)
+        let hostWindow = NSWindow(
+            contentRect: screen.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        let view = CaptureOverlayView(
+            frame: NSRect(origin: .zero, size: screen.frame.size),
+            settings: settings,
+            safeAreaTopInset: 0,
+            presetsDisabled: true,
+            allowsMultiWindowSelection: false
+        )
+        hostWindow.contentView = view
+        view.setMode(.windowSelection([]))
+
+        var selectedWindowID: CGWindowID?
+        view.onWindowSelected = { selectedWindowID = $0 }
+        view.handleWindowClick(42, modifierFlags: .shift)
+
+        XCTAssertEqual(selectedWindowID, 42)
+        XCTAssertFalse(view.handleEscapeKey(), "Shift-click must not leave recording in multi-select state")
+    }
+
+    private func makeEscapeEvent(windowNumber: Int) throws -> NSEvent {
+        try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: windowNumber,
+            context: nil,
+            characters: "\u{1B}",
+            charactersIgnoringModifiers: "\u{1B}",
+            isARepeat: false,
+            keyCode: 53
+        ))
+    }
+}

--- a/App/Tests/CaptureOverlayInteractionTests.swift
+++ b/App/Tests/CaptureOverlayInteractionTests.swift
@@ -10,8 +10,16 @@ final class CaptureOverlayInteractionTests: XCTestCase {
         defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
 
         let screen = try XCTUnwrap(NSScreen.main)
-        let firstWindow = CaptureOverlayWindow(screen: screen, settings: settings)
-        let secondWindow = CaptureOverlayWindow(screen: screen, settings: settings)
+        let firstWindow = CaptureOverlayWindow(
+            screen: screen,
+            settings: settings,
+            handlesGlobalKeyEvents: true
+        )
+        let secondWindow = CaptureOverlayWindow(
+            screen: screen,
+            settings: settings,
+            handlesGlobalKeyEvents: false
+        )
         let firstView = try XCTUnwrap(firstWindow.contentView as? CaptureOverlayView)
         let secondView = try XCTUnwrap(secondWindow.contentView as? CaptureOverlayView)
 
@@ -34,6 +42,49 @@ final class CaptureOverlayInteractionTests: XCTestCase {
 
         let secondEscape = try makeEscapeEvent(windowNumber: secondWindow.windowNumber)
         XCTAssertNil(secondWindow.handleLocalKeyEvent(secondEscape))
+        XCTAssertEqual(cancellationCount, 1)
+    }
+
+    func testGlobalEscapeUsesOneOwnerWhenNoOverlayIsKey() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+
+        let screen = try XCTUnwrap(NSScreen.main)
+        let firstWindow = CaptureOverlayWindow(
+            screen: screen,
+            settings: settings,
+            handlesGlobalKeyEvents: true
+        )
+        let secondWindow = CaptureOverlayWindow(
+            screen: screen,
+            settings: settings,
+            handlesGlobalKeyEvents: false
+        )
+        let firstView = try XCTUnwrap(firstWindow.contentView as? CaptureOverlayView)
+        let secondView = try XCTUnwrap(secondWindow.contentView as? CaptureOverlayView)
+
+        firstView.setMode(.windowSelection([]))
+        secondView.setMode(.windowSelection([]))
+        NotificationCenter.default.post(
+            name: .multiWindowSelectionChanged,
+            object: self,
+            userInfo: ["windowIDs": [NSNumber(value: CGWindowID(42))]]
+        )
+
+        var cancellationCount = 0
+        firstWindow.onCancelled = { cancellationCount += 1 }
+        secondWindow.onCancelled = { cancellationCount += 1 }
+
+        XCTAssertFalse(firstWindow.isKeyWindow)
+        XCTAssertFalse(secondWindow.isKeyWindow)
+
+        let escape = try makeEscapeEvent(windowNumber: 0)
+        firstWindow.handleGlobalKeyEvent(escape)
+        secondWindow.handleGlobalKeyEvent(escape)
+        XCTAssertEqual(cancellationCount, 0)
+
+        firstWindow.handleGlobalKeyEvent(escape)
+        secondWindow.handleGlobalKeyEvent(escape)
         XCTAssertEqual(cancellationCount, 1)
     }
 
@@ -66,6 +117,29 @@ final class CaptureOverlayInteractionTests: XCTestCase {
         XCTAssertFalse(view.handleEscapeKey(), "Shift-click must not leave recording in multi-select state")
     }
 
+    func testSingleShiftSelectionUsesSingleWindowCallback() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+
+        let view = CaptureOverlayView(
+            frame: NSRect(origin: .zero, size: NSSize(width: 100, height: 100)),
+            settings: settings,
+            safeAreaTopInset: 0
+        )
+        view.setMode(.windowSelection([]))
+
+        var selectedWindowID: CGWindowID?
+        var selectedWindowIDs: [CGWindowID]?
+        view.onWindowSelected = { selectedWindowID = $0 }
+        view.onWindowsSelected = { selectedWindowIDs = $0 }
+
+        view.handleWindowClick(42, modifierFlags: .shift)
+        view.handleFlagsChanged(try makeFlagsChangedEvent(modifierFlags: []))
+
+        XCTAssertEqual(selectedWindowID, 42)
+        XCTAssertNil(selectedWindowIDs)
+    }
+
     private func makeSettings() -> (AppSettings, String) {
         let suiteName = "CaptureOverlayInteractionTests.\(UUID().uuidString)"
         return (AppSettings(defaults: UserDefaults(suiteName: suiteName)!), suiteName)
@@ -83,6 +157,21 @@ final class CaptureOverlayInteractionTests: XCTestCase {
             charactersIgnoringModifiers: "\u{1B}",
             isARepeat: false,
             keyCode: 53
+        ))
+    }
+
+    private func makeFlagsChangedEvent(modifierFlags: NSEvent.ModifierFlags) throws -> NSEvent {
+        try XCTUnwrap(NSEvent.keyEvent(
+            with: .flagsChanged,
+            location: .zero,
+            modifierFlags: modifierFlags,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: 56
         ))
     }
 }

--- a/Packages/CaptureKit/Sources/CaptureKit/MultiWindowCompositor.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/MultiWindowCompositor.swift
@@ -1,0 +1,281 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import QuartzCore
+
+/// Pure geometry helpers for compositing multiple window screenshots onto one
+/// transparent canvas. Frames use ScreenCaptureKit global coordinates (origin
+/// at the top-left of the primary display, Y increasing downward).
+public enum MultiWindowCompositor {
+
+    /// Continuous corner radius (points) matching recent macOS window chrome.
+    public static let fallbackCornerRadiusPoints: CGFloat = 16
+
+    /// Inset applied to the corner mask so soft anti-aliased fringe pixels
+    /// (often light/white against a dark backdrop) are clipped away.
+    public static let cornerMaskInsetPoints: CGFloat = 0.75
+
+    /// Alpha below this is forced to 0 after masking — kills residual soft
+    /// white halos without touching fully opaque window chrome.
+    public static let softAlphaThreshold: UInt8 = 24
+
+    public struct Layer: Sendable {
+        public let image: CGImage
+        /// Window frame in ScreenCaptureKit global point coordinates.
+        public let frame: CGRect
+
+        public init(image: CGImage, frame: CGRect) {
+            self.image = image
+            self.frame = frame
+        }
+    }
+
+    /// Axis-aligned union of the given frames. Returns `nil` when `frames` is empty.
+    public static func unionBounds(of frames: [CGRect]) -> CGRect? {
+        guard let first = frames.first else { return nil }
+        return frames.dropFirst().reduce(first) { $0.union($1) }
+    }
+
+    /// Composite layers onto a transparent canvas sized to the union of their
+    /// frames. `layers` is front-to-back (index 0 = frontmost); drawing walks
+    /// the array in reverse so earlier entries end on top.
+    ///
+    /// Gaps between windows stay fully transparent (alpha 0). Each layer is
+    /// pre-masked with a continuous corner silhouette (slightly inset) so
+    /// square/white corner fringes do not survive into the composite.
+    public static func composite(
+        layers: [Layer],
+        cornerRadiusPoints: CGFloat = fallbackCornerRadiusPoints
+    ) -> CGImage? {
+        guard !layers.isEmpty else { return nil }
+        guard let union = unionBounds(of: layers.map(\.frame)),
+              union.width > 0, union.height > 0 else {
+            return nil
+        }
+
+        let scale = layers.map { layer -> CGFloat in
+            guard layer.frame.width > 0 else { return 2 }
+            return CGFloat(layer.image.width) / layer.frame.width
+        }.max() ?? 2
+
+        let pixelWidth = max(1, Int((union.width * scale).rounded()))
+        let pixelHeight = max(1, Int((union.height * scale).rounded()))
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: pixelWidth,
+            height: pixelHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return nil
+        }
+
+        context.clear(CGRect(x: 0, y: 0, width: pixelWidth, height: pixelHeight))
+        // Prefer crisp edges over soft resampling fringe when sizes differ by a px.
+        context.interpolationQuality = .medium
+
+        for layer in layers.reversed() {
+            let prepared = prepareLayerImage(
+                layer.image,
+                pointSize: layer.frame.size,
+                cornerRadiusPoints: cornerRadiusPoints
+            ) ?? layer.image
+
+            let localX = layer.frame.minX - union.minX
+            let localTopY = layer.frame.minY - union.minY
+            let localBottomY = union.height - localTopY - layer.frame.height
+            let dest = CGRect(
+                x: localX * scale,
+                y: localBottomY * scale,
+                width: layer.frame.width * scale,
+                height: layer.frame.height * scale
+            )
+            context.draw(prepared, in: dest)
+        }
+
+        return context.makeImage()
+    }
+
+    /// Mask a captured window bitmap to a continuous rounded rect and harden
+    /// soft alpha. Exposed for unit tests.
+    public static func prepareLayerImage(
+        _ image: CGImage,
+        pointSize: CGSize,
+        cornerRadiusPoints: CGFloat,
+        insetPoints: CGFloat = cornerMaskInsetPoints,
+        softAlphaThreshold: UInt8 = softAlphaThreshold
+    ) -> CGImage? {
+        let masked: CGImage
+        if cornerRadiusPoints > 0,
+           let continuous = applyContinuousCornerMask(
+               to: image,
+               pointSize: pointSize,
+               cornerRadiusPoints: cornerRadiusPoints,
+               insetPoints: insetPoints
+           ) {
+            masked = continuous
+        } else {
+            masked = image
+        }
+        return hardenSoftAlpha(masked, threshold: softAlphaThreshold) ?? masked
+    }
+
+    // MARK: - Corner mask
+
+    private static func applyContinuousCornerMask(
+        to image: CGImage,
+        pointSize: CGSize,
+        cornerRadiusPoints: CGFloat,
+        insetPoints: CGFloat
+    ) -> CGImage? {
+        let pw = image.width
+        let ph = image.height
+        guard pw > 0, ph > 0, pointSize.width > 0, pointSize.height > 0 else { return nil }
+
+        guard let mask = continuousCornerMask(
+            pixelWidth: pw,
+            pixelHeight: ph,
+            pointSize: pointSize,
+            cornerRadiusPoints: cornerRadiusPoints,
+            insetPoints: insetPoints
+        ) else {
+            return nil
+        }
+
+        let colorSpace: CGColorSpace = {
+            if let cs = image.colorSpace, cs.model == .rgb { return cs }
+            return CGColorSpaceCreateDeviceRGB()
+        }()
+
+        guard let context = CGContext(
+            data: nil,
+            width: pw,
+            height: ph,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return nil
+        }
+
+        let rect = CGRect(x: 0, y: 0, width: pw, height: ph)
+        context.interpolationQuality = .high
+        context.draw(image, in: rect)
+        // Multiply destination alpha by the continuous mask silhouette.
+        context.setBlendMode(.destinationIn)
+        context.draw(mask, in: rect)
+        return context.makeImage()
+    }
+
+    private static func continuousCornerMask(
+        pixelWidth: Int,
+        pixelHeight: Int,
+        pointSize: CGSize,
+        cornerRadiusPoints: CGFloat,
+        insetPoints: CGFloat
+    ) -> CGImage? {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: pixelWidth,
+            height: pixelHeight,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return nil
+        }
+
+        let scaleX = CGFloat(pixelWidth) / pointSize.width
+        let scaleY = CGFloat(pixelHeight) / pointSize.height
+        let scale = max(scaleX, scaleY)
+        let inset = max(0, insetPoints)
+        let drawableSize = CGSize(
+            width: max(1, pointSize.width - inset * 2),
+            height: max(1, pointSize.height - inset * 2)
+        )
+        let radius = min(
+            cornerRadiusPoints,
+            min(drawableSize.width, drawableSize.height) / 2
+        )
+
+        context.clear(CGRect(x: 0, y: 0, width: pixelWidth, height: pixelHeight))
+        context.translateBy(x: inset * scaleX, y: inset * scaleY)
+        context.scaleBy(x: scaleX, y: scaleY)
+
+        let layer = CALayer()
+        layer.frame = CGRect(origin: .zero, size: drawableSize)
+        layer.backgroundColor = NSColor.white.cgColor
+        layer.cornerRadius = radius
+        layer.cornerCurve = .continuous
+        layer.contentsScale = scale
+        layer.rasterizationScale = scale
+        layer.masksToBounds = true
+        layer.render(in: context)
+
+        return context.makeImage()
+    }
+
+    // MARK: - Soft alpha cleanup
+
+    /// Force nearly-transparent fringe pixels to fully transparent so light
+    /// premultiplied RGB cannot read as a white halo on dark backgrounds.
+    private static func hardenSoftAlpha(_ image: CGImage, threshold: UInt8) -> CGImage? {
+        let width = image.width
+        let height = image.height
+        guard width > 0, height > 0 else { return nil }
+
+        let bytesPerPixel = 4
+        let bytesPerRow = width * bytesPerPixel
+        var pixels = [UInt8](repeating: 0, count: bytesPerRow * height)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+
+        let drew = pixels.withUnsafeMutableBytes { ptr -> Bool in
+            guard let context = CGContext(
+                data: ptr.baseAddress,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: bytesPerRow,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ) else {
+                return false
+            }
+            context.clear(CGRect(x: 0, y: 0, width: width, height: height))
+            context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+            return true
+        }
+        guard drew else { return nil }
+
+        for i in stride(from: 0, to: pixels.count, by: bytesPerPixel) {
+            let alpha = pixels[i + 3]
+            if alpha < threshold {
+                pixels[i] = 0
+                pixels[i + 1] = 0
+                pixels[i + 2] = 0
+                pixels[i + 3] = 0
+            }
+        }
+
+        guard let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ),
+        let out = context.makeImage() else {
+            return nil
+        }
+        return out
+    }
+}

--- a/Packages/CaptureKit/Sources/CaptureKit/MultiWindowCompositor.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/MultiWindowCompositor.swift
@@ -6,32 +6,32 @@ import QuartzCore
 /// Pure geometry helpers for compositing multiple window screenshots onto one
 /// transparent canvas. Frames use ScreenCaptureKit global coordinates (origin
 /// at the top-left of the primary display, Y increasing downward).
-public enum MultiWindowCompositor {
+enum MultiWindowCompositor {
 
     /// Continuous corner radius (points) matching recent macOS window chrome.
-    public static let fallbackCornerRadiusPoints: CGFloat = 16
+    static let fallbackCornerRadiusPoints: CGFloat = 16
 
     /// Inset applied to the corner mask so soft anti-aliased fringe pixels
     /// (often light/white against a dark backdrop) are clipped away.
-    public static let cornerMaskInsetPoints: CGFloat = 0.75
+    static let cornerMaskInsetPoints: CGFloat = 0.75
 
     /// Alpha below this is forced to 0 after masking — kills residual soft
     /// white halos without touching fully opaque window chrome.
-    public static let softAlphaThreshold: UInt8 = 24
+    static let softAlphaThreshold: UInt8 = 24
 
-    public struct Layer: Sendable {
-        public let image: CGImage
+    struct Layer: Sendable {
+        let image: CGImage
         /// Window frame in ScreenCaptureKit global point coordinates.
-        public let frame: CGRect
+        let frame: CGRect
 
-        public init(image: CGImage, frame: CGRect) {
+        init(image: CGImage, frame: CGRect) {
             self.image = image
             self.frame = frame
         }
     }
 
     /// Axis-aligned union of the given frames. Returns `nil` when `frames` is empty.
-    public static func unionBounds(of frames: [CGRect]) -> CGRect? {
+    static func unionBounds(of frames: [CGRect]) -> CGRect? {
         guard let first = frames.first else { return nil }
         return frames.dropFirst().reduce(first) { $0.union($1) }
     }
@@ -43,7 +43,7 @@ public enum MultiWindowCompositor {
     /// Gaps between windows stay fully transparent (alpha 0). Each layer is
     /// pre-masked with a continuous corner silhouette (slightly inset) so
     /// square/white corner fringes do not survive into the composite.
-    public static func composite(
+    static func composite(
         layers: [Layer],
         cornerRadiusPoints: CGFloat = fallbackCornerRadiusPoints
     ) -> CGImage? {
@@ -102,7 +102,7 @@ public enum MultiWindowCompositor {
 
     /// Mask a captured window bitmap to a continuous rounded rect and harden
     /// soft alpha. Exposed for unit tests.
-    public static func prepareLayerImage(
+    static func prepareLayerImage(
         _ image: CGImage,
         pointSize: CGSize,
         cornerRadiusPoints: CGFloat,

--- a/Packages/CaptureKit/Sources/CaptureKit/ScreenCaptureManager.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/ScreenCaptureManager.swift
@@ -119,6 +119,101 @@ public enum ScreenCaptureManager {
         )
     }
 
+    // MARK: - Multi-Window Capture
+
+    /// Capture multiple windows and composite them onto a transparent canvas at
+    /// their screen positions. `windowIDs` should be front-to-back (index 0 =
+    /// frontmost) so overlapping windows stack correctly.
+    ///
+    /// Uses desktop-independent capture with shadows stripped so each layer
+    /// keeps the WindowServer alpha silhouette (rounded corners). The
+    /// display-based `includeShadow: false` path is intentionally avoided —
+    /// it bakes an opaque rectangle and leaves white/jagged corner fringes.
+    public static func captureWindows(
+        windowIDs: [CGWindowID],
+        showsCursor: Bool = false
+    ) async throws -> CaptureResult {
+        guard !windowIDs.isEmpty else {
+            throw CaptureError.captureFailed("No windows selected")
+        }
+
+        var layers: [MultiWindowCompositor.Layer] = []
+        layers.reserveCapacity(windowIDs.count)
+        var displayID = CGMainDisplayID()
+
+        for windowID in windowIDs {
+            let result = try await captureWindowForMultiComposite(
+                windowID: windowID,
+                showsCursor: showsCursor
+            )
+            layers.append(MultiWindowCompositor.Layer(image: result.image, frame: result.captureRect))
+            displayID = result.displayID
+        }
+
+        guard let union = MultiWindowCompositor.unionBounds(of: layers.map(\.frame)),
+              let image = MultiWindowCompositor.composite(layers: layers) else {
+            throw CaptureError.captureFailed("Failed to composite selected windows")
+        }
+
+        return CaptureResult(
+            image: image,
+            mode: .window,
+            captureRect: union,
+            windowName: "\(windowIDs.count) windows",
+            appName: nil,
+            appBundleIdentifier: nil,
+            displayID: displayID
+        )
+    }
+
+    /// Single-window capture tuned for multi-window compositing: transparent
+    /// backdrop, real window alpha, no drop shadow (so frames stay aligned to
+    /// `SCWindow.frame` for layout).
+    private static func captureWindowForMultiComposite(
+        windowID: CGWindowID,
+        showsCursor: Bool
+    ) async throws -> CaptureResult {
+        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
+
+        guard let scWindow = content.windows.first(where: { $0.windowID == windowID }) else {
+            throw CaptureError.windowNotFound(windowID)
+        }
+
+        let windowCenter = CGPoint(x: scWindow.frame.midX, y: scWindow.frame.midY)
+        guard let display = content.displays.first(where: { $0.frame.contains(windowCenter) })
+            ?? content.displays.first else {
+            throw CaptureError.noDisplayFound
+        }
+
+        let filter = SCContentFilter(desktopIndependentWindow: scWindow)
+        let config = SCStreamConfiguration()
+        config.captureResolution = .best
+        config.showsCursor = showsCursor
+        // Keep the WindowServer alpha mask (rounded corners) but drop the
+        // shadow so the bitmap lines up with `scWindow.frame` for compositing.
+        config.ignoreShadowsSingleWindow = true
+        // Size to the window frame (not contentRect) so the bitmap aspect
+        // matches layout and we avoid stretch-induced edge fringe.
+        let scaleFactor = CGFloat(filter.pointPixelScale)
+        config.width = max(1, Int((scWindow.frame.width * scaleFactor).rounded()))
+        config.height = max(1, Int((scWindow.frame.height * scaleFactor).rounded()))
+
+        let image = try await SCScreenshotManager.captureImage(
+            contentFilter: filter,
+            configuration: config
+        )
+
+        return CaptureResult(
+            image: image,
+            mode: .window,
+            captureRect: scWindow.frame,
+            windowName: scWindow.title,
+            appName: scWindow.owningApplication?.applicationName,
+            appBundleIdentifier: scWindow.owningApplication?.bundleIdentifier,
+            displayID: display.displayID
+        )
+    }
+
     // MARK: - Desktop Background Capture (for window shadow compositing)
 
     /// Capture the desktop behind a window (excluding the window itself),

--- a/Packages/CaptureKit/Tests/CaptureKitTests/MultiWindowCompositorTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/MultiWindowCompositorTests.swift
@@ -1,0 +1,144 @@
+import Testing
+import CoreGraphics
+@testable import CaptureKit
+
+@Suite("MultiWindowCompositor")
+struct MultiWindowCompositorTests {
+
+    @Test("unionBounds returns nil for empty input")
+    func unionEmpty() {
+        #expect(MultiWindowCompositor.unionBounds(of: []) == nil)
+    }
+
+    @Test("unionBounds unions overlapping and disjoint frames")
+    func unionFrames() {
+        let a = CGRect(x: 0, y: 0, width: 100, height: 80)
+        let b = CGRect(x: 50, y: 40, width: 100, height: 80)
+        let union = MultiWindowCompositor.unionBounds(of: [a, b])
+        #expect(union == CGRect(x: 0, y: 0, width: 150, height: 120))
+
+        let c = CGRect(x: 200, y: 200, width: 50, height: 50)
+        let disjoint = MultiWindowCompositor.unionBounds(of: [a, c])
+        #expect(disjoint == CGRect(x: 0, y: 0, width: 250, height: 250))
+    }
+
+    @Test("composite draws frontmost layer on top")
+    func compositeZOrder() {
+        // Back layer: opaque red 40x40 at (0,0)
+        let back = makeSolidImage(width: 40, height: 40, rgba: (1, 0, 0, 1))
+        // Front layer: opaque blue 40x40 overlapping at (20,20)
+        let front = makeSolidImage(width: 40, height: 40, rgba: (0, 0, 1, 1))
+
+        let layers = [
+            MultiWindowCompositor.Layer(
+                image: front,
+                frame: CGRect(x: 20, y: 20, width: 40, height: 40)
+            ),
+            MultiWindowCompositor.Layer(
+                image: back,
+                frame: CGRect(x: 0, y: 0, width: 40, height: 40)
+            ),
+        ]
+
+        // Disable corner masking so solid test rects stay fully opaque.
+        let image = MultiWindowCompositor.composite(layers: layers, cornerRadiusPoints: 0)
+        #expect(image != nil)
+        guard let image else { return }
+
+        // Canvas is 60x60 points at 1x (images are 40px for 40pt frames).
+        #expect(image.width == 60)
+        #expect(image.height == 60)
+
+        // Overlap center ≈ (30, 30) in top-left SC space → bitmap (30, 29)
+        // because Y flips (bottom-left). Sample a pixel firmly inside the
+        // overlap in bitmap coords.
+        let overlapPixel = samplePixel(image, x: 30, y: 29)
+        #expect(overlapPixel.b > overlapPixel.r)
+        #expect(overlapPixel.b > 0.5)
+
+        // Non-overlapping corner of the back layer (top-left SC → top of bitmap
+        // after flip is high Y). Point (5,5) SC → bitmap y = 60 - 5 - 1 = 54.
+        let backOnly = samplePixel(image, x: 5, y: 54)
+        #expect(backOnly.r > 0.5)
+        #expect(backOnly.b < 0.5)
+    }
+
+    @Test("prepareLayerImage clears soft fringe outside continuous corners")
+    func prepareClearsCornerFringe() {
+        // Opaque white square — after continuous masking, corner pixels that
+        // sit outside the silhouette must become fully transparent.
+        let square = makeSolidImage(width: 100, height: 100, rgba: (1, 1, 1, 1))
+        let prepared = MultiWindowCompositor.prepareLayerImage(
+            square,
+            pointSize: CGSize(width: 100, height: 100),
+            cornerRadiusPoints: 16,
+            insetPoints: 0.75
+        )
+        #expect(prepared != nil)
+        guard let prepared else { return }
+
+        let corner = samplePixel(prepared, x: 1, y: 1)
+        #expect(corner.a < 0.05)
+
+        let center = samplePixel(prepared, x: 50, y: 50)
+        #expect(center.a > 0.9)
+        #expect(center.r > 0.9)
+    }
+
+    @Test("composite returns nil for empty layers")
+    func compositeEmpty() {
+        #expect(MultiWindowCompositor.composite(layers: []) == nil)
+    }
+
+    // MARK: - Helpers
+
+    private func makeSolidImage(
+        width: Int,
+        height: Int,
+        rgba: (CGFloat, CGFloat, CGFloat, CGFloat)
+    ) -> CGImage {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        context.setFillColor(
+            red: rgba.0, green: rgba.1, blue: rgba.2, alpha: rgba.3
+        )
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return context.makeImage()!
+    }
+
+    private func samplePixel(
+        _ image: CGImage,
+        x: Int,
+        y: Int
+    ) -> (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        var pixel = [UInt8](repeating: 0, count: 4)
+        let context = CGContext(
+            data: &pixel,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 4,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        context.draw(
+            image,
+            in: CGRect(x: -x, y: -y, width: image.width, height: image.height)
+        )
+        return (
+            r: CGFloat(pixel[0]) / 255,
+            g: CGFloat(pixel[1]) / 255,
+            b: CGFloat(pixel[2]) / 255,
+            a: CGFloat(pixel[3]) / 255
+        )
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -98,3 +98,30 @@ targets:
         com.apple.security.device.camera: true
         com.apple.security.device.audio-input: true
         com.apple.security.network.client: true
+
+  CapsoTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - path: App/Tests
+    dependencies:
+      - target: Capso
+      - package: SharedKit
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.awesomemacapps.capso.tests
+        GENERATE_INFOPLIST_FILE: YES
+        BUNDLE_LOADER: "$(TEST_HOST)"
+        TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Capso.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Capso"
+
+schemes:
+  Capso:
+    build:
+      targets:
+        Capso: all
+    run:
+      config: Debug
+    test:
+      config: Debug
+      targets:
+        - CapsoTests


### PR DESCRIPTION
## Summary
- Adds iShot-style multi-window capture for [#191](https://github.com/lzhgus/Capso/issues/191): in **Capture Window**, hold **⇧** and click to toggle windows, then release **⇧** to composite them onto a transparent canvas at their screen positions.
- Single-window click (no Shift) is unchanged. Esc clears a multi-selection first, then cancels.
- Discovery: overlay hint (`Hold ⇧ and click to select multiple windows`) plus Contextual Shortcuts entries under Settings → Shortcuts.
- CaptureKit: `captureWindows` + `MultiWindowCompositor` with continuous corner masking to avoid white edge fringe.

## Test plan
- [ ] Capture Window → click one window → same as before (including window shadow setting)
- [ ] Hold ⇧, click 2+ windows → release ⇧ → transparent composite with correct positions/z-order
- [ ] ⇧-click again to deselect a window before releasing → only remaining windows appear
- [ ] Esc clears multi-select; second Esc cancels overlay
- [ ] Dual display: select one window per screen → composite spans correctly
- [ ] Overlay shows idle hint before any Shift selection; count badge after selecting
- [ ] Settings → Shortcuts → Contextual Shortcuts lists the new Window Capture rows
- [ ] Recording window selection still single-select only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core capture overlay input, global event monitors, and ScreenCaptureKit compositing across displays; behavior is covered by new tests but multi-monitor edge cases remain the main regression surface.
> 
> **Overview**
> Adds **Shift multi-select** to screenshot window capture: hold **⇧**, click windows to toggle, release **⇧** to capture (single-window click without Shift is unchanged). The overlay shows hints and a selection count, syncs picks across displays, and **Esc** clears the set before cancelling.
> 
> **CaptureKit** gains `captureWindows` and `MultiWindowCompositor` (per-window ScreenCaptureKit capture, z-ordered transparent composite with rounded-corner masking). **Recording** keeps single-window selection via `allowsMultiWindowSelection: false`.
> 
> Multi-display overlays now designate one **`handlesGlobalKeyEvents`** owner so Esc/Space/Shift are not handled twice; local monitors only consume events for their own window.
> 
> Also adds a **CapsoTests** bundle (overlay interaction tests), **AppDelegate** early exit under XCTest, CI `xcodebuild test`, and contextual shortcut docs for the new gestures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7b98f6867bfe497c8c10eebebcfb8b4eb32c1e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->