### PR TITLE
Add camera PiP fade-on-hover and click-through options.

### DIFF
--- a/App/Sources/Camera/CameraPiPWindow.swift
+++ b/App/Sources/Camera/CameraPiPWindow.swift
@@ -4,6 +4,33 @@ import SwiftUI
 import CameraKit
 import SharedKit
 
+/// Hosts the SwiftUI PiP content and reports pointer enter/exit for fade-on-idle.
+@MainActor
+private final class CameraPiPTrackingHostingView<Content: View>: NSHostingView<Content> {
+    var onPointerInsideChange: ((Bool) -> Void)?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        trackingAreas.forEach(removeTrackingArea)
+        let options: NSTrackingArea.Options = [
+            .mouseEnteredAndExited,
+            .activeAlways,
+            .inVisibleRect
+        ]
+        addTrackingArea(NSTrackingArea(rect: .zero, options: options, owner: self, userInfo: nil))
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        onPointerInsideChange?(true)
+        super.mouseEntered(with: event)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        onPointerInsideChange?(false)
+        super.mouseExited(with: event)
+    }
+}
+
 @MainActor
 final class CameraPiPWindow: NSPanel {
     private let cameraManager: CameraManager
@@ -19,6 +46,10 @@ final class CameraPiPWindow: NSPanel {
     private var allowsPresentationFrameOutsideVisibleArea = false
     private var storedPiPFrame: CGRect?
     private var mouseDownPoint: NSPoint?
+    private var isPointerInside = false
+    /// Stored as `nonisolated(unsafe)` so deinit can tear monitors down without MainActor hops.
+    nonisolated(unsafe) private var globalMouseMonitor: Any?
+    nonisolated(unsafe) private var localMouseMonitor: Any?
     private let clickThreshold: CGFloat = 5
     private let defaultWindowLevel: NSWindow.Level = .floating
     private let presentationWindowLevel = NSWindow.Level.statusBar + 1
@@ -89,6 +120,9 @@ final class CameraPiPWindow: NSPanel {
         }
 
         installContentView()
+        // Start fully solid; fade / click-through only kick in once the pointer enters the PiP.
+        isPointerInside = false
+        updateHoverInteraction(animated: false)
 
         // Snap to corners when dragged near screen edges
         NotificationCenter.default.addObserver(
@@ -97,9 +131,20 @@ final class CameraPiPWindow: NSPanel {
             name: NSWindow.didMoveNotification,
             object: self
         )
+
+        // Preferences can toggle fade mid-session; re-apply when UserDefaults changes.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleDefaultsChanged),
+            name: UserDefaults.didChangeNotification,
+            object: nil
+        )
     }
 
-    func show() { makeKeyAndOrderFront(nil) }
+    func show() {
+        makeKeyAndOrderFront(nil)
+        updateHoverInteraction(animated: false)
+    }
 
     func togglePresentationMode() {
         guard !isPresentationTransitioning else { return }
@@ -115,6 +160,8 @@ final class CameraPiPWindow: NSPanel {
         isPresentationMode = true
         isPresentationTransitioning = true
         applyPresentationWindowMode()
+        // Fullscreen presentation must stay fully opaque and interactive.
+        updateHoverInteraction(animated: true)
 
         // Animate to fill the recording area.
         NSAnimationContext.runAnimationGroup { context in
@@ -124,6 +171,7 @@ final class CameraPiPWindow: NSPanel {
         } completionHandler: {
             self.installContentView()
             self.isPresentationTransitioning = false
+            self.updateHoverInteraction(animated: false)
         }
     }
 
@@ -134,11 +182,14 @@ final class CameraPiPWindow: NSPanel {
             isPresentationMode = false
             installContentView()
             restoreDefaultWindowMode()
+            updateHoverInteraction(animated: true)
             return
         }
 
         isPresentationMode = false
         isPresentationTransitioning = true
+        // Restore fade / click-through behavior as soon as we leave presentation chrome.
+        updateHoverInteraction(animated: true)
 
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.28
@@ -149,6 +200,7 @@ final class CameraPiPWindow: NSPanel {
             self.storedPiPFrame = nil
             self.isPresentationTransitioning = false
             self.restoreDefaultWindowMode()
+            self.updateHoverInteraction(animated: false)
         }
     }
 
@@ -162,6 +214,7 @@ final class CameraPiPWindow: NSPanel {
         builder.onShapeSelected = { [weak self] _ in self?.applySettings() }
         builder.onSizeSelected = { [weak self] _ in self?.applySettings() }
         builder.onMirrorToggled = { [weak self] _ in self?.applySettings() }
+        builder.onHoverOptionsChanged = { [weak self] in self?.updateHoverInteraction(animated: true) }
         // PiP context menu doesn't change camera device — toolbar handles enable/disable.
         builder.onCameraSelected = nil
         builder.onMenuClosed = { [weak self] in self?.menuBuilder = nil }
@@ -305,7 +358,21 @@ final class CameraPiPWindow: NSPanel {
     }
 
     deinit {
+        if let globalMouseMonitor {
+            NSEvent.removeMonitor(globalMouseMonitor)
+        }
+        if let localMouseMonitor {
+            NSEvent.removeMonitor(localMouseMonitor)
+        }
         NotificationCenter.default.removeObserver(self)
+    }
+
+    /// UserDefaults can post from background threads (e.g. CoreML feature-flag registration
+    /// while the camera pipeline starts). Hop to the main actor before touching UI state.
+    @objc nonisolated private func handleDefaultsChanged() {
+        Task { @MainActor [weak self] in
+            self?.updateHoverInteraction(animated: true)
+        }
     }
 
     override var canBecomeKey: Bool { true }
@@ -320,13 +387,17 @@ final class CameraPiPWindow: NSPanel {
 
     /// Re-read settings and update the window's size + content view.
     func applySettings() {
-        let newSize = Self.windowSize(shape: settings.cameraShape, settings: settings)
-        var newFrame = self.frame
-        // Keep top-left fixed when resizing
-        newFrame.origin.y += newFrame.size.height - newSize.height
-        newFrame.size = newSize
-        self.setFrame(newFrame, display: true, animate: true)
+        // Presentation mode fills the recording area — don't shrink to the PiP preset size.
+        if !isPresentationMode {
+            let newSize = Self.windowSize(shape: settings.cameraShape, settings: settings)
+            var newFrame = self.frame
+            // Keep top-left fixed when resizing
+            newFrame.origin.y += newFrame.size.height - newSize.height
+            newFrame.size = newSize
+            self.setFrame(newFrame, display: true, animate: true)
+        }
         installContentView()
+        updateHoverInteraction(animated: true)
     }
 
     /// Compute the window content size for the given shape, honoring custom size override.
@@ -388,6 +459,98 @@ final class CameraPiPWindow: NSPanel {
             usePresentationChrome: isPresentationMode,
             forcedSize: isPresentationMode ? self.frame.size : nil
         )
-        self.contentView = NSHostingView(rootView: view)
+        let hostingView = CameraPiPTrackingHostingView(rootView: view)
+        hostingView.onPointerInsideChange = { [weak self] inside in
+            self?.handlePointerInsideChange(inside)
+        }
+        self.contentView = hostingView
+    }
+
+    private func handlePointerInsideChange(_ inside: Bool) {
+        guard isPointerInside != inside else { return }
+        isPointerInside = inside
+        updateHoverInteraction(animated: true)
+    }
+
+    /// Applies fade opacity and optional click-through from current pointer / settings state.
+    private func updateHoverInteraction(animated: Bool) {
+        let fadeEnabled = settings.cameraPiPFadeWhenIdle
+        let clickThroughEnabled = settings.cameraPiPClickThroughWhenFaded
+
+        let target = CameraPiPPlacement.fadeAlpha(
+            enabled: fadeEnabled,
+            presentationModeActive: isPresentationMode,
+            pointerInside: isPointerInside
+        )
+
+        if abs(alphaValue - target) > 0.001 {
+            if animated {
+                NSAnimationContext.runAnimationGroup { context in
+                    context.duration = 0.18
+                    context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+                    self.animator().alphaValue = target
+                }
+            } else {
+                alphaValue = target
+            }
+        }
+
+        let shouldClickThrough = CameraPiPPlacement.shouldClickThrough(
+            fadeEnabled: fadeEnabled,
+            clickThroughEnabled: clickThroughEnabled,
+            presentationModeActive: isPresentationMode,
+            pointerInside: isPointerInside
+        )
+        applyClickThrough(shouldClickThrough)
+    }
+
+    private func applyClickThrough(_ enabled: Bool) {
+        if ignoresMouseEvents != enabled {
+            ignoresMouseEvents = enabled
+        }
+        // Tracking areas stop receiving enter/exit while the window ignores mouse events.
+        // Poll screen-space mouse location until the pointer leaves the PiP frame.
+        if enabled {
+            startClickThroughMouseMonitorsIfNeeded()
+        } else {
+            stopClickThroughMouseMonitors()
+        }
+    }
+
+    private func startClickThroughMouseMonitorsIfNeeded() {
+        guard globalMouseMonitor == nil, localMouseMonitor == nil else { return }
+
+        let handler: (NSEvent) -> Void = { [weak self] _ in
+            Task { @MainActor in
+                self?.syncPointerInsideFromScreenLocation()
+            }
+        }
+
+        globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.mouseMoved, .leftMouseDragged, .rightMouseDragged],
+            handler: handler
+        )
+        localMouseMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.mouseMoved, .leftMouseDragged, .rightMouseDragged]
+        ) { event in
+            handler(event)
+            return event
+        }
+    }
+
+    private func stopClickThroughMouseMonitors() {
+        if let globalMouseMonitor {
+            NSEvent.removeMonitor(globalMouseMonitor)
+            self.globalMouseMonitor = nil
+        }
+        if let localMouseMonitor {
+            NSEvent.removeMonitor(localMouseMonitor)
+            self.localMouseMonitor = nil
+        }
+    }
+
+    private func syncPointerInsideFromScreenLocation() {
+        let inside = frame.contains(NSEvent.mouseLocation)
+        handlePointerInsideChange(inside)
     }
 }

--- a/App/Sources/Camera/CameraPiPWindow.swift
+++ b/App/Sources/Camera/CameraPiPWindow.swift
@@ -4,7 +4,7 @@ import SwiftUI
 import CameraKit
 import SharedKit
 
-/// Hosts the SwiftUI PiP content and reports pointer enter/exit for fade-on-idle.
+/// Hosts the SwiftUI PiP content and reports pointer enter/exit for fade-on-hover.
 @MainActor
 private final class CameraPiPTrackingHostingView<Content: View>: NSHostingView<Content> {
     var onPointerInsideChange: ((Bool) -> Void)?
@@ -132,12 +132,12 @@ final class CameraPiPWindow: NSPanel {
             object: self
         )
 
-        // Preferences can toggle fade mid-session; re-apply when UserDefaults changes.
+        // Preferences / menu bar can toggle fade mid-session; re-apply only for these keys.
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(handleDefaultsChanged),
-            name: UserDefaults.didChangeNotification,
-            object: nil
+            selector: #selector(handleHoverOptionsChanged),
+            name: .cameraPiPHoverOptionsChanged,
+            object: settings
         )
     }
 
@@ -367,9 +367,9 @@ final class CameraPiPWindow: NSPanel {
         NotificationCenter.default.removeObserver(self)
     }
 
-    /// UserDefaults can post from background threads (e.g. CoreML feature-flag registration
-    /// while the camera pipeline starts). Hop to the main actor before touching UI state.
-    @objc nonisolated private func handleDefaultsChanged() {
+    /// Posted from `AppSettings` when fade / click-through toggles change. Hop to the main
+    /// actor before touching UI state (writes can arrive off the main thread in theory).
+    @objc nonisolated private func handleHoverOptionsChanged() {
         Task { @MainActor [weak self] in
             self?.updateHoverInteraction(animated: true)
         }
@@ -474,8 +474,8 @@ final class CameraPiPWindow: NSPanel {
 
     /// Applies fade opacity and optional click-through from current pointer / settings state.
     private func updateHoverInteraction(animated: Bool) {
-        let fadeEnabled = settings.cameraPiPFadeWhenIdle
-        let clickThroughEnabled = settings.cameraPiPClickThroughWhenFaded
+        let fadeEnabled = settings.cameraPiPFadeOnHover
+        let clickThroughEnabled = settings.cameraPiPClickThrough
 
         let target = CameraPiPPlacement.fadeAlpha(
             enabled: fadeEnabled,
@@ -496,7 +496,6 @@ final class CameraPiPWindow: NSPanel {
         }
 
         let shouldClickThrough = CameraPiPPlacement.shouldClickThrough(
-            fadeEnabled: fadeEnabled,
             clickThroughEnabled: clickThroughEnabled,
             presentationModeActive: isPresentationMode,
             pointerInside: isPointerInside

--- a/App/Sources/MenuBar/MenuBarController.swift
+++ b/App/Sources/MenuBar/MenuBarController.swift
@@ -129,6 +129,8 @@ final class MenuBarController: NSObject {
         recordScreen.setShortcut(for: .recordScreen)
         menu.addItem(recordScreen)
 
+        menu.addItem(cameraPiPMenuItem())
+
         menu.addItem(.separator())
 
         let screenshotHistory = menuItem(String(localized: "Screenshot History..."), action: #selector(openHistory))
@@ -149,6 +151,62 @@ final class MenuBarController: NSObject {
         item.keyEquivalentModifierMask = modifiers
         item.target = self
         return item
+    }
+
+    /// Submenu for camera PiP interaction options (fade / click-through).
+    /// Kept in the status-item menu so users can disable click-through without opening Preferences
+    /// (click-through blocks dragging the PiP while active).
+    private func cameraPiPMenuItem() -> NSMenuItem {
+        let item = NSMenuItem(title: String(localized: "Camera PiP"), action: nil, keyEquivalent: "")
+        let submenu = NSMenu()
+
+        let fadeItem = NSMenuItem(
+            title: String(localized: "Fade on Hover"),
+            action: #selector(toggleCameraPiPFadeOnHover),
+            keyEquivalent: ""
+        )
+        fadeItem.target = self
+        fadeItem.state = settings.cameraPiPFadeWhenIdle ? .on : .off
+        submenu.addItem(fadeItem)
+
+        let clickThroughItem = NSMenuItem(
+            title: String(localized: "Click Through When Faded"),
+            action: #selector(toggleCameraPiPClickThroughWhenFaded),
+            keyEquivalent: ""
+        )
+        clickThroughItem.target = self
+        clickThroughItem.state = settings.cameraPiPClickThroughWhenFaded ? .on : .off
+        clickThroughItem.isEnabled = settings.cameraPiPFadeWhenIdle
+        submenu.addItem(clickThroughItem)
+
+        item.submenu = submenu
+        return item
+    }
+
+    private func refreshCameraPiPMenuItems(in menu: NSMenu) {
+        for item in menu.items {
+            if let submenu = item.submenu {
+                refreshCameraPiPMenuItems(in: submenu)
+            }
+            switch item.action {
+            case #selector(toggleCameraPiPFadeOnHover):
+                item.state = settings.cameraPiPFadeWhenIdle ? .on : .off
+            case #selector(toggleCameraPiPClickThroughWhenFaded):
+                item.state = settings.cameraPiPClickThroughWhenFaded ? .on : .off
+                item.isEnabled = settings.cameraPiPFadeWhenIdle
+            default:
+                break
+            }
+        }
+    }
+
+    @objc private func toggleCameraPiPFadeOnHover() {
+        settings.cameraPiPFadeWhenIdle.toggle()
+    }
+
+    @objc private func toggleCameraPiPClickThroughWhenFaded() {
+        guard settings.cameraPiPFadeWhenIdle else { return }
+        settings.cameraPiPClickThroughWhenFaded.toggle()
     }
 
     /// Self-Timer menu row. Title is "Self-Timer" with the saved duration
@@ -274,5 +332,6 @@ extension MenuBarController: NSMenuDelegate {
             default: break
             }
         }
+        refreshCameraPiPMenuItems(in: menu)
     }
 }

--- a/App/Sources/MenuBar/MenuBarController.swift
+++ b/App/Sources/MenuBar/MenuBarController.swift
@@ -166,17 +166,16 @@ final class MenuBarController: NSObject {
             keyEquivalent: ""
         )
         fadeItem.target = self
-        fadeItem.state = settings.cameraPiPFadeWhenIdle ? .on : .off
+        fadeItem.state = settings.cameraPiPFadeOnHover ? .on : .off
         submenu.addItem(fadeItem)
 
         let clickThroughItem = NSMenuItem(
-            title: String(localized: "Click Through When Faded"),
-            action: #selector(toggleCameraPiPClickThroughWhenFaded),
+            title: String(localized: "Click Through PiP"),
+            action: #selector(toggleCameraPiPClickThrough),
             keyEquivalent: ""
         )
         clickThroughItem.target = self
-        clickThroughItem.state = settings.cameraPiPClickThroughWhenFaded ? .on : .off
-        clickThroughItem.isEnabled = settings.cameraPiPFadeWhenIdle
+        clickThroughItem.state = settings.cameraPiPClickThrough ? .on : .off
         submenu.addItem(clickThroughItem)
 
         item.submenu = submenu
@@ -190,10 +189,9 @@ final class MenuBarController: NSObject {
             }
             switch item.action {
             case #selector(toggleCameraPiPFadeOnHover):
-                item.state = settings.cameraPiPFadeWhenIdle ? .on : .off
-            case #selector(toggleCameraPiPClickThroughWhenFaded):
-                item.state = settings.cameraPiPClickThroughWhenFaded ? .on : .off
-                item.isEnabled = settings.cameraPiPFadeWhenIdle
+                item.state = settings.cameraPiPFadeOnHover ? .on : .off
+            case #selector(toggleCameraPiPClickThrough):
+                item.state = settings.cameraPiPClickThrough ? .on : .off
             default:
                 break
             }
@@ -201,12 +199,11 @@ final class MenuBarController: NSObject {
     }
 
     @objc private func toggleCameraPiPFadeOnHover() {
-        settings.cameraPiPFadeWhenIdle.toggle()
+        settings.cameraPiPFadeOnHover.toggle()
     }
 
-    @objc private func toggleCameraPiPClickThroughWhenFaded() {
-        guard settings.cameraPiPFadeWhenIdle else { return }
-        settings.cameraPiPClickThroughWhenFaded.toggle()
+    @objc private func toggleCameraPiPClickThrough() {
+        settings.cameraPiPClickThrough.toggle()
     }
 
     /// Self-Timer menu row. Title is "Self-Timer" with the saved duration

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -440,6 +440,28 @@ final class PreferencesViewModel {
             }
         }
     }
+    var cameraPiPFadeWhenIdle: Bool {
+        get {
+            access(keyPath: \.cameraPiPFadeWhenIdle)
+            return settings.cameraPiPFadeWhenIdle
+        }
+        set {
+            withMutation(keyPath: \.cameraPiPFadeWhenIdle) {
+                settings.cameraPiPFadeWhenIdle = newValue
+            }
+        }
+    }
+    var cameraPiPClickThroughWhenFaded: Bool {
+        get {
+            access(keyPath: \.cameraPiPClickThroughWhenFaded)
+            return settings.cameraPiPClickThroughWhenFaded
+        }
+        set {
+            withMutation(keyPath: \.cameraPiPClickThroughWhenFaded) {
+                settings.cameraPiPClickThroughWhenFaded = newValue
+            }
+        }
+    }
 
     // MARK: Quick Access
     var quickAccessPosition: QuickAccessPosition {

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -440,25 +440,25 @@ final class PreferencesViewModel {
             }
         }
     }
-    var cameraPiPFadeWhenIdle: Bool {
+    var cameraPiPFadeOnHover: Bool {
         get {
-            access(keyPath: \.cameraPiPFadeWhenIdle)
-            return settings.cameraPiPFadeWhenIdle
+            access(keyPath: \.cameraPiPFadeOnHover)
+            return settings.cameraPiPFadeOnHover
         }
         set {
-            withMutation(keyPath: \.cameraPiPFadeWhenIdle) {
-                settings.cameraPiPFadeWhenIdle = newValue
+            withMutation(keyPath: \.cameraPiPFadeOnHover) {
+                settings.cameraPiPFadeOnHover = newValue
             }
         }
     }
-    var cameraPiPClickThroughWhenFaded: Bool {
+    var cameraPiPClickThrough: Bool {
         get {
-            access(keyPath: \.cameraPiPClickThroughWhenFaded)
-            return settings.cameraPiPClickThroughWhenFaded
+            access(keyPath: \.cameraPiPClickThrough)
+            return settings.cameraPiPClickThrough
         }
         set {
-            withMutation(keyPath: \.cameraPiPClickThroughWhenFaded) {
-                settings.cameraPiPClickThroughWhenFaded = newValue
+            withMutation(keyPath: \.cameraPiPClickThrough) {
+                settings.cameraPiPClickThrough = newValue
             }
         }
     }

--- a/App/Sources/Preferences/Tabs/RecordingSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/RecordingSettingsView.swift
@@ -63,6 +63,29 @@ struct RecordingSettingsView: View {
                 }
             }
 
+            SettingGroup(title: "Camera PiP") {
+                SettingCard {
+                    SettingRow(
+                        label: "Fade on Hover",
+                        sublabel: "Solid until you hover — then nearly transparent so you can see behind it. Stays solid in fullscreen. Recorded output matches what you see."
+                    ) {
+                        Toggle("", isOn: $viewModel.cameraPiPFadeWhenIdle)
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                    }
+                    SettingRow(
+                        label: "Click Through When Faded",
+                        sublabel: "While faded, clicks pass through the PiP to whatever is behind it. Requires Fade on Hover.",
+                        showDivider: true
+                    ) {
+                        Toggle("", isOn: $viewModel.cameraPiPClickThroughWhenFaded)
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                            .disabled(!viewModel.cameraPiPFadeWhenIdle)
+                    }
+                }
+            }
+
             // TODO: Re-enable the "Format" group once AppSettings.recordingFormat
             // is actually honored as the *default* pick in RecordingToolbar.
             // Today the format (MP4 / GIF) is chosen per-session via the

--- a/App/Sources/Preferences/Tabs/RecordingSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/RecordingSettingsView.swift
@@ -69,19 +69,18 @@ struct RecordingSettingsView: View {
                         label: "Fade on Hover",
                         sublabel: "Solid until you hover — then nearly transparent so you can see behind it. Stays solid in fullscreen. Recorded output matches what you see."
                     ) {
-                        Toggle("", isOn: $viewModel.cameraPiPFadeWhenIdle)
+                        Toggle("", isOn: $viewModel.cameraPiPFadeOnHover)
                             .toggleStyle(.switch)
                             .controlSize(.small)
                     }
                     SettingRow(
-                        label: "Click Through When Faded",
-                        sublabel: "While faded, clicks pass through the PiP to whatever is behind it. Requires Fade on Hover.",
+                        label: "Click Through PiP",
+                        sublabel: "While the pointer is over the small camera view, clicks pass through to whatever is behind it. Independent of Fade on Hover. Never applies in fullscreen.",
                         showDivider: true
                     ) {
-                        Toggle("", isOn: $viewModel.cameraPiPClickThroughWhenFaded)
+                        Toggle("", isOn: $viewModel.cameraPiPClickThrough)
                             .toggleStyle(.switch)
                             .controlSize(.small)
-                            .disabled(!viewModel.cameraPiPFadeWhenIdle)
                     }
                 }
             }

--- a/App/Sources/Recording/CameraMenuBuilder.swift
+++ b/App/Sources/Recording/CameraMenuBuilder.swift
@@ -11,6 +11,8 @@ final class CameraMenuBuilder: NSObject, NSMenuDelegate {
     var onShapeSelected: ((CameraShape) -> Void)?
     var onSizeSelected: ((SharedKit.CameraSize) -> Void)?
     var onMirrorToggled: ((Bool) -> Void)?
+    /// Called after fade / click-through options change so the PiP can re-apply interaction state.
+    var onHoverOptionsChanged: (() -> Void)?
     var onMenuClosed: (() -> Void)?
 
     /// The currently selected camera unique ID (nil = None).
@@ -84,6 +86,24 @@ final class CameraMenuBuilder: NSObject, NSMenuDelegate {
         )
         menu.addItem(mirrorItem)
 
+        menu.addItem(.separator())
+
+        let fadeItem = makeItem(
+            title: String(localized: "Fade on Hover"),
+            isSelected: settings.cameraPiPFadeWhenIdle,
+            action: #selector(toggleFadeOnHover)
+        )
+        menu.addItem(fadeItem)
+
+        let clickThroughItem = makeItem(
+            title: String(localized: "Click Through When Faded"),
+            isSelected: settings.cameraPiPClickThroughWhenFaded,
+            action: #selector(toggleClickThroughWhenFaded)
+        )
+        // Click-through only applies while fade-on-hover is enabled (moving PiP is blocked when active).
+        clickThroughItem.isEnabled = settings.cameraPiPFadeWhenIdle
+        menu.addItem(clickThroughItem)
+
         // Wire all items to this builder so selectors fire on it
         for item in menu.items where item.action != nil {
             item.target = self
@@ -145,6 +165,17 @@ final class CameraMenuBuilder: NSObject, NSMenuDelegate {
     @objc private func toggleMirror() {
         settings.cameraMirror.toggle()
         onMirrorToggled?(settings.cameraMirror)
+    }
+
+    @objc private func toggleFadeOnHover() {
+        settings.cameraPiPFadeWhenIdle.toggle()
+        onHoverOptionsChanged?()
+    }
+
+    @objc private func toggleClickThroughWhenFaded() {
+        guard settings.cameraPiPFadeWhenIdle else { return }
+        settings.cameraPiPClickThroughWhenFaded.toggle()
+        onHoverOptionsChanged?()
     }
 }
 

--- a/App/Sources/Recording/CameraMenuBuilder.swift
+++ b/App/Sources/Recording/CameraMenuBuilder.swift
@@ -90,18 +90,17 @@ final class CameraMenuBuilder: NSObject, NSMenuDelegate {
 
         let fadeItem = makeItem(
             title: String(localized: "Fade on Hover"),
-            isSelected: settings.cameraPiPFadeWhenIdle,
+            isSelected: settings.cameraPiPFadeOnHover,
             action: #selector(toggleFadeOnHover)
         )
         menu.addItem(fadeItem)
 
         let clickThroughItem = makeItem(
-            title: String(localized: "Click Through When Faded"),
-            isSelected: settings.cameraPiPClickThroughWhenFaded,
-            action: #selector(toggleClickThroughWhenFaded)
+            title: String(localized: "Click Through PiP"),
+            isSelected: settings.cameraPiPClickThrough,
+            action: #selector(toggleClickThrough)
         )
-        // Click-through only applies while fade-on-hover is enabled (moving PiP is blocked when active).
-        clickThroughItem.isEnabled = settings.cameraPiPFadeWhenIdle
+        // Independent of fade-on-hover. Fullscreen presentation never click-throughs.
         menu.addItem(clickThroughItem)
 
         // Wire all items to this builder so selectors fire on it
@@ -168,13 +167,12 @@ final class CameraMenuBuilder: NSObject, NSMenuDelegate {
     }
 
     @objc private func toggleFadeOnHover() {
-        settings.cameraPiPFadeWhenIdle.toggle()
+        settings.cameraPiPFadeOnHover.toggle()
         onHoverOptionsChanged?()
     }
 
-    @objc private func toggleClickThroughWhenFaded() {
-        guard settings.cameraPiPFadeWhenIdle else { return }
-        settings.cameraPiPClickThroughWhenFaded.toggle()
+    @objc private func toggleClickThrough() {
+        settings.cameraPiPClickThrough.toggle()
         onHoverOptionsChanged?()
     }
 }

--- a/App/Sources/Recording/RecordingToolbar.swift
+++ b/App/Sources/Recording/RecordingToolbar.swift
@@ -239,6 +239,34 @@ struct RecordingToolbarView: View {
                     Text("Mirror")
                 }
             }
+
+            Divider()
+
+            Button {
+                settings.cameraPiPFadeWhenIdle.toggle()
+                cameraMenuRevision += 1
+                onCameraSettingsChanged()
+            } label: {
+                if settings.cameraPiPFadeWhenIdle {
+                    Label("Fade on Hover", systemImage: "checkmark")
+                } else {
+                    Text("Fade on Hover")
+                }
+            }
+
+            Button {
+                guard settings.cameraPiPFadeWhenIdle else { return }
+                settings.cameraPiPClickThroughWhenFaded.toggle()
+                cameraMenuRevision += 1
+                onCameraSettingsChanged()
+            } label: {
+                if settings.cameraPiPClickThroughWhenFaded {
+                    Label("Click Through When Faded", systemImage: "checkmark")
+                } else {
+                    Text("Click Through When Faded")
+                }
+            }
+            .disabled(!settings.cameraPiPFadeWhenIdle)
         } label: {
             Image(systemName: cameraEnabled ? "camera.fill" : "camera")
                 .font(.system(size: 14))

--- a/App/Sources/Recording/RecordingToolbar.swift
+++ b/App/Sources/Recording/RecordingToolbar.swift
@@ -243,11 +243,11 @@ struct RecordingToolbarView: View {
             Divider()
 
             Button {
-                settings.cameraPiPFadeWhenIdle.toggle()
+                settings.cameraPiPFadeOnHover.toggle()
                 cameraMenuRevision += 1
                 onCameraSettingsChanged()
             } label: {
-                if settings.cameraPiPFadeWhenIdle {
+                if settings.cameraPiPFadeOnHover {
                     Label("Fade on Hover", systemImage: "checkmark")
                 } else {
                     Text("Fade on Hover")
@@ -255,18 +255,16 @@ struct RecordingToolbarView: View {
             }
 
             Button {
-                guard settings.cameraPiPFadeWhenIdle else { return }
-                settings.cameraPiPClickThroughWhenFaded.toggle()
+                settings.cameraPiPClickThrough.toggle()
                 cameraMenuRevision += 1
                 onCameraSettingsChanged()
             } label: {
-                if settings.cameraPiPClickThroughWhenFaded {
-                    Label("Click Through When Faded", systemImage: "checkmark")
+                if settings.cameraPiPClickThrough {
+                    Label("Click Through PiP", systemImage: "checkmark")
                 } else {
-                    Text("Click Through When Faded")
+                    Text("Click Through PiP")
                 }
             }
-            .disabled(!settings.cameraPiPFadeWhenIdle)
         } label: {
             Image(systemName: cameraEnabled ? "camera.fill" : "camera")
                 .font(.system(size: 14))

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -373,6 +373,22 @@ public final class AppSettings: @unchecked Sendable {
         set { defaults.set(newValue, forKey: "cameraCustomSizePt") }
     }
 
+    /// When `true`, the camera PiP becomes nearly transparent while the pointer is over it
+    /// (so content behind it is readable without moving the window). Idle stays fully solid.
+    /// Presentation / fullscreen mode always stays opaque. Off by default.
+    /// Recorded output matches on-screen opacity.
+    public var cameraPiPFadeWhenIdle: Bool {
+        get { defaults.object(forKey: "cameraPiPFadeWhenIdle") as? Bool ?? false }
+        set { defaults.set(newValue, forKey: "cameraPiPFadeWhenIdle") }
+    }
+
+    /// When `true` (and fade-on-hover is also on), mouse clicks pass through the faded PiP
+    /// to whatever is behind it. Off by default. Has no effect while presentation mode is active.
+    public var cameraPiPClickThroughWhenFaded: Bool {
+        get { defaults.object(forKey: "cameraPiPClickThroughWhenFaded") as? Bool ?? false }
+        set { defaults.set(newValue, forKey: "cameraPiPClickThroughWhenFaded") }
+    }
+
     // MARK: Screenshots
     public var screenshotShowPreview: Bool {
         get { defaults.object(forKey: "screenshotShowPreview") as? Bool ?? true }

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -377,16 +377,25 @@ public final class AppSettings: @unchecked Sendable {
     /// (so content behind it is readable without moving the window). Idle stays fully solid.
     /// Presentation / fullscreen mode always stays opaque. Off by default.
     /// Recorded output matches on-screen opacity.
-    public var cameraPiPFadeWhenIdle: Bool {
-        get { defaults.object(forKey: "cameraPiPFadeWhenIdle") as? Bool ?? false }
-        set { defaults.set(newValue, forKey: "cameraPiPFadeWhenIdle") }
+    public var cameraPiPFadeOnHover: Bool {
+        get { defaults.object(forKey: "cameraPiPFadeOnHover") as? Bool ?? false }
+        set {
+            guard cameraPiPFadeOnHover != newValue else { return }
+            defaults.set(newValue, forKey: "cameraPiPFadeOnHover")
+            NotificationCenter.default.post(name: .cameraPiPHoverOptionsChanged, object: self)
+        }
     }
 
-    /// When `true` (and fade-on-hover is also on), mouse clicks pass through the faded PiP
-    /// to whatever is behind it. Off by default. Has no effect while presentation mode is active.
-    public var cameraPiPClickThroughWhenFaded: Bool {
-        get { defaults.object(forKey: "cameraPiPClickThroughWhenFaded") as? Bool ?? false }
-        set { defaults.set(newValue, forKey: "cameraPiPClickThroughWhenFaded") }
+    /// When `true`, mouse clicks pass through the small camera PiP to whatever is behind it
+    /// while the pointer is over it. Independent of fade-on-hover. Off by default.
+    /// Never applies in fullscreen / presentation mode (PiP stays interactive there).
+    public var cameraPiPClickThrough: Bool {
+        get { defaults.object(forKey: "cameraPiPClickThrough") as? Bool ?? false }
+        set {
+            guard cameraPiPClickThrough != newValue else { return }
+            defaults.set(newValue, forKey: "cameraPiPClickThrough")
+            NotificationCenter.default.post(name: .cameraPiPHoverOptionsChanged, object: self)
+        }
     }
 
     // MARK: Screenshots
@@ -878,4 +887,12 @@ public final class AppSettings: @unchecked Sendable {
     public init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
     }
+}
+
+// MARK: - Camera PiP hover option notifications
+
+public extension Notification.Name {
+    /// Posted when `cameraPiPFadeOnHover` or `cameraPiPClickThrough` changes,
+    /// so a live PiP can re-apply opacity / click-through without observing all UserDefaults writes.
+    static let cameraPiPHoverOptionsChanged = Notification.Name("cameraPiPHoverOptionsChanged")
 }

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/CameraPiPPlacement.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/CameraPiPPlacement.swift
@@ -15,6 +15,40 @@ public enum CameraPiPPlacement {
     public static let recordingBottomOffset: CGFloat = 20
     public static let visibleMargin: CGFloat = 8
 
+    /// Opacity applied to the camera PiP when fade-on-hover is enabled and the pointer is over it
+    /// (so content behind the PiP is readable without moving the window).
+    public static let fadeHoverAlpha: CGFloat = 0.18
+
+    /// Full opacity for the camera PiP (idle, presentation mode, or feature disabled).
+    public static let fadeFullAlpha: CGFloat = 1.0
+
+    /// Target window opacity for optional fade-when-hover behavior.
+    /// PiP stays fully solid until the pointer enters it, then becomes nearly transparent.
+    /// Fullscreen / presentation mode always stays fully opaque.
+    public static func fadeAlpha(
+        enabled: Bool,
+        presentationModeActive: Bool,
+        pointerInside: Bool
+    ) -> CGFloat {
+        guard enabled, !presentationModeActive else { return fadeFullAlpha }
+        return pointerInside ? fadeHoverAlpha : fadeFullAlpha
+    }
+
+    /// Whether the PiP window should ignore mouse events so clicks hit content behind it.
+    /// Only while fade-on-hover is active, the pointer is over the PiP, and click-through is enabled.
+    /// Fullscreen / presentation mode never click-through.
+    public static func shouldClickThrough(
+        fadeEnabled: Bool,
+        clickThroughEnabled: Bool,
+        presentationModeActive: Bool,
+        pointerInside: Bool
+    ) -> Bool {
+        guard fadeEnabled, clickThroughEnabled, !presentationModeActive, pointerInside else {
+            return false
+        }
+        return true
+    }
+
     public static func frame(
         restoredFrame: CGRect?,
         defaultSize: CGSize,

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/CameraPiPPlacement.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/CameraPiPPlacement.swift
@@ -22,7 +22,7 @@ public enum CameraPiPPlacement {
     /// Full opacity for the camera PiP (idle, presentation mode, or feature disabled).
     public static let fadeFullAlpha: CGFloat = 1.0
 
-    /// Target window opacity for optional fade-when-hover behavior.
+    /// Target window opacity for optional fade-on-hover behavior.
     /// PiP stays fully solid until the pointer enters it, then becomes nearly transparent.
     /// Fullscreen / presentation mode always stays fully opaque.
     public static func fadeAlpha(
@@ -34,18 +34,17 @@ public enum CameraPiPPlacement {
         return pointerInside ? fadeHoverAlpha : fadeFullAlpha
     }
 
-    /// Whether the PiP window should ignore mouse events so clicks hit content behind it.
-    /// Only while fade-on-hover is active, the pointer is over the PiP, and click-through is enabled.
-    /// Fullscreen / presentation mode never click-through.
+    /// Whether the small camera PiP should ignore mouse events so clicks hit content behind it.
+    /// Independent of fade-on-hover. Requires click-through enabled, pointer over the PiP, and
+    /// **not** fullscreen presentation mode (fullscreen always stays interactive).
     public static func shouldClickThrough(
-        fadeEnabled: Bool,
         clickThroughEnabled: Bool,
         presentationModeActive: Bool,
         pointerInside: Bool
     ) -> Bool {
-        guard fadeEnabled, clickThroughEnabled, !presentationModeActive, pointerInside else {
-            return false
-        }
+        // Fullscreen / presentation mode always receives clicks (never click-through).
+        guard !presentationModeActive else { return false }
+        guard clickThroughEnabled, pointerInside else { return false }
         return true
     }
 

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -162,6 +162,46 @@ struct AppSettingsTests {
         #expect(settings.playShutterSound == true)
     }
 
+    @Test("Camera PiP fade when idle is disabled by default")
+    func defaultCameraPiPFadeWhenIdle() {
+        let suite = "test.cameraPiPFadeWhenIdle.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.cameraPiPFadeWhenIdle == false)
+    }
+
+    @Test("Camera PiP fade when idle persists across instances")
+    func cameraPiPFadeWhenIdlePersists() {
+        let suite = "test.cameraPiPFadeWhenIdle.persists"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let first = AppSettings(defaults: defaults)
+        first.cameraPiPFadeWhenIdle = true
+        let second = AppSettings(defaults: defaults)
+        #expect(second.cameraPiPFadeWhenIdle == true)
+    }
+
+    @Test("Camera PiP click-through when faded is disabled by default")
+    func defaultCameraPiPClickThroughWhenFaded() {
+        let suite = "test.cameraPiPClickThroughWhenFaded.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.cameraPiPClickThroughWhenFaded == false)
+    }
+
+    @Test("Camera PiP click-through when faded persists across instances")
+    func cameraPiPClickThroughWhenFadedPersists() {
+        let suite = "test.cameraPiPClickThroughWhenFaded.persists"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let first = AppSettings(defaults: defaults)
+        first.cameraPiPClickThroughWhenFaded = true
+        let second = AppSettings(defaults: defaults)
+        #expect(second.cameraPiPClickThroughWhenFaded == true)
+    }
+
     @Test("Diagnostic logging is disabled by default")
     func defaultDiagnosticLoggingEnabled() {
         let suite = "test.diagnosticLogging.default"

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -162,44 +162,71 @@ struct AppSettingsTests {
         #expect(settings.playShutterSound == true)
     }
 
-    @Test("Camera PiP fade when idle is disabled by default")
-    func defaultCameraPiPFadeWhenIdle() {
-        let suite = "test.cameraPiPFadeWhenIdle.default"
+    @Test("Camera PiP fade on hover is disabled by default")
+    func defaultCameraPiPFadeOnHover() {
+        let suite = "test.cameraPiPFadeOnHover.default"
         let defaults = UserDefaults(suiteName: suite)!
         defaults.removePersistentDomain(forName: suite)
         let settings = AppSettings(defaults: defaults)
-        #expect(settings.cameraPiPFadeWhenIdle == false)
+        #expect(settings.cameraPiPFadeOnHover == false)
     }
 
-    @Test("Camera PiP fade when idle persists across instances")
-    func cameraPiPFadeWhenIdlePersists() {
-        let suite = "test.cameraPiPFadeWhenIdle.persists"
+    @Test("Camera PiP fade on hover persists across instances")
+    func cameraPiPFadeOnHoverPersists() {
+        let suite = "test.cameraPiPFadeOnHover.persists"
         let defaults = UserDefaults(suiteName: suite)!
         defaults.removePersistentDomain(forName: suite)
         let first = AppSettings(defaults: defaults)
-        first.cameraPiPFadeWhenIdle = true
+        first.cameraPiPFadeOnHover = true
         let second = AppSettings(defaults: defaults)
-        #expect(second.cameraPiPFadeWhenIdle == true)
+        #expect(second.cameraPiPFadeOnHover == true)
     }
 
-    @Test("Camera PiP click-through when faded is disabled by default")
-    func defaultCameraPiPClickThroughWhenFaded() {
-        let suite = "test.cameraPiPClickThroughWhenFaded.default"
+    @Test("Camera PiP hover option changes post a scoped notification only when value changes")
+    func cameraPiPHoverOptionsChangedNotification() {
+        let suite = "test.cameraPiPHoverOptionsChanged.notification"
         let defaults = UserDefaults(suiteName: suite)!
         defaults.removePersistentDomain(forName: suite)
         let settings = AppSettings(defaults: defaults)
-        #expect(settings.cameraPiPClickThroughWhenFaded == false)
+
+        final class PostCounter: @unchecked Sendable {
+            var count = 0
+        }
+        let posts = PostCounter()
+        let observer = NotificationCenter.default.addObserver(
+            forName: .cameraPiPHoverOptionsChanged,
+            object: settings,
+            queue: nil
+        ) { _ in posts.count += 1 }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        settings.cameraPiPFadeOnHover = true
+        settings.cameraPiPFadeOnHover = true // no-op, same value
+        #expect(posts.count == 1)
+
+        settings.cameraPiPClickThrough = true
+        settings.cameraPiPClickThrough = true // no-op
+        #expect(posts.count == 2)
     }
 
-    @Test("Camera PiP click-through when faded persists across instances")
-    func cameraPiPClickThroughWhenFadedPersists() {
-        let suite = "test.cameraPiPClickThroughWhenFaded.persists"
+    @Test("Camera PiP click-through is disabled by default")
+    func defaultCameraPiPClickThrough() {
+        let suite = "test.cameraPiPClickThrough.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.cameraPiPClickThrough == false)
+    }
+
+    @Test("Camera PiP click-through persists across instances")
+    func cameraPiPClickThroughPersists() {
+        let suite = "test.cameraPiPClickThrough.persists"
         let defaults = UserDefaults(suiteName: suite)!
         defaults.removePersistentDomain(forName: suite)
         let first = AppSettings(defaults: defaults)
-        first.cameraPiPClickThroughWhenFaded = true
+        first.cameraPiPClickThrough = true
         let second = AppSettings(defaults: defaults)
-        #expect(second.cameraPiPClickThroughWhenFaded == true)
+        #expect(second.cameraPiPClickThrough == true)
     }
 
     @Test("Diagnostic logging is disabled by default")

--- a/Packages/SharedKit/Tests/SharedKitTests/CameraPiPPlacementTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/CameraPiPPlacementTests.swift
@@ -123,4 +123,96 @@ struct CameraPiPPlacementTests {
 
         #expect(frame == recordingFrame)
     }
+
+    @Test("Fade alpha stays full when feature is disabled")
+    func fadeAlphaStaysFullWhenDisabled() {
+        #expect(
+            CameraPiPPlacement.fadeAlpha(
+                enabled: false,
+                presentationModeActive: false,
+                pointerInside: true
+            ) == CameraPiPPlacement.fadeFullAlpha
+        )
+    }
+
+    @Test("Fade alpha stays full while idle and enabled")
+    func fadeAlphaStaysFullWhileIdleAndEnabled() {
+        #expect(
+            CameraPiPPlacement.fadeAlpha(
+                enabled: true,
+                presentationModeActive: false,
+                pointerInside: false
+            ) == CameraPiPPlacement.fadeFullAlpha
+        )
+    }
+
+    @Test("Fade alpha drops while pointer is over PiP")
+    func fadeAlphaDropsWhilePointerInside() {
+        #expect(
+            CameraPiPPlacement.fadeAlpha(
+                enabled: true,
+                presentationModeActive: false,
+                pointerInside: true
+            ) == CameraPiPPlacement.fadeHoverAlpha
+        )
+    }
+
+    @Test("Fade alpha stays full in presentation mode even when pointer is over PiP")
+    func fadeAlphaStaysFullInPresentationMode() {
+        #expect(
+            CameraPiPPlacement.fadeAlpha(
+                enabled: true,
+                presentationModeActive: true,
+                pointerInside: true
+            ) == CameraPiPPlacement.fadeFullAlpha
+        )
+    }
+
+    @Test("Click-through is off unless fade, option, and hover all apply")
+    func clickThroughRequiresFadeHoverAndOption() {
+        #expect(
+            !CameraPiPPlacement.shouldClickThrough(
+                fadeEnabled: false,
+                clickThroughEnabled: true,
+                presentationModeActive: false,
+                pointerInside: true
+            )
+        )
+        #expect(
+            !CameraPiPPlacement.shouldClickThrough(
+                fadeEnabled: true,
+                clickThroughEnabled: false,
+                presentationModeActive: false,
+                pointerInside: true
+            )
+        )
+        #expect(
+            !CameraPiPPlacement.shouldClickThrough(
+                fadeEnabled: true,
+                clickThroughEnabled: true,
+                presentationModeActive: false,
+                pointerInside: false
+            )
+        )
+        #expect(
+            CameraPiPPlacement.shouldClickThrough(
+                fadeEnabled: true,
+                clickThroughEnabled: true,
+                presentationModeActive: false,
+                pointerInside: true
+            )
+        )
+    }
+
+    @Test("Click-through is never active in presentation mode")
+    func clickThroughDisabledInPresentationMode() {
+        #expect(
+            !CameraPiPPlacement.shouldClickThrough(
+                fadeEnabled: true,
+                clickThroughEnabled: true,
+                presentationModeActive: true,
+                pointerInside: true
+            )
+        )
+    }
 }

--- a/Packages/SharedKit/Tests/SharedKitTests/CameraPiPPlacementTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/CameraPiPPlacementTests.swift
@@ -168,19 +168,10 @@ struct CameraPiPPlacementTests {
         )
     }
 
-    @Test("Click-through is off unless fade, option, and hover all apply")
-    func clickThroughRequiresFadeHoverAndOption() {
+    @Test("Click-through is independent of fade and only needs option + hover")
+    func clickThroughRequiresOptionAndHover() {
         #expect(
             !CameraPiPPlacement.shouldClickThrough(
-                fadeEnabled: false,
-                clickThroughEnabled: true,
-                presentationModeActive: false,
-                pointerInside: true
-            )
-        )
-        #expect(
-            !CameraPiPPlacement.shouldClickThrough(
-                fadeEnabled: true,
                 clickThroughEnabled: false,
                 presentationModeActive: false,
                 pointerInside: true
@@ -188,7 +179,6 @@ struct CameraPiPPlacementTests {
         )
         #expect(
             !CameraPiPPlacement.shouldClickThrough(
-                fadeEnabled: true,
                 clickThroughEnabled: true,
                 presentationModeActive: false,
                 pointerInside: false
@@ -196,7 +186,6 @@ struct CameraPiPPlacementTests {
         )
         #expect(
             CameraPiPPlacement.shouldClickThrough(
-                fadeEnabled: true,
                 clickThroughEnabled: true,
                 presentationModeActive: false,
                 pointerInside: true
@@ -204,14 +193,20 @@ struct CameraPiPPlacementTests {
         )
     }
 
-    @Test("Click-through is never active in presentation mode")
+    @Test("Click-through is never active in fullscreen presentation mode")
     func clickThroughDisabledInPresentationMode() {
         #expect(
             !CameraPiPPlacement.shouldClickThrough(
-                fadeEnabled: true,
                 clickThroughEnabled: true,
                 presentationModeActive: true,
                 pointerInside: true
+            )
+        )
+        #expect(
+            !CameraPiPPlacement.shouldClickThrough(
+                clickThroughEnabled: true,
+                presentationModeActive: true,
+                pointerInside: false
             )
         )
     }


### PR DESCRIPTION
## What changed

Let the selfie PiP stay solid until hover, then fade (and optionally pass clicks through) so content behind it stays usable without dragging the window. Expose toggles in Recording settings, the pre-record camera menu, menu bar, and PiP context menu.

## Related issue

None
## Screenshots / recordings
<img width="3600" height="2338" alt="Capso Screenshot 2026-07-20 at 14 41 33" src="https://github.com/user-attachments/assets/a3b6e6fe-31e6-4cb4-b85c-af6a7b68dfc3" />

<img width="1427" height="1111" alt="Capso Screenshot - Capso 2026-07-20 at 14 40 09" src="https://github.com/user-attachments/assets/54aed0fc-5cb8-4a09-abac-60b5ba6773a4" />

<img width="990" height="1100" alt="Capso Screenshot - Safari 2026-07-20 at 14 42 32" src="https://github.com/user-attachments/assets/0b5c9809-45c6-4390-bc75-f1983346827e" />

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass (`swift test --package-path Packages/<Kit>`)
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)
