### PR TITLE
test: fix AnnotationEditorWindow onSave stub after #196/#197 interaction

### DIFF
--- a/App/Tests/AnnotationEditorWindowCloseTests.swift
+++ b/App/Tests/AnnotationEditorWindowCloseTests.swift
@@ -26,7 +26,7 @@ final class AnnotationEditorWindowCloseTests: XCTestCase {
             image: try makeTestImage(),
             screenshotOutputPreset: .losslessPNG,
             screenshotFilenameTemplate: "Screenshot",
-            onSave: { _ in },
+            onSave: { _ in true },
             onCopy: { _ in },
             onPin: { _, _ in },
             onClose: onClose


### PR DESCRIPTION
Hotfix for main after squash-merging #196 and #197 back-to-back.

## What happened

- #196 (Esc fix) added `App/Tests/AnnotationEditorWindowCloseTests.swift` using the previous `onSave: (CGImage) -> Void` signature.
- #197 (Open image files) changed `AnnotationEditorWindow.onSave` to `(CGImage) -> Bool` so failed overwrites keep the editor open.

Each PR passed CI on its own, but their interaction broke main:

```
App/Tests/AnnotationEditorWindowCloseTests.swift:29:21: error: cannot convert value of type '()' to closure result type 'Bool'
```

## Fix

Return `true` from the test's `onSave` stub so it matches the new signature. One-line test-only change.

## Test plan

- [x] Diff is limited to `App/Tests/AnnotationEditorWindowCloseTests.swift` (helper only)
- [ ] Waiting for `build-and-test` to go green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change in test helpers only; no production behavior.
> 
> **Overview**
> **Test-only fix** so `AnnotationEditorWindowCloseTests` compiles after `AnnotationEditorWindow.onSave` was changed from `(CGImage) -> Void` to `(CGImage) -> Bool` (failed saves keep the editor open).
> 
> The `makeWindow` helper’s `onSave` stub now returns `true` instead of an empty closure, matching the new signature and restoring a green build on main.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e3c5920d9415dfee05bbc9159fe3b9c47aa40d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->