### PR TITLE
Support opening image files in the annotation editor

### DIFF
--- a/App/Resources/Info.plist
+++ b/App/Resources/Info.plist
@@ -27,6 +27,25 @@
             </array>
         </dict>
     </array>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>Image</string>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>LSHandlerRank</key>
+            <string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>public.png</string>
+                <string>public.jpeg</string>
+                <string>public.heic</string>
+                <string>public.tiff</string>
+                <string>com.compuserve.gif</string>
+            </array>
+        </dict>
+    </array>
     <key>LSMinimumSystemVersion</key>
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
     <key>LSUIElement</key>

--- a/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
@@ -6,7 +6,8 @@ import SharedKit
 
 @MainActor
 final class AnnotationEditorWindow: NSPanel {
-    private let document: AnnotationDocument
+    /// Internal (not private) so tests can assert on document state.
+    let document: AnnotationDocument
     private let interactionState = AnnotationEditorInteractionState()
     private var alphaValueBeforeDrag: CGFloat?
 
@@ -18,7 +19,7 @@ final class AnnotationEditorWindow: NSPanel {
         captureDate: Date = Date(),
         screenshotOutputPreset: ScreenshotOutputPreset,
         screenshotFilenameTemplate: String,
-        onSave: @escaping (CGImage) -> Void,
+        onSave: @escaping (CGImage) -> Bool,
         onCopy: @escaping (CGImage) -> Void,
         onPin: @escaping (CGImage, CGRect?) -> Void,
         onClose: @escaping () -> Void
@@ -82,7 +83,10 @@ final class AnnotationEditorWindow: NSPanel {
             screenshotOutputPreset: screenshotOutputPreset,
             screenshotFilenameTemplate: screenshotFilenameTemplate,
             onSave: { [weak self] rendered in
-                onSave(rendered)
+                // `onSave` may cancel (e.g. the user dismisses an "overwrite
+                // vs. save a copy" prompt) — only close the window when a
+                // save actually happened, otherwise the editor should stay open.
+                guard onSave(rendered) else { return }
                 MainActor.assumeIsolated {
                     self?.close()
                 }

--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -24,6 +24,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var preferencesWindow: PreferencesWindow?
     private var automationURLRequestBuffer = AutomationURLRequestBuffer()
     private var receivedAutomationURLDuringLaunch = false
+    private var imageFileOpenBuffer = ImageFileOpenBuffer()
     /// Sparkle update coordinator used by preferences and manual update checks.
     let updateManager = UpdateManager()
 
@@ -74,6 +75,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         registerGlobalShortcuts()
         performPendingAutomationURLAction()
+        performPendingImageFileOpen()
         historyCoordinator?.runCleanup()
 
         // Safety net: if the menu bar icon is hidden, the user has no obvious
@@ -197,11 +199,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func application(_ application: NSApplication, open urls: [URL]) {
+        let (imageFiles, remainder) = ImageFileOpenRequest.partition(urls: urls)
+
+        // Opening image files is never gated by the Automation URLs toggle —
+        // that setting only governs the `capso://` automation scheme.
+        if !imageFiles.isEmpty {
+            imageFileOpenBuffer.enqueue(imageFiles)
+            performPendingImageFileOpen()
+        }
+
+        guard !remainder.isEmpty else { return }
+
         guard settings.automationURLsEnabled else {
             logAutomationURL("Ignored request because Automation URLs are disabled")
             return
         }
-        guard let action = urls.lazy.compactMap(AutomationURLAction.init(url:)).first else {
+        guard let action = remainder.lazy.compactMap(AutomationURLAction.init(url:)).first else {
             logAutomationURL("Ignored unsupported request")
             return
         }
@@ -209,6 +222,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         receivedAutomationURLDuringLaunch = true
         automationURLRequestBuffer.enqueue(action)
         performPendingAutomationURLAction()
+    }
+
+    private func performPendingImageFileOpen() {
+        guard let urls = imageFileOpenBuffer.takeIfReady(coordinatorIsReady: captureCoordinator != nil) else {
+            return
+        }
+        captureCoordinator?.openImageFiles(urls)
     }
 
     private func performPendingAutomationURLAction() {

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -25,7 +25,7 @@ final class CaptureCoordinator {
     /// Maximum previews kept on-screen. Oldest is evicted when exceeded.
     private let maxQuickAccessStackSize = 5
     private var quickAccessPreviewWindow: QuickAccessPreviewWindow?
-    private var annotationWindow: AnnotationEditorWindow?
+    private(set) var annotationWindow: AnnotationEditorWindow?
     private var inlineAnnotationWindow: InlineAnnotationEditorWindow?
     private var allInOneToolbarWindow: CaptureAllInOneToolbarWindow?
     private var pinnedControllers: [PinnedScreenshotController] = []
@@ -57,6 +57,14 @@ final class CaptureCoordinator {
     private struct SourceApplication: Sendable {
         let name: String?
         let bundleIdentifier: String?
+    }
+
+    /// User's answer to the "Overwrite Original" / "Save as New Copy" prompt
+    /// shown when saving a file opened from disk (see `handleOpenedFileSave`).
+    enum OpenedImageSaveChoice {
+        case overwrite
+        case saveAsCopy
+        case cancel
     }
 
     enum PostCaptureAction {
@@ -185,6 +193,139 @@ final class CaptureCoordinator {
             displayID: screen?.displayID ?? CGMainDisplayID()
         )
         openAnnotationEditor(result, anchorScreen: screen)
+    }
+
+    /// Test seam — injected by tests so no real NSOpenPanel appears.
+    var openPanelURLsProvider: (() -> [URL])?
+
+    @discardableResult
+    func openImageFiles(_ urls: [URL]) -> Bool {
+        let candidates = urls.filter(ImageFileReader.isSupported)
+        guard let (url, image) = candidates.lazy
+            .compactMap({ candidateURL in ImageFileReader.image(at: candidateURL).map { (candidateURL, $0) } })
+            .first
+        else {
+            if !urls.isEmpty {
+                showToast(
+                    String(localized: "Couldn't open image"),
+                    icon: "photo.on.rectangle.angled",
+                    iconColor: .systemYellow
+                )
+            }
+            return false
+        }
+
+        let screen = NSScreen.screens.first { NSMouseInRect(NSEvent.mouseLocation, $0.frame, false) }
+            ?? NSScreen.main
+        let result = CaptureResult(
+            image: image,
+            mode: .area,
+            captureRect: CGRect(x: 0, y: 0, width: image.width, height: image.height),
+            appName: url.deletingPathExtension().lastPathComponent,
+            displayID: screen?.displayID ?? CGMainDisplayID()
+        )
+
+        if candidates.count > 1 {
+            showToast(
+                String(localized: "Opened 1 of \(candidates.count) images"),
+                icon: "photo.on.rectangle.angled",
+                iconColor: .systemYellow
+            )
+        }
+
+        openAnnotationEditor(result, anchorScreen: screen, openedFileURL: url)
+        return true
+    }
+
+    func openImageFilesWithPanel() {
+        let urls = openPanelURLsProvider?() ?? runImageOpenPanel()
+        guard !urls.isEmpty else { return }
+        openImageFiles(urls)
+    }
+
+    private func runImageOpenPanel() -> [URL] {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = ImageFileReader.supportedContentTypes
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        // LSUIElement app — the panel needs explicit activation to come to the front.
+        NSApp.activate(ignoringOtherApps: true)
+        return panel.runModal() == .OK ? panel.urls : []
+    }
+
+    /// Test seam — injected by tests so no real NSAlert appears.
+    var saveChoicePrompt: ((URL) -> OpenedImageSaveChoice)?
+
+    /// Save handler for a file opened from disk (vs. a fresh capture).
+    /// Returns `false` when the user cancels (window should stay open).
+    @discardableResult
+    func handleOpenedFileSave(
+        _ rendered: CGImage,
+        originalURL: URL,
+        sourceAppName: String?,
+        sourceWindowTitle: String?,
+        date: Date
+    ) -> Bool {
+        switch settings.openedImageSaveBehavior {
+        case .overwrite:
+            overwriteOriginalFile(rendered, at: originalURL)
+            return true
+        case .copy:
+            saveRenderedImage(rendered, sourceAppName: sourceAppName, sourceWindowTitle: sourceWindowTitle, date: date)
+            return true
+        case .ask:
+            let choice = saveChoicePrompt?(originalURL) ?? promptSaveChoice(for: originalURL)
+            switch choice {
+            case .overwrite:
+                overwriteOriginalFile(rendered, at: originalURL)
+                return true
+            case .saveAsCopy:
+                saveRenderedImage(rendered, sourceAppName: sourceAppName, sourceWindowTitle: sourceWindowTitle, date: date)
+                return true
+            case .cancel:
+                return false
+            }
+        }
+    }
+
+    private func promptSaveChoice(for url: URL) -> OpenedImageSaveChoice {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = String(localized: "Save changes to \"\(url.lastPathComponent)\"?")
+        alert.informativeText = String(localized: "You can overwrite the original file or save your annotations as a new file.")
+        alert.addButton(withTitle: String(localized: "Save as New Copy"))
+        alert.addButton(withTitle: String(localized: "Overwrite Original"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+
+        NSApp.activate(ignoringOtherApps: true)
+        switch alert.runModal() {
+        case .alertFirstButtonReturn:
+            return .saveAsCopy
+        case .alertSecondButtonReturn:
+            return .overwrite
+        default:
+            return .cancel
+        }
+    }
+
+    private func overwriteOriginalFile(_ rendered: CGImage, at url: URL) {
+        guard let data = ImageFileWriter.data(from: rendered, matchingFormatOf: url) else {
+            showToast(
+                String(localized: "Couldn't overwrite file"),
+                icon: "exclamationmark.triangle",
+                iconColor: .systemRed
+            )
+            return
+        }
+        do {
+            try data.write(to: url, options: .atomic)
+        } catch {
+            showToast(
+                String(localized: "Couldn't overwrite file"),
+                icon: "exclamationmark.triangle",
+                iconColor: .systemRed
+            )
+        }
     }
 
     func captureAreaAndShare() {
@@ -1436,7 +1577,11 @@ final class CaptureCoordinator {
         }
     }
 
-    private func openAnnotationEditor(_ result: CaptureResult, anchorScreen: NSScreen? = nil) {
+    private func openAnnotationEditor(
+        _ result: CaptureResult,
+        anchorScreen: NSScreen? = nil,
+        openedFileURL: URL? = nil
+    ) {
         let screen = anchorScreen ?? screenFor(result: result)
 
         inlineAnnotationWindow?.close()
@@ -1449,14 +1594,30 @@ final class CaptureCoordinator {
             captureDate: result.timestamp,
             screenshotOutputPreset: settings.screenshotOutputPreset,
             screenshotFilenameTemplate: settings.screenshotFilenameTemplate,
-            onSave: { [weak self] (rendered: CGImage) in
-                self?.saveRenderedImage(
-                    rendered,
-                    sourceAppName: result.appName,
-                    sourceWindowTitle: result.windowName,
-                    date: result.timestamp
-                )
-                self?.annotationWindow = nil
+            onSave: { [weak self] (rendered: CGImage) -> Bool in
+                guard let self else { return false }
+                if let openedFileURL {
+                    let didSave = self.handleOpenedFileSave(
+                        rendered,
+                        originalURL: openedFileURL,
+                        sourceAppName: result.appName,
+                        sourceWindowTitle: result.windowName,
+                        date: result.timestamp
+                    )
+                    if didSave {
+                        self.annotationWindow = nil
+                    }
+                    return didSave
+                } else {
+                    self.saveRenderedImage(
+                        rendered,
+                        sourceAppName: result.appName,
+                        sourceWindowTitle: result.windowName,
+                        date: result.timestamp
+                    )
+                    self.annotationWindow = nil
+                    return true
+                }
             },
             onCopy: { [weak self] (rendered: CGImage) in
                 self?.copyRenderedImage(rendered)

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -268,8 +268,7 @@ final class CaptureCoordinator {
     ) -> Bool {
         switch settings.openedImageSaveBehavior {
         case .overwrite:
-            overwriteOriginalFile(rendered, at: originalURL)
-            return true
+            return overwriteOriginalFile(rendered, at: originalURL)
         case .copy:
             saveRenderedImage(rendered, sourceAppName: sourceAppName, sourceWindowTitle: sourceWindowTitle, date: date)
             return true
@@ -277,8 +276,7 @@ final class CaptureCoordinator {
             let choice = saveChoicePrompt?(originalURL) ?? promptSaveChoice(for: originalURL)
             switch choice {
             case .overwrite:
-                overwriteOriginalFile(rendered, at: originalURL)
-                return true
+                return overwriteOriginalFile(rendered, at: originalURL)
             case .saveAsCopy:
                 saveRenderedImage(rendered, sourceAppName: sourceAppName, sourceWindowTitle: sourceWindowTitle, date: date)
                 return true
@@ -308,23 +306,26 @@ final class CaptureCoordinator {
         }
     }
 
-    private func overwriteOriginalFile(_ rendered: CGImage, at url: URL) {
+    @discardableResult
+    private func overwriteOriginalFile(_ rendered: CGImage, at url: URL) -> Bool {
         guard let data = ImageFileWriter.data(from: rendered, matchingFormatOf: url) else {
             showToast(
                 String(localized: "Couldn't overwrite file"),
                 icon: "exclamationmark.triangle",
                 iconColor: .systemRed
             )
-            return
+            return false
         }
         do {
             try data.write(to: url, options: .atomic)
+            return true
         } catch {
             showToast(
                 String(localized: "Couldn't overwrite file"),
                 icon: "exclamationmark.triangle",
                 iconColor: .systemRed
             )
+            return false
         }
     }
 

--- a/App/Sources/History/HistoryCoordinator.swift
+++ b/App/Sources/History/HistoryCoordinator.swift
@@ -497,6 +497,7 @@ final class HistoryCoordinator {
             onSave: { [weak self] rendered in
                 self?.replaceImage(for: entry, with: rendered)
                 self?.annotationWindow = nil
+                return true
             },
             onCopy: { [weak self] rendered in
                 self?.copyImageToClipboard(rendered)

--- a/App/Sources/MenuBar/MenuBarController.swift
+++ b/App/Sources/MenuBar/MenuBarController.swift
@@ -94,7 +94,7 @@ final class MenuBarController: NSObject {
         editClipboardImage.toolTip = String(localized: "Open the image currently copied to the clipboard in Annotate")
         menu.addItem(editClipboardImage)
 
-        let openImageFile = menuItem(String(localized: "Open Image..."), action: #selector(openImageFile))
+        let openImageFile = menuItem(String(localized: "Open Image..."), action: #selector(openImageFile), key: "o", modifiers: [.command])
         openImageFile.toolTip = String(localized: "Open an image file in Annotate")
         menu.addItem(openImageFile)
 

--- a/App/Sources/MenuBar/MenuBarController.swift
+++ b/App/Sources/MenuBar/MenuBarController.swift
@@ -94,6 +94,10 @@ final class MenuBarController: NSObject {
         editClipboardImage.toolTip = String(localized: "Open the image currently copied to the clipboard in Annotate")
         menu.addItem(editClipboardImage)
 
+        let openImageFile = menuItem(String(localized: "Open Image..."), action: #selector(openImageFile))
+        openImageFile.toolTip = String(localized: "Open an image file in Annotate")
+        menu.addItem(openImageFile)
+
         menu.addItem(.separator())
 
         let captureText = menuItem(String(localized: "Capture Text (OCR)"), action: #selector(captureText))
@@ -193,6 +197,10 @@ final class MenuBarController: NSObject {
 
     @objc private func editClipboardImage() {
         captureCoordinator.editClipboardImage()
+    }
+
+    @objc private func openImageFile() {
+        captureCoordinator.openImageFilesWithPanel()
     }
 
     @objc private func captureText() {

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -147,6 +147,17 @@ final class PreferencesViewModel {
             }
         }
     }
+    var openedImageSaveBehavior: OpenedImageSaveBehavior {
+        get {
+            access(keyPath: \.openedImageSaveBehavior)
+            return settings.openedImageSaveBehavior
+        }
+        set {
+            withMutation(keyPath: \.openedImageSaveBehavior) {
+                settings.openedImageSaveBehavior = newValue
+            }
+        }
+    }
     var screenshotTimestampEnabled: Bool {
         get {
             access(keyPath: \.screenshotTimestampEnabled)

--- a/App/Sources/Preferences/Tabs/ExportSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ExportSettingsView.swift
@@ -63,6 +63,23 @@ struct ExportSettingsView: View {
                     filenameTemplateEditor
                 }
             }
+
+            SettingGroup(title: "Opened Images") {
+                SettingCard {
+                    SettingRow(
+                        label: "When Saving an Opened Image",
+                        sublabel: "Applies to images opened from Finder or the Open Image panel"
+                    ) {
+                        Picker("", selection: $viewModel.openedImageSaveBehavior) {
+                            Text("Ask Every Time").tag(OpenedImageSaveBehavior.ask)
+                            Text("Overwrite Original").tag(OpenedImageSaveBehavior.overwrite)
+                            Text("Save New Copy").tag(OpenedImageSaveBehavior.copy)
+                        }
+                        .pickerStyle(.menu)
+                        .frame(width: 180)
+                    }
+                }
+            }
         }
         .onAppear {
             filenameTemplateDraft = viewModel.screenshotFilenameTemplate

--- a/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
@@ -93,7 +93,7 @@ struct ShortcutSettingsView: View {
                     shortcutRow("Translate Typed Text", name: .translateTypedText, showDivider: true)
                     shortcutRow("Capture Previous Area", name: .captureLastArea, showDivider: true)
                     shortcutRow("Start / Stop Recording", name: .recordScreen, showDivider: true)
-                    shortcutRow("Screenshot History", name: .screenshotHistory)
+                    shortcutRow("Screenshot History", name: .screenshotHistory, showDivider: true)
                 }
             }
 

--- a/App/Tests/OpenImageFileTests.swift
+++ b/App/Tests/OpenImageFileTests.swift
@@ -1,0 +1,133 @@
+import AppKit
+import XCTest
+import SharedKit
+@testable import Capso
+
+@MainActor
+final class OpenImageFileTests: XCTestCase {
+    func testInfoPlistDeclaresImageDocumentTypes() throws {
+        let types = try XCTUnwrap(
+            Bundle.main.object(forInfoDictionaryKey: "CFBundleDocumentTypes") as? [[String: Any]]
+        )
+        let imageEntry = try XCTUnwrap(types.first { entry in
+            (entry["LSItemContentTypes"] as? [String])?.contains("public.png") == true
+        })
+
+        let contentTypes = try XCTUnwrap(imageEntry["LSItemContentTypes"] as? [String])
+        for expected in ["public.png", "public.jpeg", "public.heic", "public.tiff", "com.compuserve.gif"] {
+            XCTAssertTrue(contentTypes.contains(expected), "missing \(expected)")
+        }
+        XCTAssertEqual(imageEntry["CFBundleTypeRole"] as? String, "Editor")
+        XCTAssertEqual(imageEntry["LSHandlerRank"] as? String, "Alternate")
+    }
+
+    // MARK: - openImageFiles
+
+    func testOpenImageFilesShowsAnnotationEditorForValidPNG() throws {
+        let coordinator = makeCoordinator()
+        let url = try writePNG(width: 4, height: 4)
+        defer {
+            try? FileManager.default.removeItem(at: url)
+            coordinator.annotationWindow?.close()
+        }
+
+        let result = coordinator.openImageFiles([url])
+
+        XCTAssertTrue(result)
+        XCTAssertNotNil(coordinator.annotationWindow)
+    }
+
+    func testOpenImageFilesReturnsFalseForCorruptFile() throws {
+        let coordinator = makeCoordinator()
+        let url = try writeCorruptFile(extension: "png")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let result = coordinator.openImageFiles([url])
+
+        XCTAssertFalse(result)
+        XCTAssertNil(coordinator.annotationWindow)
+    }
+
+    func testOpenImageFilesReturnsFalseForEmptyList() {
+        let coordinator = makeCoordinator()
+
+        let result = coordinator.openImageFiles([])
+
+        XCTAssertFalse(result)
+        XCTAssertNil(coordinator.annotationWindow)
+    }
+
+    func testOpenImageFilesOpensFirstLoadableAndSkipsRest() throws {
+        let coordinator = makeCoordinator()
+        let corrupt = try writeCorruptFile(extension: "png")
+        let goodA = try writePNG(width: 7, height: 5)
+        let goodB = try writePNG(width: 3, height: 3)
+        defer {
+            try? FileManager.default.removeItem(at: corrupt)
+            try? FileManager.default.removeItem(at: goodA)
+            try? FileManager.default.removeItem(at: goodB)
+            coordinator.annotationWindow?.close()
+        }
+
+        let result = coordinator.openImageFiles([corrupt, goodA, goodB])
+
+        XCTAssertTrue(result)
+        let window = try XCTUnwrap(coordinator.annotationWindow)
+        XCTAssertEqual(window.document.imageSize, CGSize(width: 7, height: 5))
+    }
+
+    func testOpenImageFilesWithPanelUsesInjectedProvider() throws {
+        let coordinator = makeCoordinator()
+        let url = try writePNG(width: 6, height: 6)
+        defer {
+            try? FileManager.default.removeItem(at: url)
+            coordinator.annotationWindow?.close()
+        }
+        coordinator.openPanelURLsProvider = { [url] }
+
+        coordinator.openImageFilesWithPanel()
+
+        XCTAssertNotNil(coordinator.annotationWindow)
+    }
+
+    // MARK: - Helpers
+
+    private func makeCoordinator() -> CaptureCoordinator {
+        let suiteName = "OpenImageFileTests.\(UUID().uuidString)"
+        let settings = AppSettings(defaults: UserDefaults(suiteName: suiteName)!)
+        return CaptureCoordinator(settings: settings)
+    }
+
+    private func makeTestImage(width: Int, height: Int) throws -> CGImage {
+        let context = try XCTUnwrap(CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return try XCTUnwrap(context.makeImage())
+    }
+
+    private func writePNG(width: Int, height: Int) throws -> URL {
+        let image = try makeTestImage(width: width, height: height)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-openimage-\(UUID().uuidString)")
+            .appendingPathExtension("png")
+        let data = try XCTUnwrap(ImageUtilities.pngData(from: image))
+        try data.write(to: url)
+        return url
+    }
+
+    private func writeCorruptFile(extension ext: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-openimage-corrupt-\(UUID().uuidString)")
+            .appendingPathExtension(ext)
+        try Data([0x00, 0x01, 0x02, 0x03]).write(to: url)
+        return url
+    }
+}

--- a/App/Tests/OpenedImageSaveTests.swift
+++ b/App/Tests/OpenedImageSaveTests.swift
@@ -104,6 +104,41 @@ final class OpenedImageSaveTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: originalURL), originalData)
     }
 
+    func testHandleOpenedFileSaveWithOverwriteBehaviorReturnsFalseWhenWriteFails() throws {
+        let (coordinator, settings, exportDir) = try makeCoordinatorWithTempExport()
+        defer { try? FileManager.default.removeItem(at: exportDir) }
+        settings.openedImageSaveBehavior = .overwrite
+
+        let originalURL = exportDir
+            .appendingPathComponent("missing-subdir")
+            .appendingPathComponent("original.png")
+        let rendered = try makeTestImage(width: 9, height: 3)
+
+        let didProceed = coordinator.handleOpenedFileSave(
+            rendered, originalURL: originalURL, sourceAppName: nil, sourceWindowTitle: nil, date: Date()
+        )
+
+        XCTAssertFalse(didProceed)
+    }
+
+    func testHandleOpenedFileSaveWithAskBehaviorOverwriteReturnsFalseWhenWriteFails() throws {
+        let (coordinator, settings, exportDir) = try makeCoordinatorWithTempExport()
+        defer { try? FileManager.default.removeItem(at: exportDir) }
+        settings.openedImageSaveBehavior = .ask
+        coordinator.saveChoicePrompt = { _ in .overwrite }
+
+        let originalURL = exportDir
+            .appendingPathComponent("missing-subdir")
+            .appendingPathComponent("original.png")
+        let rendered = try makeTestImage(width: 7, height: 2)
+
+        let didProceed = coordinator.handleOpenedFileSave(
+            rendered, originalURL: originalURL, sourceAppName: nil, sourceWindowTitle: nil, date: Date()
+        )
+
+        XCTAssertFalse(didProceed)
+    }
+
     // MARK: - Helpers
 
     private func makeCoordinatorWithTempExport() throws -> (CaptureCoordinator, AppSettings, URL) {

--- a/App/Tests/OpenedImageSaveTests.swift
+++ b/App/Tests/OpenedImageSaveTests.swift
@@ -1,0 +1,142 @@
+import AppKit
+import XCTest
+import SharedKit
+@testable import Capso
+
+@MainActor
+final class OpenedImageSaveTests: XCTestCase {
+    func testHandleOpenedFileSaveWithCopyBehaviorSavesNewFileAndLeavesOriginalUntouched() throws {
+        let (coordinator, settings, exportDir) = try makeCoordinatorWithTempExport()
+        defer { try? FileManager.default.removeItem(at: exportDir) }
+        settings.openedImageSaveBehavior = .copy
+
+        let originalURL = try writePNG(width: 5, height: 5, in: exportDir)
+        let originalData = try Data(contentsOf: originalURL)
+        let rendered = try makeTestImage(width: 9, height: 3)
+
+        let before = try FileManager.default.contentsOfDirectory(at: exportDir, includingPropertiesForKeys: nil)
+        let didProceed = coordinator.handleOpenedFileSave(
+            rendered, originalURL: originalURL, sourceAppName: nil, sourceWindowTitle: nil, date: Date()
+        )
+        let after = try FileManager.default.contentsOfDirectory(at: exportDir, includingPropertiesForKeys: nil)
+
+        XCTAssertTrue(didProceed)
+        XCTAssertEqual(after.count, before.count + 1)
+        XCTAssertEqual(try Data(contentsOf: originalURL), originalData)
+    }
+
+    func testHandleOpenedFileSaveWithOverwriteBehaviorRewritesOriginalFileInPlace() throws {
+        let (coordinator, settings, exportDir) = try makeCoordinatorWithTempExport()
+        defer { try? FileManager.default.removeItem(at: exportDir) }
+        settings.openedImageSaveBehavior = .overwrite
+
+        let originalURL = try writePNG(width: 5, height: 5, in: exportDir)
+        let rendered = try makeTestImage(width: 9, height: 3)
+
+        let didProceed = coordinator.handleOpenedFileSave(
+            rendered, originalURL: originalURL, sourceAppName: nil, sourceWindowTitle: nil, date: Date()
+        )
+
+        XCTAssertTrue(didProceed)
+        let overwritten = try XCTUnwrap(ImageFileReader.image(at: originalURL))
+        XCTAssertEqual(overwritten.width, 9)
+        XCTAssertEqual(overwritten.height, 3)
+    }
+
+    func testHandleOpenedFileSaveWithAskBehaviorUsesInjectedPromptOverwrite() throws {
+        let (coordinator, settings, exportDir) = try makeCoordinatorWithTempExport()
+        defer { try? FileManager.default.removeItem(at: exportDir) }
+        settings.openedImageSaveBehavior = .ask
+        coordinator.saveChoicePrompt = { _ in .overwrite }
+
+        let originalURL = try writePNG(width: 5, height: 5, in: exportDir)
+        let rendered = try makeTestImage(width: 7, height: 2)
+
+        let didProceed = coordinator.handleOpenedFileSave(
+            rendered, originalURL: originalURL, sourceAppName: nil, sourceWindowTitle: nil, date: Date()
+        )
+
+        XCTAssertTrue(didProceed)
+        let overwritten = try XCTUnwrap(ImageFileReader.image(at: originalURL))
+        XCTAssertEqual(overwritten.width, 7)
+        XCTAssertEqual(overwritten.height, 2)
+    }
+
+    func testHandleOpenedFileSaveWithAskBehaviorUsesInjectedPromptSaveAsCopy() throws {
+        let (coordinator, settings, exportDir) = try makeCoordinatorWithTempExport()
+        defer { try? FileManager.default.removeItem(at: exportDir) }
+        settings.openedImageSaveBehavior = .ask
+        coordinator.saveChoicePrompt = { _ in .saveAsCopy }
+
+        let originalURL = try writePNG(width: 5, height: 5, in: exportDir)
+        let originalData = try Data(contentsOf: originalURL)
+        let rendered = try makeTestImage(width: 6, height: 6)
+
+        let before = try FileManager.default.contentsOfDirectory(at: exportDir, includingPropertiesForKeys: nil)
+        let didProceed = coordinator.handleOpenedFileSave(
+            rendered, originalURL: originalURL, sourceAppName: nil, sourceWindowTitle: nil, date: Date()
+        )
+        let after = try FileManager.default.contentsOfDirectory(at: exportDir, includingPropertiesForKeys: nil)
+
+        XCTAssertTrue(didProceed)
+        XCTAssertEqual(after.count, before.count + 1)
+        XCTAssertEqual(try Data(contentsOf: originalURL), originalData)
+    }
+
+    func testHandleOpenedFileSaveWithAskBehaviorCancelLeavesEverythingUntouched() throws {
+        let (coordinator, settings, exportDir) = try makeCoordinatorWithTempExport()
+        defer { try? FileManager.default.removeItem(at: exportDir) }
+        settings.openedImageSaveBehavior = .ask
+        coordinator.saveChoicePrompt = { _ in .cancel }
+
+        let originalURL = try writePNG(width: 5, height: 5, in: exportDir)
+        let originalData = try Data(contentsOf: originalURL)
+        let rendered = try makeTestImage(width: 6, height: 6)
+
+        let before = try FileManager.default.contentsOfDirectory(at: exportDir, includingPropertiesForKeys: nil)
+        let didProceed = coordinator.handleOpenedFileSave(
+            rendered, originalURL: originalURL, sourceAppName: nil, sourceWindowTitle: nil, date: Date()
+        )
+        let after = try FileManager.default.contentsOfDirectory(at: exportDir, includingPropertiesForKeys: nil)
+
+        XCTAssertFalse(didProceed)
+        XCTAssertEqual(after.count, before.count)
+        XCTAssertEqual(try Data(contentsOf: originalURL), originalData)
+    }
+
+    // MARK: - Helpers
+
+    private func makeCoordinatorWithTempExport() throws -> (CaptureCoordinator, AppSettings, URL) {
+        let suiteName = "OpenedImageSaveTests.\(UUID().uuidString)"
+        let settings = AppSettings(defaults: UserDefaults(suiteName: suiteName)!)
+        let exportDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-openedimagesave-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: exportDir, withIntermediateDirectories: true)
+        settings.setExportLocation(exportDir)
+        let coordinator = CaptureCoordinator(settings: settings)
+        return (coordinator, settings, exportDir)
+    }
+
+    private func makeTestImage(width: Int, height: Int) throws -> CGImage {
+        let context = try XCTUnwrap(CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(CGColor(red: 0, green: 1, blue: 0, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return try XCTUnwrap(context.makeImage())
+    }
+
+    private func writePNG(width: Int, height: Int, in directory: URL) throws -> URL {
+        let image = try makeTestImage(width: width, height: height)
+        let url = directory.appendingPathComponent("original-\(UUID().uuidString)").appendingPathExtension("png")
+        let data = try XCTUnwrap(ImageUtilities.pngData(from: image))
+        try data.write(to: url)
+        return url
+    }
+}

--- a/Packages/SharedKit/Sources/SharedKit/ImageFileOpenRequest.swift
+++ b/Packages/SharedKit/Sources/SharedKit/ImageFileOpenRequest.swift
@@ -1,0 +1,34 @@
+// Packages/SharedKit/Sources/SharedKit/ImageFileOpenRequest.swift
+import Foundation
+
+public enum ImageFileOpenRequest {
+    public static func partition(urls: [URL]) -> (imageFiles: [URL], remainder: [URL]) {
+        var imageFiles: [URL] = []
+        var remainder: [URL] = []
+        for url in urls {
+            if ImageFileReader.isSupported(url) {
+                imageFiles.append(url)
+            } else {
+                remainder.append(url)
+            }
+        }
+        return (imageFiles, remainder)
+    }
+}
+
+public struct ImageFileOpenBuffer: Sendable {
+    private var pendingURLs: [URL]?
+
+    public init() {}
+
+    public mutating func enqueue(_ urls: [URL]) {
+        guard pendingURLs == nil else { return }
+        pendingURLs = urls
+    }
+
+    public mutating func takeIfReady(coordinatorIsReady: Bool) -> [URL]? {
+        guard coordinatorIsReady, let urls = pendingURLs else { return nil }
+        pendingURLs = nil
+        return urls
+    }
+}

--- a/Packages/SharedKit/Sources/SharedKit/ImageFileOpenRequest.swift
+++ b/Packages/SharedKit/Sources/SharedKit/ImageFileOpenRequest.swift
@@ -22,8 +22,11 @@ public struct ImageFileOpenBuffer: Sendable {
     public init() {}
 
     public mutating func enqueue(_ urls: [URL]) {
-        guard pendingURLs == nil else { return }
-        pendingURLs = urls
+        if let existing = pendingURLs {
+            pendingURLs = existing + urls
+        } else {
+            pendingURLs = urls
+        }
     }
 
     public mutating func takeIfReady(coordinatorIsReady: Bool) -> [URL]? {

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -45,6 +45,16 @@ public enum RecordingFormat: String, CaseIterable, Sendable {
     case gif
 }
 
+/// What Save does when annotating a file opened from disk (vs. a fresh capture).
+public enum OpenedImageSaveBehavior: String, CaseIterable, Sendable {
+    /// Prompt every time with "Overwrite Original" / "Save as New Copy".
+    case ask
+    /// Always overwrite the original file, preserving its format.
+    case overwrite
+    /// Always save a new file, exactly like a fresh capture.
+    case copy
+}
+
 public enum TranslationCardPosition: String, CaseIterable, Sendable {
     case belowSelection
     case centerScreen
@@ -750,6 +760,15 @@ public final class AppSettings: @unchecked Sendable {
 
     public func setExportLocation(_ url: URL) {
         defaults.set(url, forKey: "exportLocation")
+    }
+
+    public var openedImageSaveBehavior: OpenedImageSaveBehavior {
+        get {
+            guard let raw = defaults.string(forKey: "openedImageSaveBehavior"),
+                  let value = OpenedImageSaveBehavior(rawValue: raw) else { return .ask }
+            return value
+        }
+        set { defaults.set(newValue.rawValue, forKey: "openedImageSaveBehavior") }
     }
 
     // MARK: Cloud Share

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ClipboardImageReader.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ClipboardImageReader.swift
@@ -13,11 +13,10 @@ public enum ClipboardImageReader {
             .urlReadingFileURLsOnly: true
         ]
         let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: options) as? [URL]
-        guard let url = urls?.first(where: { $0.isFileURL }),
-              let image = NSImage(contentsOf: url) else {
+        guard let url = urls?.first(where: { $0.isFileURL }) else {
             return nil
         }
-        return ImageUtilities.cgImage(from: image)
+        return ImageFileReader.image(at: url)
     }
 
     private static func objectImage(from pasteboard: NSPasteboard) -> CGImage? {

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ImageFileReader.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ImageFileReader.swift
@@ -1,0 +1,20 @@
+// Packages/SharedKit/Sources/SharedKit/Utilities/ImageFileReader.swift
+import AppKit
+import UniformTypeIdentifiers
+
+public enum ImageFileReader {
+    public static let supportedContentTypes: [UTType] = [.png, .jpeg, .heic, .tiff, .gif]
+
+    public static func isSupported(_ url: URL) -> Bool {
+        guard url.isFileURL,
+              let type = UTType(filenameExtension: url.pathExtension.lowercased()) else {
+            return false
+        }
+        return supportedContentTypes.contains { type.conforms(to: $0) }
+    }
+
+    public static func image(at url: URL) -> CGImage? {
+        guard let nsImage = NSImage(contentsOf: url) else { return nil }
+        return ImageUtilities.cgImage(from: nsImage)
+    }
+}

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ImageFileWriter.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ImageFileWriter.swift
@@ -1,0 +1,40 @@
+// Packages/SharedKit/Sources/SharedKit/Utilities/ImageFileWriter.swift
+import AppKit
+import ImageIO
+import UniformTypeIdentifiers
+
+/// Encodes a rendered CGImage back into the byte format of an existing file,
+/// so overwriting an opened image preserves its original format.
+public enum ImageFileWriter {
+    public static func data(from cgImage: CGImage, matchingFormatOf url: URL) -> Data? {
+        guard let type = UTType(filenameExtension: url.pathExtension.lowercased()) else {
+            return ImageUtilities.pngData(from: cgImage)
+        }
+
+        if type.conforms(to: .jpeg) {
+            return ImageUtilities.jpegData(from: cgImage)
+        }
+        if type.conforms(to: .heic) {
+            return heicData(from: cgImage)
+        }
+        if type.conforms(to: .tiff) {
+            return NSBitmapImageRep(cgImage: cgImage).representation(using: .tiff, properties: [:])
+        }
+        if type.conforms(to: .gif) {
+            return NSBitmapImageRep(cgImage: cgImage).representation(using: .gif, properties: [:])
+        }
+        return ImageUtilities.pngData(from: cgImage)
+    }
+
+    private static func heicData(from cgImage: CGImage) -> Data? {
+        let mutableData = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            mutableData, UTType.heic.identifier as CFString, 1, nil
+        ) else {
+            return nil
+        }
+        CGImageDestinationAddImage(destination, cgImage, nil)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return mutableData as Data
+    }
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -508,4 +508,28 @@ struct AppSettingsTests {
         settings.selfTimerHUDPosition = nil
         #expect(settings.selfTimerHUDPosition == nil)
     }
+
+    @Test("Default opened image save behavior is ask")
+    func defaultOpenedImageSaveBehavior() {
+        let suite = "test.openedImageSaveBehavior.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+
+        #expect(settings.openedImageSaveBehavior == .ask)
+    }
+
+    @Test("Opened image save behavior round-trips")
+    func openedImageSaveBehaviorRoundTrip() {
+        let suite = "test.openedImageSaveBehavior.roundtrip"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+
+        settings.openedImageSaveBehavior = .overwrite
+        #expect(settings.openedImageSaveBehavior == .overwrite)
+
+        settings.openedImageSaveBehavior = .copy
+        #expect(settings.openedImageSaveBehavior == .copy)
+    }
 }

--- a/Packages/SharedKit/Tests/SharedKitTests/ImageFileOpenRequestTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ImageFileOpenRequestTests.swift
@@ -37,14 +37,14 @@ struct ImageFileOpenBufferTests {
         #expect(buffer.takeIfReady(coordinatorIsReady: true) == nil)
     }
 
-    @Test("buffer keeps the first batch")
-    func bufferKeepsFirstBatch() {
+    @Test("buffer appends a second batch instead of dropping it")
+    func bufferAppendsSecondBatch() {
         var buffer = ImageFileOpenBuffer()
         let first = [URL(fileURLWithPath: "/tmp/a.png")]
         let second = [URL(fileURLWithPath: "/tmp/b.png")]
         buffer.enqueue(first)
         buffer.enqueue(second)
 
-        #expect(buffer.takeIfReady(coordinatorIsReady: true) == first)
+        #expect(buffer.takeIfReady(coordinatorIsReady: true) == first + second)
     }
 }

--- a/Packages/SharedKit/Tests/SharedKitTests/ImageFileOpenRequestTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ImageFileOpenRequestTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import SharedKit
+
+@Suite("ImageFileOpenRequest")
+struct ImageFileOpenRequestTests {
+    @Test("partition splits image files from other URLs")
+    func partitionSplitsImageFilesFromOtherURLs() throws {
+        let photo = URL(fileURLWithPath: "/tmp/photo.png")
+        let automation = try #require(URL(string: "capso://grab/area"))
+        let notes = URL(fileURLWithPath: "/tmp/notes.txt")
+
+        let result = ImageFileOpenRequest.partition(urls: [photo, automation, notes])
+
+        #expect(result.imageFiles == [photo])
+        #expect(result.remainder == [automation, notes])
+    }
+
+    @Test("partition of empty list is empty")
+    func partitionOfEmptyListIsEmpty() {
+        let result = ImageFileOpenRequest.partition(urls: [])
+        #expect(result.imageFiles.isEmpty)
+        #expect(result.remainder.isEmpty)
+    }
+}
+
+@Suite("ImageFileOpenBuffer")
+struct ImageFileOpenBufferTests {
+    @Test("buffer holds URLs until the coordinator is ready")
+    func bufferHoldsURLsUntilCoordinatorReady() {
+        var buffer = ImageFileOpenBuffer()
+        let urls = [URL(fileURLWithPath: "/tmp/a.png")]
+        buffer.enqueue(urls)
+
+        #expect(buffer.takeIfReady(coordinatorIsReady: false) == nil)
+        #expect(buffer.takeIfReady(coordinatorIsReady: true) == urls)
+        #expect(buffer.takeIfReady(coordinatorIsReady: true) == nil)
+    }
+
+    @Test("buffer keeps the first batch")
+    func bufferKeepsFirstBatch() {
+        var buffer = ImageFileOpenBuffer()
+        let first = [URL(fileURLWithPath: "/tmp/a.png")]
+        let second = [URL(fileURLWithPath: "/tmp/b.png")]
+        buffer.enqueue(first)
+        buffer.enqueue(second)
+
+        #expect(buffer.takeIfReady(coordinatorIsReady: true) == first)
+    }
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/ImageFileReaderTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ImageFileReaderTests.swift
@@ -1,0 +1,136 @@
+import AppKit
+import ImageIO
+import UniformTypeIdentifiers
+import Testing
+@testable import SharedKit
+
+@Suite("ImageFileReader")
+struct ImageFileReaderTests {
+    @Test("supported content types cover issue formats")
+    func supportedContentTypesCoverIssueFormats() {
+        let types = ImageFileReader.supportedContentTypes
+        #expect(types.contains(.png))
+        #expect(types.contains(.jpeg))
+        #expect(types.contains(.heic))
+        #expect(types.contains(.tiff))
+        #expect(types.contains(.gif))
+    }
+
+    @Test("accepts image extensions case-insensitively")
+    func isSupportedAcceptsImageExtensionsCaseInsensitively() {
+        for name in ["b.PNG", "b.jpg", "b.jpeg", "b.heic", "b.tif", "b.tiff", "b.gif"] {
+            let url = URL(fileURLWithPath: "/tmp/\(name)")
+            #expect(ImageFileReader.isSupported(url), "expected \(name) to be supported")
+        }
+    }
+
+    @Test("rejects non-image and non-file URLs")
+    func isSupportedRejectsNonImageAndNonFileURLs() throws {
+        #expect(!ImageFileReader.isSupported(URL(fileURLWithPath: "/tmp/x.pdf")))
+        #expect(!ImageFileReader.isSupported(URL(fileURLWithPath: "/tmp/x.txt")))
+        #expect(!ImageFileReader.isSupported(URL(fileURLWithPath: "/tmp/x")))
+        let remoteURL = try #require(URL(string: "capso://grab/area"))
+        #expect(!ImageFileReader.isSupported(remoteURL))
+    }
+
+    @Test("loads PNG at original pixel size")
+    func loadsPNGAtOriginalPixelSize() throws {
+        let image = try makeImage(width: 9, height: 4)
+        let url = try writeImage(image, extension: "png", using: .png)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let loaded = try #require(ImageFileReader.image(at: url))
+
+        #expect(loaded.width == 9)
+        #expect(loaded.height == 4)
+    }
+
+    @Test("loads JPEG, TIFF, and GIF")
+    func loadsJPEGTIFFAndGIF() throws {
+        let image = try makeImage(width: 6, height: 3)
+
+        for (ext, type) in [("jpg", NSBitmapImageRep.FileType.jpeg), ("tiff", .tiff), ("gif", .gif)] {
+            let url = try writeImage(image, extension: ext, using: type)
+            defer { try? FileManager.default.removeItem(at: url) }
+
+            let loaded = try #require(ImageFileReader.image(at: url), "failed to load .\(ext)")
+
+            #expect(loaded.width == 6, "unexpected width for .\(ext)")
+            #expect(loaded.height == 3, "unexpected height for .\(ext)")
+        }
+    }
+
+    @Test("loads HEIC when an encoder is available")
+    func loadsHEICWhenEncoderAvailable() throws {
+        let image = try makeImage(width: 5, height: 5)
+        guard let url = writeHEIC(image) else {
+            // Some Intel Macs lack an HEVC encoder; skip rather than fail the suite.
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let loaded = try #require(ImageFileReader.image(at: url))
+
+        #expect(loaded.width == 5)
+        #expect(loaded.height == 5)
+    }
+
+    @Test("returns nil for corrupt data")
+    func returnsNilForCorruptData() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-imagefile-\(UUID().uuidString)")
+            .appendingPathExtension("png")
+        try Data([0x00, 0x01, 0x02, 0x03]).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(ImageFileReader.image(at: url) == nil)
+    }
+
+    @Test("returns nil for a missing file")
+    func returnsNilForMissingFile() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-imagefile-missing-\(UUID().uuidString)")
+            .appendingPathExtension("png")
+
+        #expect(ImageFileReader.image(at: url) == nil)
+    }
+
+    private func makeImage(width: Int, height: Int) throws -> CGImage {
+        let context = try #require(CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(CGColor(red: 0.5, green: 0.5, blue: 0.1, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return try #require(context.makeImage())
+    }
+
+    private func writeImage(_ cgImage: CGImage, extension ext: String, using type: NSBitmapImageRep.FileType) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-imagefile-\(UUID().uuidString)")
+            .appendingPathExtension(ext)
+        let rep = NSBitmapImageRep(cgImage: cgImage)
+        let data = try #require(rep.representation(using: type, properties: [:]))
+        try data.write(to: url)
+        return url
+    }
+
+    private func writeHEIC(_ cgImage: CGImage) -> URL? {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-imagefile-\(UUID().uuidString)")
+            .appendingPathExtension("heic")
+        guard let destination = CGImageDestinationCreateWithURL(
+            url as CFURL, UTType.heic.identifier as CFString, 1, nil
+        ) else {
+            return nil
+        }
+        CGImageDestinationAddImage(destination, cgImage, nil)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return url
+    }
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/ImageFileWriterTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ImageFileWriterTests.swift
@@ -1,0 +1,91 @@
+import AppKit
+import ImageIO
+import UniformTypeIdentifiers
+import Testing
+@testable import SharedKit
+
+@Suite("ImageFileWriter")
+struct ImageFileWriterTests {
+    @Test("matches PNG format for a .png URL")
+    func matchesPNGFormatForPNGURL() throws {
+        let image = try makeImage(width: 4, height: 4)
+        let url = URL(fileURLWithPath: "/tmp/photo.png")
+
+        let data = try #require(ImageFileWriter.data(from: image, matchingFormatOf: url))
+
+        #expect(writtenFormatUTI(data) == UTType.png.identifier)
+    }
+
+    @Test("matches JPEG format for a .jpg URL")
+    func matchesJPEGFormatForJPEGURL() throws {
+        let image = try makeImage(width: 4, height: 4)
+        let url = URL(fileURLWithPath: "/tmp/photo.jpg")
+
+        let data = try #require(ImageFileWriter.data(from: image, matchingFormatOf: url))
+
+        #expect(writtenFormatUTI(data) == UTType.jpeg.identifier)
+    }
+
+    @Test("matches TIFF format for a .tiff URL")
+    func matchesTIFFFormatForTIFFURL() throws {
+        let image = try makeImage(width: 4, height: 4)
+        let url = URL(fileURLWithPath: "/tmp/photo.tiff")
+
+        let data = try #require(ImageFileWriter.data(from: image, matchingFormatOf: url))
+
+        #expect(writtenFormatUTI(data) == UTType.tiff.identifier)
+    }
+
+    @Test("matches GIF format for a .gif URL")
+    func matchesGIFFormatForGIFURL() throws {
+        let image = try makeImage(width: 4, height: 4)
+        let url = URL(fileURLWithPath: "/tmp/photo.gif")
+
+        let data = try #require(ImageFileWriter.data(from: image, matchingFormatOf: url))
+
+        #expect(writtenFormatUTI(data) == UTType.gif.identifier)
+    }
+
+    @Test("matches HEIC format for a .heic URL when an encoder is available")
+    func matchesHEICFormatForHEICURLWhenEncoderAvailable() throws {
+        let image = try makeImage(width: 4, height: 4)
+        let url = URL(fileURLWithPath: "/tmp/photo.heic")
+
+        guard let data = ImageFileWriter.data(from: image, matchingFormatOf: url) else {
+            // Some Intel Macs lack an HEVC encoder; skip rather than fail the suite.
+            return
+        }
+
+        #expect(writtenFormatUTI(data) == UTType.heic.identifier)
+    }
+
+    @Test("falls back to PNG for an unrecognized extension")
+    func fallsBackToPNGForUnknownExtension() throws {
+        let image = try makeImage(width: 4, height: 4)
+        let url = URL(fileURLWithPath: "/tmp/photo.xyz")
+
+        let data = try #require(ImageFileWriter.data(from: image, matchingFormatOf: url))
+
+        #expect(writtenFormatUTI(data) == UTType.png.identifier)
+    }
+
+    private func makeImage(width: Int, height: Int) throws -> CGImage {
+        let context = try #require(CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(CGColor(red: 0.1, green: 0.7, blue: 0.3, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return try #require(context.makeImage())
+    }
+
+    private func writtenFormatUTI(_ data: Data) -> String? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        return CGImageSourceGetType(source) as String?
+    }
+}


### PR DESCRIPTION
## What changed

- Registers Capso as an editor for PNG/JPEG/HEIC/TIFF/GIF via `CFBundleDocumentTypes`, so Finder's "Open With" lists Capso and double-clicking a supported file (or launching Capso while it's not running) opens it straight into Annotate.
- Adds an "Open Image…" item to the menu bar that shows a file picker filtered to those formats.
- An opened file behaves like a fresh capture: annotate, then Save/Copy/Pin.
- Saving an *opened* file prompts to overwrite the original or save a new copy, since silently writing a brand-new file elsewhere (the existing "Save" behavior for captures) isn't what most people expect when editing an existing file, and silently overwriting isn't safe either. The prompt (Overwrite Original / Save as New Copy / Cancel) only appears when Preferences → Export → "When Saving an Opened Image" is set to "Ask Every Time" (the default); it can also be set to always Overwrite or always Save New Copy. Overwriting preserves the original file's format.
- Multi-select in Finder opens the first loadable image and shows a toast noting how many were skipped; a corrupt/unreadable file shows a toast instead of a blank editor.

Built with TDD throughout — new `ImageFileReader`/`ImageFileWriter`/`ImageFileOpenRequest` utilities in SharedKit, `CaptureCoordinator.openImageFiles`/`handleOpenedFileSave`, and an `AppSettings.openedImageSaveBehavior` setting, each with unit tests before implementation.

## Related issue

Fixes #194

## Screenshots / recordings

<img width="800" height="442" alt="Capso Recording 2026-07-17 at 12 11 42 (compressed)" src="https://github.com/user-attachments/assets/6482d97b-5c66-4592-a62f-fbc48c9efcd1" />

<img width="780" height="612" alt="Capso Screenshot - Capso 2026-07-17 at 12 13 05" src="https://github.com/user-attachments/assets/d5c14ad1-3c66-4b98-9e82-26ec9a083c92" />

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass (`swift test --package-path Packages/<Kit>`)
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per CONTRIBUTING.md