### PR TITLE
Fix Esc closing the annotation editor and discarding unsaved work

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationEditorCloseGuard.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorCloseGuard.swift
@@ -1,0 +1,28 @@
+// App/Sources/AnnotationEditor/AnnotationEditorCloseGuard.swift
+import AppKit
+
+@MainActor
+enum AnnotationEditorCloseGuard {
+    static func shouldClose(hasUnsavedChanges: Bool, confirmDiscard: () -> Bool) -> Bool {
+        !hasUnsavedChanges || confirmDiscard()
+    }
+
+    static func presentDiscardAlert(above window: NSWindow?) -> Bool {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = String(localized: "Discard your edits?")
+        alert.informativeText = String(localized: "Your annotations haven't been saved and will be lost.")
+        alert.addButton(withTitle: String(localized: "Discard"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+
+        // The inline area-capture editor's panel sits at `.screenSaver` level;
+        // an unparented alert would render behind it, so lift the alert above
+        // whichever window is asking.
+        if let window {
+            alert.window.level = NSWindow.Level(rawValue: window.level.rawValue + 1)
+        }
+
+        let response = alert.runModal()
+        return response == .alertFirstButtonReturn
+    }
+}

--- a/App/Sources/AnnotationEditor/AnnotationEditorView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorView.swift
@@ -234,7 +234,42 @@ struct AnnotationEditorView: View {
                 editorContent
             }
         }
+        .background(escapeKeyHandler)
         .onDisappear { invalidateDragCache() }
+    }
+
+    /// A zero-size button is the same key-equivalent mechanism the toolbar's
+    /// Close button used to use, so Esc keeps working without focus. Unlike
+    /// that button, this one never closes the editor — see
+    /// `AnnotationEscapePolicy` for the full precedence.
+    private var escapeKeyHandler: some View {
+        Button(action: handleEscape) { EmptyView() }
+            .buttonStyle(.plain)
+            .frame(width: 0, height: 0)
+            .opacity(0)
+            .accessibilityHidden(true)
+            .keyboardShortcut(.escape, modifiers: [])
+    }
+
+    private func handleEscape() {
+        switch AnnotationEscapePolicy.action(
+            isEditingText: isEditingText,
+            isCropMode: isCropMode,
+            currentTool: currentTool,
+            hasSelection: document.selectedObjectID != nil
+        ) {
+        case .commitTextEditing:
+            commitEditingTrigger += 1
+        case .exitCropMode:
+            isCropMode = false
+        case .switchToSelectTool:
+            switchToSelectTool()
+        case .clearSelection:
+            document.clearSelection()
+            refreshTrigger += 1
+        case .none:
+            break
+        }
     }
 
     private var cropEditor: some View {

--- a/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
@@ -127,8 +127,9 @@ final class AnnotationEditorWindow: NSPanel, NSWindowDelegate {
     }
 
     /// Closes if there's nothing to lose, otherwise confirms with the user
-    /// first. Used by Esc and the toolbar's Close button — never by
-    /// Save/Copy/Pin, which call `close()` directly and should never prompt.
+    /// first. Used by the toolbar's Close button and the red titlebar button
+    /// — never by Save/Copy/Pin, which call `close()` directly and should
+    /// never prompt. Esc never reaches this; see `AnnotationEscapePolicy`.
     func requestClose() {
         guard AnnotationEditorCloseGuard.shouldClose(
             hasUnsavedChanges: document.hasUnsavedChanges,

--- a/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
@@ -5,10 +5,13 @@ import AnnotationKit
 import SharedKit
 
 @MainActor
-final class AnnotationEditorWindow: NSPanel {
-    private let document: AnnotationDocument
+final class AnnotationEditorWindow: NSPanel, NSWindowDelegate {
+    let document: AnnotationDocument
     private let interactionState = AnnotationEditorInteractionState()
     private var alphaValueBeforeDrag: CGFloat?
+    private let onCloseCallback: () -> Void
+    /// Injectable so tests never present a real modal alert.
+    var confirmDiscard: () -> Bool = { false }
 
     init(
         image: CGImage,
@@ -26,6 +29,7 @@ final class AnnotationEditorWindow: NSPanel {
         let imgW = CGFloat(image.width)
         let imgH = CGFloat(image.height)
         self.document = AnnotationDocument(imageSize: CGSize(width: imgW, height: imgH))
+        self.onCloseCallback = onClose
 
         // Prefer the screen where the capture originated (the one the user was
         // focused on). Falling back to NSScreen.main unconditionally would
@@ -72,6 +76,11 @@ final class AnnotationEditorWindow: NSPanel {
         self.isRestorable = false
         self.setFrame(targetFrame, display: false)
 
+        self.confirmDiscard = { [weak self] in
+            AnnotationEditorCloseGuard.presentDiscardAlert(above: self)
+        }
+        self.delegate = self
+
         let view = AnnotationEditorView(
             sourceImage: image,
             document: document,
@@ -110,14 +119,33 @@ final class AnnotationEditorWindow: NSPanel {
                 }
             },
             onCancel: { [weak self] in
-                onClose()
-                MainActor.assumeIsolated {
-                    self?.close()
-                }
+                self?.requestClose()
             }
         )
 
         self.contentView = NSHostingView(rootView: view)
+    }
+
+    /// Closes if there's nothing to lose, otherwise confirms with the user
+    /// first. Used by Esc and the toolbar's Close button — never by
+    /// Save/Copy/Pin, which call `close()` directly and should never prompt.
+    func requestClose() {
+        guard AnnotationEditorCloseGuard.shouldClose(
+            hasUnsavedChanges: document.hasUnsavedChanges,
+            confirmDiscard: confirmDiscard
+        ) else { return }
+        close()
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        AnnotationEditorCloseGuard.shouldClose(
+            hasUnsavedChanges: document.hasUnsavedChanges,
+            confirmDiscard: confirmDiscard
+        )
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        onCloseCallback()
     }
 
     private func hideDuringExternalDrag() {

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -273,7 +273,6 @@ struct AnnotationToolbar: View {
     private var actionGroup: some View {
         HStack(spacing: 6) {
             actionButton(icon: "xmark", help: "Close", isDestructive: true, action: onCancel)
-                .keyboardShortcut(.escape, modifiers: [])
 
             dragActionButton
 

--- a/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
@@ -5,9 +5,12 @@ import CaptureKit
 import OCRKit
 
 @MainActor
-final class InlineAnnotationEditorWindow: NSPanel {
-    private let document: AnnotationDocument
+final class InlineAnnotationEditorWindow: NSPanel, NSWindowDelegate {
+    let document: AnnotationDocument
     private let interactionState = AnnotationEditorInteractionState()
+    private let onCloseCallback: () -> Void
+    /// Injectable so tests never present a real modal alert.
+    var confirmDiscard: () -> Bool = { false }
 
     init(
         image: CGImage,
@@ -21,6 +24,7 @@ final class InlineAnnotationEditorWindow: NSPanel {
         self.document = AnnotationDocument(
             imageSize: CGSize(width: image.width, height: image.height)
         )
+        self.onCloseCallback = onClose
 
         super.init(
             contentRect: screen.frame,
@@ -40,6 +44,11 @@ final class InlineAnnotationEditorWindow: NSPanel {
         self.isMovable = false
         self.isRestorable = false
         self.setFrame(screen.frame, display: false)
+
+        self.confirmDiscard = { [weak self] in
+            AnnotationEditorCloseGuard.presentDiscardAlert(above: self)
+        }
+        self.delegate = self
 
         let pinAnchor = CGRect(
             x: screen.frame.minX + screenLocalRect.minX,
@@ -67,8 +76,7 @@ final class InlineAnnotationEditorWindow: NSPanel {
                 self?.close()
             },
             onCancel: { [weak self] in
-                onClose()
-                self?.close()
+                self?.requestClose()
             }
         )
 
@@ -81,6 +89,28 @@ final class InlineAnnotationEditorWindow: NSPanel {
     func show() {
         orderFrontRegardless()
         makeKey()
+    }
+
+    /// Closes if there's nothing to lose, otherwise confirms with the user
+    /// first. Used by Esc and the toolbar's Close button — never by
+    /// Save/Copy/Pin, which call `close()` directly and should never prompt.
+    func requestClose() {
+        guard AnnotationEditorCloseGuard.shouldClose(
+            hasUnsavedChanges: document.hasUnsavedChanges,
+            confirmDiscard: confirmDiscard
+        ) else { return }
+        close()
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        AnnotationEditorCloseGuard.shouldClose(
+            hasUnsavedChanges: document.hasUnsavedChanges,
+            confirmDiscard: confirmDiscard
+        )
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        onCloseCallback()
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
@@ -205,6 +235,7 @@ private struct InlineAnnotationEditorView: View {
             dimmingOverlay
             canvas
             toolbar
+            escapeKeyHandler
         }
         .frame(width: screenSize.width, height: screenSize.height)
         .background(Color.clear)
@@ -320,6 +351,40 @@ private struct InlineAnnotationEditorView: View {
     private func switchToSelectTool() {
         document.clearSelection()
         currentTool = .select
+    }
+
+    /// A zero-size button is the same key-equivalent mechanism the toolbar's
+    /// Close button used to use, so Esc keeps working without focus. Unlike
+    /// that button, this one never closes the editor — see
+    /// `AnnotationEscapePolicy` for the full precedence.
+    private var escapeKeyHandler: some View {
+        Button(action: handleEscape) { EmptyView() }
+            .buttonStyle(.plain)
+            .frame(width: 0, height: 0)
+            .opacity(0)
+            .accessibilityHidden(true)
+            .keyboardShortcut(.escape, modifiers: [])
+    }
+
+    private func handleEscape() {
+        switch AnnotationEscapePolicy.action(
+            isEditingText: isEditingText,
+            isCropMode: false,
+            currentTool: currentTool,
+            hasSelection: document.selectedObjectID != nil
+        ) {
+        case .commitTextEditing:
+            commitEditingTrigger += 1
+        case .exitCropMode:
+            break
+        case .switchToSelectTool:
+            switchToSelectTool()
+        case .clearSelection:
+            document.clearSelection()
+            refreshTrigger += 1
+        case .none:
+            break
+        }
     }
 
     private func handleTextEditingStarted(
@@ -595,7 +660,6 @@ private struct InlineAnnotationToolbar: View {
     private var actionControls: some View {
         HStack(spacing: 4) {
             iconButton(systemName: "xmark", help: "Close", action: onCancel)
-                .keyboardShortcut(.escape, modifiers: [])
             copyActionButton
             iconButton(systemName: "pin", help: "Pin to Screen", action: onPin)
                 .keyboardShortcut("p", modifiers: .command)

--- a/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
@@ -92,8 +92,9 @@ final class InlineAnnotationEditorWindow: NSPanel, NSWindowDelegate {
     }
 
     /// Closes if there's nothing to lose, otherwise confirms with the user
-    /// first. Used by Esc and the toolbar's Close button — never by
-    /// Save/Copy/Pin, which call `close()` directly and should never prompt.
+    /// first. Used by the toolbar's Close button and the red titlebar button
+    /// — never by Save/Copy/Pin, which call `close()` directly and should
+    /// never prompt. Esc never reaches this; see `AnnotationEscapePolicy`.
     func requestClose() {
         guard AnnotationEditorCloseGuard.shouldClose(
             hasUnsavedChanges: document.hasUnsavedChanges,
@@ -376,6 +377,8 @@ private struct InlineAnnotationEditorView: View {
         case .commitTextEditing:
             commitEditingTrigger += 1
         case .exitCropMode:
+            // Unreachable here (isCropMode is always false above). Kept so
+            // this switch stays exhaustive and matches AnnotationEditorWindow.
             break
         case .switchToSelectTool:
             switchToSelectTool()

--- a/App/Tests/AnnotationEditorCloseGuardTests.swift
+++ b/App/Tests/AnnotationEditorCloseGuardTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import Capso
+
+@MainActor
+final class AnnotationEditorCloseGuardTests: XCTestCase {
+    func testCleanDocumentClosesWithoutPrompt() {
+        var confirmCount = 0
+        let shouldClose = AnnotationEditorCloseGuard.shouldClose(
+            hasUnsavedChanges: false,
+            confirmDiscard: {
+                confirmCount += 1
+                return true
+            }
+        )
+        XCTAssertTrue(shouldClose)
+        XCTAssertEqual(confirmCount, 0)
+    }
+
+    func testDirtyDocumentClosesWhenConfirmed() {
+        var confirmCount = 0
+        let shouldClose = AnnotationEditorCloseGuard.shouldClose(
+            hasUnsavedChanges: true,
+            confirmDiscard: {
+                confirmCount += 1
+                return true
+            }
+        )
+        XCTAssertTrue(shouldClose)
+        XCTAssertEqual(confirmCount, 1)
+    }
+
+    func testDirtyDocumentStaysOpenWhenDeclined() {
+        let shouldClose = AnnotationEditorCloseGuard.shouldClose(
+            hasUnsavedChanges: true,
+            confirmDiscard: { false }
+        )
+        XCTAssertFalse(shouldClose)
+    }
+}

--- a/App/Tests/AnnotationEditorWindowCloseTests.swift
+++ b/App/Tests/AnnotationEditorWindowCloseTests.swift
@@ -1,0 +1,134 @@
+import AppKit
+import XCTest
+import AnnotationKit
+import SharedKit
+@testable import Capso
+
+@MainActor
+final class AnnotationEditorWindowCloseTests: XCTestCase {
+    private func makeTestImage(width: Int = 2, height: Int = 2) throws -> CGImage {
+        let context = try XCTUnwrap(CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return try XCTUnwrap(context.makeImage())
+    }
+
+    private func makeWindow(onClose: @escaping () -> Void) throws -> AnnotationEditorWindow {
+        AnnotationEditorWindow(
+            image: try makeTestImage(),
+            screenshotOutputPreset: .losslessPNG,
+            screenshotFilenameTemplate: "Screenshot",
+            onSave: { _ in },
+            onCopy: { _ in },
+            onPin: { _, _ in },
+            onClose: onClose
+        )
+    }
+
+    private func makeInlineWindow(onClose: @escaping () -> Void) throws -> InlineAnnotationEditorWindow {
+        let screen = try XCTUnwrap(NSScreen.main)
+        return InlineAnnotationEditorWindow(
+            image: try makeTestImage(),
+            screen: screen,
+            screenLocalRect: CGRect(x: 0, y: 0, width: 2, height: 2),
+            onSave: { _ in },
+            onCopy: { _ in },
+            onPin: { _, _ in },
+            onClose: onClose
+        )
+    }
+
+    func testRequestCloseClosesCleanEditorWithoutPrompt() throws {
+        var closeCount = 0
+        var confirmCount = 0
+        let window = try makeWindow(onClose: { closeCount += 1 })
+        window.confirmDiscard = { confirmCount += 1; return true }
+
+        window.requestClose()
+
+        XCTAssertEqual(closeCount, 1)
+        XCTAssertEqual(confirmCount, 0)
+    }
+
+    func testRequestCloseKeepsDirtyEditorWhenDeclined() throws {
+        var closeCount = 0
+        let window = try makeWindow(onClose: { closeCount += 1 })
+        window.document.addObject(ArrowObject(start: .zero, end: CGPoint(x: 10, y: 10)))
+        window.confirmDiscard = { false }
+
+        window.requestClose()
+
+        XCTAssertEqual(closeCount, 0)
+        XCTAssertEqual(window.document.objects.count, 1)
+    }
+
+    func testRequestCloseDiscardsWhenConfirmed() throws {
+        var closeCount = 0
+        let window = try makeWindow(onClose: { closeCount += 1 })
+        window.document.addObject(ArrowObject(start: .zero, end: CGPoint(x: 10, y: 10)))
+        window.confirmDiscard = { true }
+
+        window.requestClose()
+
+        XCTAssertEqual(closeCount, 1)
+    }
+
+    func testWindowShouldCloseGuardsRedTitlebarButton() throws {
+        var confirmCount = 0
+        let window = try makeWindow(onClose: {})
+        window.document.addObject(ArrowObject(start: .zero, end: CGPoint(x: 10, y: 10)))
+        window.confirmDiscard = { confirmCount += 1; return false }
+
+        XCTAssertFalse(window.windowShouldClose(window))
+        XCTAssertEqual(confirmCount, 1)
+
+        window.document.undo()
+        confirmCount = 0
+        XCTAssertTrue(window.windowShouldClose(window))
+        XCTAssertEqual(confirmCount, 0)
+    }
+
+    func testDirectCloseBypassesConfirmationForSaveCopyPin() throws {
+        var closeCount = 0
+        var confirmCount = 0
+        let window = try makeWindow(onClose: { closeCount += 1 })
+        window.document.addObject(ArrowObject(start: .zero, end: CGPoint(x: 10, y: 10)))
+        window.confirmDiscard = { confirmCount += 1; return false }
+
+        window.close()
+
+        XCTAssertEqual(confirmCount, 0)
+        XCTAssertEqual(closeCount, 1)
+    }
+
+    func testInlineRequestCloseTrio() throws {
+        var closeCount = 0
+        let cleanWindow = try makeInlineWindow(onClose: { closeCount += 1 })
+        cleanWindow.confirmDiscard = { true }
+        cleanWindow.requestClose()
+        XCTAssertEqual(closeCount, 1)
+
+        closeCount = 0
+        let declinedWindow = try makeInlineWindow(onClose: { closeCount += 1 })
+        declinedWindow.document.addObject(ArrowObject(start: .zero, end: CGPoint(x: 10, y: 10)))
+        declinedWindow.confirmDiscard = { false }
+        declinedWindow.requestClose()
+        XCTAssertEqual(closeCount, 0)
+        XCTAssertEqual(declinedWindow.document.objects.count, 1)
+
+        closeCount = 0
+        let confirmedWindow = try makeInlineWindow(onClose: { closeCount += 1 })
+        confirmedWindow.document.addObject(ArrowObject(start: .zero, end: CGPoint(x: 10, y: 10)))
+        confirmedWindow.confirmDiscard = { true }
+        confirmedWindow.requestClose()
+        XCTAssertEqual(closeCount, 1)
+    }
+}

--- a/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationDocument.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationDocument.swift
@@ -23,6 +23,14 @@ public final class AnnotationDocument {
     public var canUndo: Bool { !undoStack.isEmpty }
     public var canRedo: Bool { !redoStack.isEmpty }
 
+    /// Whether the document has anything a user would be upset to lose.
+    /// `canUndo` is included (not just `objects`/`cropRect`) so that
+    /// destructive edits which don't leave visible objects behind — e.g. a
+    /// rotate/flip via `replaceImage` — still count as unsaved work.
+    public var hasUnsavedChanges: Bool {
+        !objects.isEmpty || cropRect != nil || canUndo
+    }
+
     public init(imageSize: CGSize) {
         self.imageSize = imageSize
     }

--- a/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationEscapePolicy.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationEscapePolicy.swift
@@ -1,0 +1,28 @@
+// Packages/AnnotationKit/Sources/AnnotationKit/AnnotationEscapePolicy.swift
+
+public enum AnnotationEscapeAction: Equatable, Sendable {
+    case commitTextEditing
+    case exitCropMode
+    case switchToSelectTool
+    case clearSelection
+    case none
+}
+
+/// Decides what pressing Esc should do in the annotation editor. Esc never
+/// closes the editor — it only ever backs the user out one step at a time:
+/// finish text editing, then leave crop mode, then drop back to the select
+/// tool, then clear a selection, then do nothing.
+public enum AnnotationEscapePolicy {
+    public static func action(
+        isEditingText: Bool,
+        isCropMode: Bool,
+        currentTool: AnnotationTool,
+        hasSelection: Bool
+    ) -> AnnotationEscapeAction {
+        if isEditingText { return .commitTextEditing }
+        if isCropMode { return .exitCropMode }
+        if currentTool != .select { return .switchToSelectTool }
+        if hasSelection { return .clearSelection }
+        return .none
+    }
+}

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationDocumentTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationDocumentTests.swift
@@ -123,4 +123,56 @@ struct AnnotationDocumentTests {
         doc.undo()
         #expect(doc.objects.count == 0)
     }
+
+    @Test("Fresh document has no unsaved changes")
+    @MainActor
+    func freshDocumentIsClean() {
+        let doc = AnnotationDocument(imageSize: CGSize(width: 800, height: 600))
+        #expect(doc.hasUnsavedChanges == false)
+    }
+
+    @Test("Adding an object marks the document dirty")
+    @MainActor
+    func addObjectMarksDirty() {
+        let doc = AnnotationDocument(imageSize: CGSize(width: 800, height: 600))
+        doc.addObject(ArrowObject(start: .zero, end: CGPoint(x: 100, y: 100)))
+        #expect(doc.hasUnsavedChanges == true)
+    }
+
+    @Test("Undoing back to the start is clean again")
+    @MainActor
+    func undoBackToCleanIsClean() {
+        let doc = AnnotationDocument(imageSize: CGSize(width: 800, height: 600))
+        doc.addObject(ArrowObject(start: .zero, end: CGPoint(x: 100, y: 100)))
+        doc.undo()
+        #expect(doc.hasUnsavedChanges == false)
+    }
+
+    @Test("Adding then removing the object stays dirty")
+    @MainActor
+    func addThenRemoveStaysDirty() {
+        let doc = AnnotationDocument(imageSize: CGSize(width: 800, height: 600))
+        let arrow = ArrowObject(start: .zero, end: CGPoint(x: 100, y: 100))
+        doc.addObject(arrow)
+        doc.removeObject(id: arrow.id)
+        #expect(doc.hasUnsavedChanges == true)
+    }
+
+    @Test("Setting a crop rect marks the document dirty")
+    @MainActor
+    func cropRectMarksDirty() {
+        let doc = AnnotationDocument(imageSize: CGSize(width: 800, height: 600))
+        doc.setCropRect(CGRect(x: 0, y: 0, width: 100, height: 100))
+        #expect(doc.hasUnsavedChanges == true)
+        doc.undo()
+        #expect(doc.hasUnsavedChanges == false)
+    }
+
+    @Test("Replacing the image (rotate/flip) marks the document dirty")
+    @MainActor
+    func replaceImageMarksDirty() {
+        let doc = AnnotationDocument(imageSize: CGSize(width: 800, height: 600))
+        doc.replaceImage(size: CGSize(width: 600, height: 800))
+        #expect(doc.hasUnsavedChanges == true)
+    }
 }

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationEscapePolicyTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationEscapePolicyTests.swift
@@ -1,0 +1,66 @@
+// Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationEscapePolicyTests.swift
+import Testing
+@testable import AnnotationKit
+
+@Suite("AnnotationEscapePolicy")
+struct AnnotationEscapePolicyTests {
+    @Test("Text editing takes precedence over everything else")
+    func textEditingWinsOverEverything() {
+        let action = AnnotationEscapePolicy.action(
+            isEditingText: true,
+            isCropMode: true,
+            currentTool: .arrow,
+            hasSelection: true
+        )
+        #expect(action == .commitTextEditing)
+    }
+
+    @Test("Crop mode beats switching tools", arguments: [
+        (AnnotationTool.arrow, false),
+        (AnnotationTool.select, true)
+    ])
+    func cropModeBeatsToolSwitch(tool: AnnotationTool, hasSelection: Bool) {
+        let action = AnnotationEscapePolicy.action(
+            isEditingText: false,
+            isCropMode: true,
+            currentTool: tool,
+            hasSelection: hasSelection
+        )
+        #expect(action == .exitCropMode)
+    }
+
+    @Test("Any non-select tool switches back to select", arguments: [
+        AnnotationTool.arrow, .line, .rectangle, .ellipse, .text, .freehand, .pixelate, .counter, .highlighter
+    ], [true, false])
+    func nonSelectToolSwitchesToSelect(tool: AnnotationTool, hasSelection: Bool) {
+        let action = AnnotationEscapePolicy.action(
+            isEditingText: false,
+            isCropMode: false,
+            currentTool: tool,
+            hasSelection: hasSelection
+        )
+        #expect(action == .switchToSelectTool)
+    }
+
+    @Test("Select tool with a selection clears it")
+    func selectToolWithSelectionClearsIt() {
+        let action = AnnotationEscapePolicy.action(
+            isEditingText: false,
+            isCropMode: false,
+            currentTool: .select,
+            hasSelection: true
+        )
+        #expect(action == .clearSelection)
+    }
+
+    @Test("Select tool with nothing selected does nothing — Esc never closes the editor")
+    func selectToolWithNothingDoesNothing() {
+        let action = AnnotationEscapePolicy.action(
+            isEditingText: false,
+            isCropMode: false,
+            currentTool: .select,
+            hasSelection: false
+        )
+        #expect(action == .none)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -107,6 +107,7 @@ targets:
     dependencies:
       - target: Capso
       - package: SharedKit
+      - package: AnnotationKit
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.awesomemacapps.capso.tests


### PR DESCRIPTION
## What changed

Esc was bound directly to the toolbar's Close button in both the regular and inline annotation editors, so pressing it immediately closed the session and threw away every annotation, with no confirmation.

Esc now steps back one level at a time instead, and never closes the editor:
1. Commit an active text edit
2. Exit crop mode
3. Switch back to the select/pointer tool
4. Clear the current selection
5. Otherwise do nothing

Explicit close actions (the toolbar's xmark button, the window's red titlebar button) now prompt "Discard your edits?" when there are unsaved annotations, a crop, or an undo-able rotate/flip. Save, Copy, and Pin are untouched — they still close without any prompt since they don't discard anything.

New pieces, split so the decision logic is unit-testable:
- `AnnotationDocument.hasUnsavedChanges` (AnnotationKit)
- `AnnotationEscapePolicy`, a pure function encoding the Esc precedence above (AnnotationKit)
- `AnnotationEditorCloseGuard`, the confirm-before-discard check + alert (App)
- Both editor windows now conform to `NSWindowDelegate` so the red titlebar button is guarded too (previously it bypassed everything and leaked the coordinator's window reference — `windowWillClose` fixes that as well)

`project.yml` now lists `AnnotationKit` as a `CapsoTests` dependency so the app-level tests can exercise `AnnotationDocument`.

## Related issue

Fixes #195

## Screenshots / recordings

Manually verified end-to-end against a Debug build (draw + Esc keeps annotations and returns to the pointer tool, xmark/red button prompt only when there are unsaved edits, Save/Copy/Pin never prompt, crop mode exits via Esc). Happy to attach a recording if useful — let me know.

## Checklist

- [x] `xcodegen generate` run (project.yml changed)
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass (`swift test --package-path Packages/AnnotationKit`, plus `-only-testing:CapsoTests`)
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per CONTRIBUTING.md#license