### PR TITLE
Add KeyCastr-style keystroke overlay while recording.

### DIFF
--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -12,6 +12,7 @@ final class PreferencesViewModel {
 
     private(set) var screenRecordingGranted: Bool = false
     private(set) var accessibilityGranted: Bool = false
+    private(set) var inputMonitoringGranted: Bool = false
     private(set) var cameraGranted: Bool = false
     private(set) var microphoneGranted: Bool = false
 
@@ -336,6 +337,17 @@ final class PreferencesViewModel {
         set {
             withMutation(keyPath: \.highlightClicks) {
                 settings.highlightClicks = newValue
+            }
+        }
+    }
+    var showKeyPressesWhileRecording: Bool {
+        get {
+            access(keyPath: \.showKeyPressesWhileRecording)
+            return settings.showKeyPressesWhileRecording
+        }
+        set {
+            withMutation(keyPath: \.showKeyPressesWhileRecording) {
+                settings.showKeyPressesWhileRecording = newValue
             }
         }
     }
@@ -672,6 +684,9 @@ final class PreferencesViewModel {
         case .accessibility:
             permissionManager.requestAccessibilityPermission()
             permissionManager.openSettings(for: kind)
+        case .inputMonitoring:
+            _ = permissionManager.requestInputMonitoringPermission()
+            permissionManager.openSettings(for: kind)
         case .camera:
             await permissionManager.requestCameraPermission()
         case .microphone:
@@ -687,6 +702,7 @@ final class PreferencesViewModel {
     private func updatePermissionSnapshot() {
         screenRecordingGranted = permissionManager.screenRecordingGranted
         accessibilityGranted = permissionManager.accessibilityGranted
+        inputMonitoringGranted = permissionManager.inputMonitoringGranted
         cameraGranted = permissionManager.cameraGranted
         microphoneGranted = permissionManager.microphoneGranted
     }

--- a/App/Sources/Preferences/Tabs/PermissionSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/PermissionSettingsView.swift
@@ -32,6 +32,13 @@ struct PermissionSettingsView: View {
                         showDivider: true
                     )
                     permissionRow(
+                        kind: .inputMonitoring,
+                        title: "Input Monitoring",
+                        subtitle: "Required to show key presses while recording",
+                        isGranted: viewModel.inputMonitoringGranted,
+                        showDivider: true
+                    )
+                    permissionRow(
                         kind: .camera,
                         title: "Camera",
                         subtitle: "Required for camera overlay",
@@ -93,7 +100,7 @@ struct PermissionSettingsView: View {
         switch kind {
         case .camera, .microphone:
             return "Request"
-        case .screenRecording, .accessibility:
+        case .screenRecording, .accessibility, .inputMonitoring:
             return "Open"
         }
     }
@@ -103,7 +110,7 @@ struct PermissionSettingsView: View {
         switch kind {
         case .camera, .microphone:
             return "hand.tap"
-        case .screenRecording, .accessibility:
+        case .screenRecording, .accessibility, .inputMonitoring:
             return "gearshape"
         }
     }

--- a/App/Sources/Preferences/Tabs/RecordingSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/RecordingSettingsView.swift
@@ -22,6 +22,15 @@ struct RecordingSettingsView: View {
                             .toggleStyle(.switch)
                             .controlSize(.small)
                     }
+                    SettingRow(
+                        label: "Show Key Presses",
+                        sublabel: "KeyCastr-style overlay of keys while recording. Requires Input Monitoring. Off by default.",
+                        showDivider: true
+                    ) {
+                        Toggle("", isOn: $viewModel.showKeyPressesWhileRecording)
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                    }
                     // TODO: Re-enable "Cursor Smoothing" once Bézier interpolation
                     // of the cursor path is actually implemented in the recording
                     // pipeline. AppSettings.cursorSmoothing is stored but never

--- a/App/Sources/Recording/KeyPressOverlayWindow.swift
+++ b/App/Sources/Recording/KeyPressOverlayWindow.swift
@@ -10,22 +10,34 @@ import SharedKit
 /// - After `keystrokeDelay` (~0.5s) idle, next key starts a new bezel
 /// - Each bezel fades after `fadeDelay` (~2s)
 /// - Resize via AppKit frames only (avoids SwiftUI display-cycle crashes)
+///
+/// Placement is relative to the active **display/area** recording frame so the HUD
+/// stays inside the capture. Window-target recording is not supported for this overlay.
 @MainActor
 final class KeyPressOverlayWindow: NSPanel {
     private let settings: AppSettings
+    /// Capture region in AppKit global coordinates (bottom-left origin).
+    private let recordingFrame: CGRect
     private var currentBezel: KeyPressBezelView?
-    private let margin: CGFloat = 24
+    private let margin: CGFloat = KeyPressOverlayPlacement.defaultMargin
     private let bezelSpacing: CGFloat = 10
     private let keystrokeDelay: TimeInterval = 0.5
     private let fadeDelay: TimeInterval = 2.0
     private let fadeDuration: TimeInterval = 0.2
     private let maxBezels = 6
 
-    init(settings: AppSettings, preferredScreen: NSScreen?) {
+    init(settings: AppSettings, recordingFrame: CGRect) {
         self.settings = settings
-        let screen = preferredScreen ?? NSScreen.main ?? NSScreen.screens.first!
-        let origin = Self.initialOrigin(settings: settings, screen: screen, margin: margin)
-        let frame = NSRect(origin: origin, size: NSSize(width: 80, height: 40))
+        self.recordingFrame = recordingFrame
+        let size = KeyPressOverlayPlacement.defaultSize
+        let origin = KeyPressOverlayPlacement.origin(
+            savedOffsetX: settings.keyPressOverlayOffsetX,
+            savedOffsetY: settings.keyPressOverlayOffsetY,
+            recordingFrame: recordingFrame,
+            size: size,
+            margin: KeyPressOverlayPlacement.defaultMargin
+        )
+        let frame = NSRect(origin: origin, size: size)
 
         super.init(
             contentRect: frame,
@@ -152,9 +164,8 @@ final class KeyPressOverlayWindow: NSPanel {
         guard let contentView else { return }
         let bezels = contentView.subviews.compactMap { $0 as? KeyPressBezelView }
         guard !bezels.isEmpty else {
-            var f = frame
-            f.size = NSSize(width: 80, height: 40)
-            setFrame(f, display: true)
+            let size = KeyPressOverlayPlacement.defaultSize
+            applyClampedFrame(CGRect(origin: frame.origin, size: size))
             return
         }
 
@@ -170,30 +181,40 @@ final class KeyPressOverlayWindow: NSPanel {
         }
 
         let height = max(40, y - bezelSpacing)
-        var windowFrame = frame
-        windowFrame.size = NSSize(width: maxWidth, height: height)
-        setFrame(windowFrame, display: true)
-        contentView.frame = NSRect(origin: .zero, size: windowFrame.size)
+        applyClampedFrame(CGRect(
+            x: frame.origin.x,
+            y: frame.origin.y,
+            width: maxWidth,
+            height: height
+        ))
+        contentView.frame = NSRect(origin: .zero, size: self.frame.size)
+    }
+
+    private func applyClampedFrame(_ proposed: CGRect) {
+        let clamped = KeyPressOverlayPlacement.clampedFrame(
+            proposed,
+            in: recordingFrame,
+            margin: margin
+        )
+        setFrame(clamped, display: true)
     }
 
     @objc private func handleMoved() {
-        settings.keyPressOverlayOriginX = frame.origin.x
-        settings.keyPressOverlayOriginY = frame.origin.y
-    }
-
-    private static func initialOrigin(
-        settings: AppSettings,
-        screen: NSScreen,
-        margin: CGFloat
-    ) -> NSPoint {
-        if let x = settings.keyPressOverlayOriginX, let y = settings.keyPressOverlayOriginY {
-            let point = NSPoint(x: x, y: y)
-            if screen.visibleFrame.insetBy(dx: -80, dy: -80).contains(point) {
-                return point
-            }
+        // Hard-clamp after drag so the HUD cannot leave the capture area.
+        let clamped = KeyPressOverlayPlacement.clampedFrame(
+            frame,
+            in: recordingFrame,
+            margin: margin
+        )
+        if clamped.origin != frame.origin {
+            setFrame(clamped, display: true)
         }
-        let visible = screen.visibleFrame
-        return NSPoint(x: visible.minX + margin, y: visible.minY + margin)
+        let off = KeyPressOverlayPlacement.offset(
+            windowOrigin: clamped.origin,
+            recordingFrame: recordingFrame
+        )
+        settings.keyPressOverlayOffsetX = off.x
+        settings.keyPressOverlayOffsetY = off.y
     }
 }
 

--- a/App/Sources/Recording/KeyPressOverlayWindow.swift
+++ b/App/Sources/Recording/KeyPressOverlayWindow.swift
@@ -37,7 +37,11 @@ final class KeyPressOverlayWindow: NSPanel {
             size: size,
             margin: KeyPressOverlayPlacement.defaultMargin
         )
-        let frame = NSRect(origin: origin, size: size)
+        let frame = KeyPressOverlayPlacement.clampedFrame(
+            NSRect(origin: origin, size: size),
+            in: recordingFrame,
+            margin: KeyPressOverlayPlacement.defaultMargin
+        )
 
         super.init(
             contentRect: frame,
@@ -206,7 +210,7 @@ final class KeyPressOverlayWindow: NSPanel {
             in: recordingFrame,
             margin: margin
         )
-        if clamped.origin != frame.origin {
+        if clamped != frame {
             setFrame(clamped, display: true)
         }
         let off = KeyPressOverlayPlacement.offset(

--- a/App/Sources/Recording/KeyPressOverlayWindow.swift
+++ b/App/Sources/Recording/KeyPressOverlayWindow.swift
@@ -1,0 +1,269 @@
+// App/Sources/Recording/KeyPressOverlayWindow.swift
+import AppKit
+import SharedKit
+
+/// Pure AppKit KeyCastr-style bezel window (no SwiftUI / NSHostingView).
+///
+/// Lessons from KeyCastr `KCDefaultVisualizerWindow` / `KCDefaultVisualizerBezelView`:
+/// - Borderless, high window level, movable by background, clear chrome
+/// - Append into the *current* bezel; ⌘/⌃ keystrokes start a new bezel
+/// - After `keystrokeDelay` (~0.5s) idle, next key starts a new bezel
+/// - Each bezel fades after `fadeDelay` (~2s)
+/// - Resize via AppKit frames only (avoids SwiftUI display-cycle crashes)
+@MainActor
+final class KeyPressOverlayWindow: NSPanel {
+    private let settings: AppSettings
+    private var currentBezel: KeyPressBezelView?
+    private let margin: CGFloat = 24
+    private let bezelSpacing: CGFloat = 10
+    private let keystrokeDelay: TimeInterval = 0.5
+    private let fadeDelay: TimeInterval = 2.0
+    private let fadeDuration: TimeInterval = 0.2
+    private let maxBezels = 6
+
+    init(settings: AppSettings, preferredScreen: NSScreen?) {
+        self.settings = settings
+        let screen = preferredScreen ?? NSScreen.main ?? NSScreen.screens.first!
+        let origin = Self.initialOrigin(settings: settings, screen: screen, margin: margin)
+        let frame = NSRect(origin: origin, size: NSSize(width: 80, height: 40))
+
+        super.init(
+            contentRect: frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        // KeyCastr uses NSScreenSaverWindowLevel so the HUD sits above almost everything.
+        self.level = .screenSaver
+        self.isOpaque = false
+        self.backgroundColor = .clear
+        self.hasShadow = false
+        self.collectionBehavior = [.canJoinAllSpaces, .transient]
+        self.isMovableByWindowBackground = true
+        self.sharingType = .readWrite
+        self.hidesOnDeactivate = false
+        self.ignoresMouseEvents = false
+
+        let root = NSView(frame: NSRect(origin: .zero, size: frame.size))
+        root.wantsLayer = true
+        root.layer?.backgroundColor = NSColor.clear.cgColor
+        self.contentView = root
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleMoved),
+            name: NSWindow.didMoveNotification,
+            object: self
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    func show() {
+        orderFrontRegardless()
+    }
+
+    func hideAndClose() {
+        NSObject.cancelPreviousPerformRequests(withTarget: self)
+        orderOut(nil)
+        close()
+    }
+
+    /// - Parameters:
+    ///   - text: formatted key label
+    ///   - isCommand: KeyCastr “command-ish” (⌘/⌃) — forces a new bezel line
+    func appendChip(_ text: String, isCommand: Bool = false) {
+        // Do not trim with `.whitespaces` — a real space key is shown as "␣",
+        // and accidental " " must not be wiped to empty.
+        guard !text.isEmpty else { return }
+
+        cancelLineBreak()
+        if isCommand {
+            abandonCurrentBezel()
+        }
+
+        if let currentBezel {
+            currentBezel.append(text)
+            currentBezel.scheduleFadeOut(delay: fadeDelay, duration: fadeDuration)
+        } else {
+            addNewBezel(text: text)
+        }
+        scheduleLineBreak()
+        layoutBezels()
+    }
+
+    // Convenience for older call sites.
+    func appendChip(_ text: String) {
+        // Heuristic: labels starting with ⌃/⌘ are command-ish.
+        let isCommand = text.contains("⌘") || text.contains("⌃")
+        appendChip(text, isCommand: isCommand)
+    }
+
+    // MARK: - Bezel management (KeyCastr)
+
+    private func addNewBezel(text: String) {
+        guard let contentView else { return }
+        let bezel = KeyPressBezelView(text: text)
+        bezel.onFullyFaded = { [weak self, weak bezel] in
+            guard let self, let bezel else { return }
+            if self.currentBezel === bezel {
+                self.currentBezel = nil
+            }
+            bezel.removeFromSuperview()
+            self.layoutBezels()
+        }
+        contentView.addSubview(bezel)
+        currentBezel = bezel
+        bezel.scheduleFadeOut(delay: fadeDelay, duration: fadeDuration)
+
+        // Drop oldest if too many.
+        let bezels = contentView.subviews.compactMap { $0 as? KeyPressBezelView }
+        if bezels.count > maxBezels {
+            for old in bezels.prefix(bezels.count - maxBezels) {
+                old.removeFromSuperview()
+            }
+        }
+    }
+
+    private func abandonCurrentBezel() {
+        currentBezel = nil
+    }
+
+    private func scheduleLineBreak() {
+        perform(#selector(abandonCurrentBezelObjC), with: nil, afterDelay: keystrokeDelay)
+    }
+
+    private func cancelLineBreak() {
+        NSObject.cancelPreviousPerformRequests(
+            withTarget: self,
+            selector: #selector(abandonCurrentBezelObjC),
+            object: nil
+        )
+    }
+
+    @objc private func abandonCurrentBezelObjC() {
+        abandonCurrentBezel()
+    }
+
+    private func layoutBezels() {
+        guard let contentView else { return }
+        let bezels = contentView.subviews.compactMap { $0 as? KeyPressBezelView }
+        guard !bezels.isEmpty else {
+            var f = frame
+            f.size = NSSize(width: 80, height: 40)
+            setFrame(f, display: true)
+            return
+        }
+
+        var y: CGFloat = 0
+        var maxWidth: CGFloat = 80
+        // Stack upward from bottom (KeyCastr grows height as bezels stack).
+        for bezel in bezels {
+            bezel.sizeToFitLabel()
+            let size = bezel.frame.size
+            bezel.frame = NSRect(x: 0, y: y, width: size.width, height: size.height)
+            maxWidth = max(maxWidth, size.width)
+            y += size.height + bezelSpacing
+        }
+
+        let height = max(40, y - bezelSpacing)
+        var windowFrame = frame
+        windowFrame.size = NSSize(width: maxWidth, height: height)
+        setFrame(windowFrame, display: true)
+        contentView.frame = NSRect(origin: .zero, size: windowFrame.size)
+    }
+
+    @objc private func handleMoved() {
+        settings.keyPressOverlayOriginX = frame.origin.x
+        settings.keyPressOverlayOriginY = frame.origin.y
+    }
+
+    private static func initialOrigin(
+        settings: AppSettings,
+        screen: NSScreen,
+        margin: CGFloat
+    ) -> NSPoint {
+        if let x = settings.keyPressOverlayOriginX, let y = settings.keyPressOverlayOriginY {
+            let point = NSPoint(x: x, y: y)
+            if screen.visibleFrame.insetBy(dx: -80, dy: -80).contains(point) {
+                return point
+            }
+        }
+        let visible = screen.visibleFrame
+        return NSPoint(x: visible.minX + margin, y: visible.minY + margin)
+    }
+}
+
+// MARK: - Bezel view (KeyCastr KCDefaultVisualizerBezelView simplified)
+
+@MainActor
+private final class KeyPressBezelView: NSView {
+    var onFullyFaded: (() -> Void)?
+
+    private let label = NSTextField(labelWithString: "")
+    private var fadeWorkItem: DispatchWorkItem?
+
+    init(text: String) {
+        super.init(frame: .zero)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.black.withAlphaComponent(0.78).cgColor
+        layer?.cornerRadius = 12
+        layer?.masksToBounds = true
+
+        label.stringValue = text
+        label.font = .systemFont(ofSize: 28, weight: .semibold)
+        label.textColor = .white
+        label.backgroundColor = .clear
+        label.isBezeled = false
+        label.isEditable = false
+        label.isSelectable = false
+        label.lineBreakMode = .byClipping
+        addSubview(label)
+        sizeToFitLabel()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    func append(_ text: String) {
+        label.stringValue += text
+        sizeToFitLabel()
+        needsDisplay = true
+    }
+
+    func sizeToFitLabel() {
+        label.sizeToFit()
+        let paddingH: CGFloat = 14
+        let paddingV: CGFloat = 10
+        let size = NSSize(
+            width: label.fittingSize.width + paddingH * 2,
+            height: label.fittingSize.height + paddingV * 2
+        )
+        setFrameSize(size)
+        label.frame = NSRect(
+            x: paddingH,
+            y: paddingV,
+            width: label.fittingSize.width,
+            height: label.fittingSize.height
+        )
+    }
+
+    func scheduleFadeOut(delay: TimeInterval, duration: TimeInterval) {
+        fadeWorkItem?.cancel()
+        alphaValue = 1
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            NSAnimationContext.runAnimationGroup({ ctx in
+                ctx.duration = duration
+                self.animator().alphaValue = 0
+            }, completionHandler: { [weak self] in
+                self?.onFullyFaded?()
+            })
+        }
+        fadeWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+    }
+}

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -871,6 +871,14 @@ final class RecordingCoordinator {
     private func startKeyPressOverlay() {
         guard settings.showKeyPressesWhileRecording else { return }
 
+        // Window-target capture only includes the selected app window, so Capso's HUD
+        // cannot appear in the file. Skip until we support compositing (if ever).
+        if case .window = selectedTarget {
+            return
+        }
+
+        guard let recordingFrame = appKitRecordingFrame() else { return }
+
         stopKeyPressOverlay()
 
         // Request Input Monitoring once so System Settings lists Capso.
@@ -881,7 +889,7 @@ final class RecordingCoordinator {
             }
         }
 
-        let window = KeyPressOverlayWindow(settings: settings, preferredScreen: selectedScreen)
+        let window = KeyPressOverlayWindow(settings: settings, recordingFrame: recordingFrame)
         window.show()
         keyPressOverlayWindow = window
 
@@ -894,6 +902,20 @@ final class RecordingCoordinator {
         }
         monitor.start()
         keyPressMonitor = monitor
+    }
+
+    /// Recording selection as an AppKit global frame (bottom-left origin).
+    /// Shared by controls, border, PiP, and the key-press HUD.
+    private func appKitRecordingFrame() -> CGRect? {
+        guard let screen = selectedScreen else { return nil }
+        let screenFrame = screen.frame
+        let viewY = screenFrame.height - selectedRect.origin.y - selectedRect.height
+        return CGRect(
+            x: selectedRect.origin.x + screenFrame.origin.x,
+            y: viewY + screenFrame.origin.y,
+            width: selectedRect.width,
+            height: selectedRect.height
+        )
     }
 
     private func stopKeyPressOverlay() {
@@ -959,16 +981,8 @@ final class RecordingCoordinator {
     }
 
     private func showRecordingControls() {
-        guard let screen = selectedScreen else { return }
-
-        let screenFrame = screen.frame
-        let viewY = screenFrame.height - selectedRect.origin.y - selectedRect.height
-        let recordingFrame = CGRect(
-            x: selectedRect.origin.x + screenFrame.origin.x,
-            y: viewY + screenFrame.origin.y,
-            width: selectedRect.width,
-            height: selectedRect.height
-        )
+        guard let screen = selectedScreen,
+              let recordingFrame = appKitRecordingFrame() else { return }
 
         controlsWindow = RecordingControlsWindow(
             recordingFrame: recordingFrame,
@@ -982,21 +996,13 @@ final class RecordingCoordinator {
     }
 
     private func showBorder() {
-        guard let screen = selectedScreen else { return }
-        // Convert selectedRect (display-local top-down) back to global AppKit
-        // coordinates for the border window's frame.
-        let screenFrame = screen.frame
-        let viewY = screenFrame.height - selectedRect.origin.y - selectedRect.height
+        guard let screen = selectedScreen,
+              let recordingFrame = appKitRecordingFrame() else { return }
         // Expand the border frame outward by the border width (3pt) so the
         // border is drawn entirely OUTSIDE the capture area. This prevents
         // ScreenCaptureKit from capturing the red border in the recording.
         let borderInset: CGFloat = 3
-        let borderFrame = CGRect(
-            x: selectedRect.origin.x + screenFrame.origin.x - borderInset,
-            y: viewY + screenFrame.origin.y - borderInset,
-            width: selectedRect.width + borderInset * 2,
-            height: selectedRect.height + borderInset * 2
-        )
+        let borderFrame = recordingFrame.insetBy(dx: -borderInset, dy: -borderInset)
         borderWindow = RecordingBorderWindow(frame: borderFrame, screen: screen)
         borderWindow?.show()
     }
@@ -1007,21 +1013,10 @@ final class RecordingCoordinator {
         cameraPiPWindow?.close()
         cameraPiPWindow = nil
 
-        var recordingFrame: CGRect?
-        if let screen = selectedScreen {
-            let screenFrame = screen.frame
-            let viewY = screenFrame.height - selectedRect.origin.y - selectedRect.height
-            recordingFrame = CGRect(
-                x: selectedRect.origin.x + screenFrame.origin.x,
-                y: viewY + screenFrame.origin.y,
-                width: selectedRect.width,
-                height: selectedRect.height
-            )
-        }
         cameraPiPWindow = CameraPiPWindow(
             cameraManager: cameraManager,
             settings: settings,
-            recordingFrame: recordingFrame,
+            recordingFrame: appKitRecordingFrame(),
             restorationState: restorationState
         )
         cameraPiPWindow?.show()

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -493,6 +493,11 @@ final class RecordingCoordinator {
             showCameraPiP(restorationState: restoredCameraPiPState)
         }
 
+        // Preflight Input Monitoring *before* capture so any System Settings
+        // prompt / alert is not baked into the recording. If denied, the session
+        // still records — just without the key HUD.
+        let keyPressOverlayReady = prepareKeyPressOverlayPermission()
+
         let actuallyStart: @MainActor () -> Void = { [weak self] in
             guard let self else { return }
             Task { @MainActor in
@@ -510,7 +515,9 @@ final class RecordingCoordinator {
                     }
                     try await self.recorder.startRecording(config: config, excludeWindowIDs: excludeIDs)
                     self.startClickHighlight()
-                    self.startKeyPressOverlay()
+                    if keyPressOverlayReady {
+                        self.startKeyPressOverlay()
+                    }
                     self.startCursorTelemetry()
                     self.showRecordingControls()
                 } catch {
@@ -868,26 +875,40 @@ final class RecordingCoordinator {
         clickHighlightWindow = nil
     }
 
-    private func startKeyPressOverlay() {
-        guard settings.showKeyPressesWhileRecording else { return }
+    /// Ensures Input Monitoring is available when the key HUD is enabled.
+    /// Must run **before** capture starts so permission UI is not recorded.
+    /// Returns `false` when the overlay should not be shown (setting off, window
+    /// target, or permission denied / continue without overlay).
+    private func prepareKeyPressOverlayPermission() -> Bool {
+        guard settings.showKeyPressesWhileRecording else { return false }
 
         // Window-target capture only includes the selected app window, so Capso's HUD
         // cannot appear in the file. Skip until we support compositing (if ever).
         if case .window = selectedTarget {
-            return
+            return false
         }
 
+        let permissions = PermissionManager()
+        if permissions.requestInputMonitoringPermission() {
+            return true
+        }
+
+        showInputMonitoringNeededAlert(permissions: permissions)
+        permissions.checkInputMonitoringPermission()
+        return permissions.inputMonitoringGranted
+    }
+
+    private func startKeyPressOverlay() {
+        guard settings.showKeyPressesWhileRecording else { return }
+        if case .window = selectedTarget { return }
         guard let recordingFrame = appKitRecordingFrame() else { return }
 
-        stopKeyPressOverlay()
+        // Permission was preflighted before capture; never create the HUD without access.
+        let permissions = PermissionManager()
+        permissions.checkInputMonitoringPermission()
+        guard permissions.inputMonitoringGranted else { return }
 
-        // Request Input Monitoring once so System Settings lists Capso.
-        if !CGPreflightListenEventAccess() {
-            _ = CGRequestListenEventAccess()
-            if !CGPreflightListenEventAccess() {
-                showInputMonitoringNeededAlert()
-            }
-        }
+        stopKeyPressOverlay()
 
         let window = KeyPressOverlayWindow(settings: settings, recordingFrame: recordingFrame)
         window.show()
@@ -925,7 +946,7 @@ final class RecordingCoordinator {
         keyPressOverlayWindow = nil
     }
 
-    private func showInputMonitoringNeededAlert() {
+    private func showInputMonitoringNeededAlert(permissions: PermissionManager) {
         let alert = NSAlert()
         alert.alertStyle = .informational
         alert.messageText = String(localized: "Input Monitoring Needed")
@@ -935,8 +956,10 @@ final class RecordingCoordinator {
         alert.window.level = .screenSaver + 2
         let response = alert.runModal()
         if response == .alertFirstButtonReturn {
-            PermissionManager().openInputMonitoringSettings()
+            permissions.openInputMonitoringSettings()
         }
+        // "Continue Without Overlay" (and Settings without granting) → caller
+        // re-checks permission and skips starting the HUD.
     }
 
     private func startCursorTelemetry() {

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -18,6 +18,16 @@ import EffectsKit
 import EditorKit
 import ShareKit
 
+enum KeyPressOverlayPermissionDecision: Equatable {
+    case showOverlay
+    case continueWithoutOverlay
+    case cancelRecording
+
+    static func forAlertResponse(_ response: NSApplication.ModalResponse) -> Self {
+        response == .alertFirstButtonReturn ? .cancelRecording : .continueWithoutOverlay
+    }
+}
+
 /// Orchestrates recording flow:
 /// 1. Show overlay for area selection (drag, or Space to switch to window selection)
 /// 2. Show recording toolbar (format, camera, mic, audio)
@@ -469,6 +479,17 @@ final class RecordingCoordinator {
         systemAudioEnabled: Bool,
         restoredCameraPiPState: CameraPiPRestorationState? = nil
     ) {
+        // Resolve Input Monitoring before creating any recording UI. Opening
+        // System Settings cancels this attempt, as the alert instructs the user
+        // to grant access and start recording again.
+        let keyPressOverlayDecision = prepareKeyPressOverlayPermission()
+        guard keyPressOverlayDecision != .cancelRecording else {
+            dismissToolbarUI()
+            selectedTarget = nil
+            return
+        }
+        let keyPressOverlayReady = keyPressOverlayDecision == .showOverlay
+
         currentRecordingFormat = format
         currentCameraEnabled = cameraEnabled
         currentMicEnabled = micEnabled
@@ -492,11 +513,6 @@ final class RecordingCoordinator {
             try? cameraManager.start()
             showCameraPiP(restorationState: restoredCameraPiPState)
         }
-
-        // Preflight Input Monitoring *before* capture so any System Settings
-        // prompt / alert is not baked into the recording. If denied, the session
-        // still records — just without the key HUD.
-        let keyPressOverlayReady = prepareKeyPressOverlayPermission()
 
         let actuallyStart: @MainActor () -> Void = { [weak self] in
             guard let self else { return }
@@ -877,25 +893,23 @@ final class RecordingCoordinator {
 
     /// Ensures Input Monitoring is available when the key HUD is enabled.
     /// Must run **before** capture starts so permission UI is not recorded.
-    /// Returns `false` when the overlay should not be shown (setting off, window
-    /// target, or permission denied / continue without overlay).
-    private func prepareKeyPressOverlayPermission() -> Bool {
-        guard settings.showKeyPressesWhileRecording else { return false }
+    /// Returns whether this attempt should show the overlay, continue without
+    /// it, or stop so the user can grant access and start recording again.
+    private func prepareKeyPressOverlayPermission() -> KeyPressOverlayPermissionDecision {
+        guard settings.showKeyPressesWhileRecording else { return .continueWithoutOverlay }
 
         // Window-target capture only includes the selected app window, so Capso's HUD
         // cannot appear in the file. Skip until we support compositing (if ever).
         if case .window = selectedTarget {
-            return false
+            return .continueWithoutOverlay
         }
 
         let permissions = PermissionManager()
         if permissions.requestInputMonitoringPermission() {
-            return true
+            return .showOverlay
         }
 
-        showInputMonitoringNeededAlert(permissions: permissions)
-        permissions.checkInputMonitoringPermission()
-        return permissions.inputMonitoringGranted
+        return showInputMonitoringNeededAlert(permissions: permissions)
     }
 
     private func startKeyPressOverlay() {
@@ -946,7 +960,9 @@ final class RecordingCoordinator {
         keyPressOverlayWindow = nil
     }
 
-    private func showInputMonitoringNeededAlert(permissions: PermissionManager) {
+    private func showInputMonitoringNeededAlert(
+        permissions: PermissionManager
+    ) -> KeyPressOverlayPermissionDecision {
         let alert = NSAlert()
         alert.alertStyle = .informational
         alert.messageText = String(localized: "Input Monitoring Needed")
@@ -955,11 +971,11 @@ final class RecordingCoordinator {
         alert.addButton(withTitle: String(localized: "Continue Without Overlay"))
         alert.window.level = .screenSaver + 2
         let response = alert.runModal()
-        if response == .alertFirstButtonReturn {
+        let decision = KeyPressOverlayPermissionDecision.forAlertResponse(response)
+        if decision == .cancelRecording {
             permissions.openInputMonitoringSettings()
         }
-        // "Continue Without Overlay" (and Settings without granting) → caller
-        // re-checks permission and skips starting the HUD.
+        return decision
     }
 
     private func startCursorTelemetry() {

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -44,6 +44,8 @@ final class RecordingCoordinator {
     private var clickMonitor: ClickMonitor?
     private var cursorTelemetry: CursorTelemetry?
     private var clickHighlightWindow: ClickHighlightWindow?
+    private var keyPressMonitor: KeyPressMonitor?
+    private var keyPressOverlayWindow: KeyPressOverlayWindow?
     private var countdownWindow: CountdownWindow?
     private var escGlobalMonitor: Any?
     private var escLocalMonitor: Any?
@@ -508,6 +510,7 @@ final class RecordingCoordinator {
                     }
                     try await self.recorder.startRecording(config: config, excludeWindowIDs: excludeIDs)
                     self.startClickHighlight()
+                    self.startKeyPressOverlay()
                     self.startCursorTelemetry()
                     self.showRecordingControls()
                 } catch {
@@ -865,6 +868,55 @@ final class RecordingCoordinator {
         clickHighlightWindow = nil
     }
 
+    private func startKeyPressOverlay() {
+        guard settings.showKeyPressesWhileRecording else { return }
+
+        stopKeyPressOverlay()
+
+        // Request Input Monitoring once so System Settings lists Capso.
+        if !CGPreflightListenEventAccess() {
+            _ = CGRequestListenEventAccess()
+            if !CGPreflightListenEventAccess() {
+                showInputMonitoringNeededAlert()
+            }
+        }
+
+        let window = KeyPressOverlayWindow(settings: settings, preferredScreen: selectedScreen)
+        window.show()
+        keyPressOverlayWindow = window
+
+        let monitor = KeyPressMonitor()
+        // Prefer detailed callback so command-ish keys (⌘/⌃) start a new bezel line (KeyCastr).
+        monitor.onKeyDisplayDetailed = { [weak self] label, isCommand in
+            Task { @MainActor in
+                self?.keyPressOverlayWindow?.appendChip(label, isCommand: isCommand)
+            }
+        }
+        monitor.start()
+        keyPressMonitor = monitor
+    }
+
+    private func stopKeyPressOverlay() {
+        keyPressMonitor?.stop()
+        keyPressMonitor = nil
+        keyPressOverlayWindow?.hideAndClose()
+        keyPressOverlayWindow = nil
+    }
+
+    private func showInputMonitoringNeededAlert() {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = String(localized: "Input Monitoring Needed")
+        alert.informativeText = String(localized: "To show key presses while recording, enable Capso in System Settings > Privacy & Security > Input Monitoring, then start recording again.")
+        alert.addButton(withTitle: String(localized: "Open Input Monitoring Settings"))
+        alert.addButton(withTitle: String(localized: "Continue Without Overlay"))
+        alert.window.level = .screenSaver + 2
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn {
+            PermissionManager().openInputMonitoringSettings()
+        }
+    }
+
     private func startCursorTelemetry() {
         // CursorTelemetry normalizes CGEvent positions, which are in global
         // TOP-LEFT origin. `selectedRect` is in display-local top-left origin
@@ -1000,6 +1052,7 @@ final class RecordingCoordinator {
 
     private func hideRecordingUI() {
         stopClickHighlight()
+        stopKeyPressOverlay()
         cursorTelemetry?.stop()
         cursorTelemetry = nil
         controlsWindow?.close()

--- a/App/Tests/KeyPressOverlayPermissionDecisionTests.swift
+++ b/App/Tests/KeyPressOverlayPermissionDecisionTests.swift
@@ -1,0 +1,19 @@
+import AppKit
+import XCTest
+@testable import Capso
+
+final class KeyPressOverlayPermissionDecisionTests: XCTestCase {
+    func testOpeningSettingsCancelsCurrentRecordingAttempt() {
+        XCTAssertEqual(
+            KeyPressOverlayPermissionDecision.forAlertResponse(.alertFirstButtonReturn),
+            .cancelRecording
+        )
+    }
+
+    func testContinueWithoutOverlayKeepsCurrentRecordingAttempt() {
+        XCTAssertEqual(
+            KeyPressOverlayPermissionDecision.forAlertResponse(.alertSecondButtonReturn),
+            .continueWithoutOverlay
+        )
+    }
+}

--- a/Packages/EffectsKit/Sources/EffectsKit/EffectsKit.swift
+++ b/Packages/EffectsKit/Sources/EffectsKit/EffectsKit.swift
@@ -1,2 +1,2 @@
 // EffectsKit — Recording effects for Capso
-// Public API: ClickMonitor, ClickHighlightWindow
+// Public API: ClickMonitor, ClickHighlightWindow, KeyPressMonitor, KeystrokeFormatter

--- a/Packages/EffectsKit/Sources/EffectsKit/KeyPressMonitor.swift
+++ b/Packages/EffectsKit/Sources/EffectsKit/KeyPressMonitor.swift
@@ -8,6 +8,8 @@ import CoreGraphics
 /// 1. Prefer a **listen-only** `CGEventTap` at the session level (same as KeyCastr)
 /// 2. Re-enable the tap if macOS disables it (`tapDisabledByTimeout` / user input)
 /// 3. Fall back to `NSEvent` global+local monitors if the tap cannot be created
+///
+/// KeyCastr is BSD-3-Clause; see `KeystrokeFormatter` and `THIRD_PARTY_NOTICES.md`.
 public final class KeyPressMonitor: @unchecked Sendable {
     public var onKeyDisplay: (@Sendable (String) -> Void)?
     /// Emits `true` for command-ish keystrokes (⌘/⌃) so the UI can break bezel lines.

--- a/Packages/EffectsKit/Sources/EffectsKit/KeyPressMonitor.swift
+++ b/Packages/EffectsKit/Sources/EffectsKit/KeyPressMonitor.swift
@@ -1,0 +1,138 @@
+import AppKit
+import CoreGraphics
+
+/// Monitors global keyboard events during screen recording and emits
+/// KeyCastr-style display strings for each key-down.
+///
+/// Capture strategy (KeyCastr `KCEventTap` + Capso click-monitor lessons):
+/// 1. Prefer a **listen-only** `CGEventTap` at the session level (same as KeyCastr)
+/// 2. Re-enable the tap if macOS disables it (`tapDisabledByTimeout` / user input)
+/// 3. Fall back to `NSEvent` global+local monitors if the tap cannot be created
+public final class KeyPressMonitor: @unchecked Sendable {
+    public var onKeyDisplay: (@Sendable (String) -> Void)?
+    /// Emits `true` for command-ish keystrokes (⌘/⌃) so the UI can break bezel lines.
+    public var onKeyDisplayDetailed: (@Sendable (_ label: String, _ isCommand: Bool) -> Void)?
+
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private var globalMonitor: Any?
+    private var localMonitor: Any?
+    private var useEventTap = false
+
+    public init() {}
+
+    public func start() {
+        guard eventTap == nil, globalMonitor == nil, localMonitor == nil else { return }
+        if installEventTap() {
+            useEventTap = true
+            return
+        }
+        useEventTap = false
+        installNSEventMonitors()
+    }
+
+    public func stop() {
+        removeEventTap()
+        if let m = globalMonitor {
+            NSEvent.removeMonitor(m)
+            globalMonitor = nil
+        }
+        if let m = localMonitor {
+            NSEvent.removeMonitor(m)
+            localMonitor = nil
+        }
+    }
+
+    deinit {
+        // Best-effort cleanup off-main.
+        if let m = globalMonitor { NSEvent.removeMonitor(m) }
+        if let m = localMonitor { NSEvent.removeMonitor(m) }
+        if let source = runLoopSource {
+            CFRunLoopSourceInvalidate(source)
+        }
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+        }
+    }
+
+    // MARK: - CGEventTap (KeyCastr path)
+
+    private func installEventTap() -> Bool {
+        let mask = (1 << CGEventType.keyDown.rawValue) | (1 << CGEventType.keyUp.rawValue)
+        let callback: CGEventTapCallBack = { proxy, type, event, refcon in
+            guard let refcon else { return Unmanaged.passUnretained(event) }
+            let monitor = Unmanaged<KeyPressMonitor>.fromOpaque(refcon).takeUnretainedValue()
+            return monitor.handleTap(proxy: proxy, type: type, event: event)
+        }
+
+        guard let tap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .listenOnly,
+            eventsOfInterest: CGEventMask(mask),
+            callback: callback,
+            userInfo: Unmanaged.passUnretained(self).toOpaque()
+        ) else {
+            return false
+        }
+
+        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
+        CGEvent.tapEnable(tap: tap, enable: true)
+        eventTap = tap
+        runLoopSource = source
+        return true
+    }
+
+    private func removeEventTap() {
+        if let source = runLoopSource {
+            CFRunLoopSourceInvalidate(source)
+            runLoopSource = nil
+        }
+        if let tap = eventTap {
+            CGEvent.tapEnable(tap: tap, enable: false)
+            eventTap = nil
+        }
+    }
+
+    private func handleTap(
+        proxy: CGEventTapProxy,
+        type: CGEventType,
+        event: CGEvent
+    ) -> Unmanaged<CGEvent>? {
+        // KeyCastr returns the event unchanged (listen-only).
+        if type == .tapDisabledByTimeout || type == .tapDisabledByUserInput {
+            if let tap = eventTap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
+            return Unmanaged.passUnretained(event)
+        }
+
+        if type == .keyDown {
+            if let nsEvent = NSEvent(cgEvent: event) {
+                emit(from: nsEvent)
+            }
+        }
+        return Unmanaged.passUnretained(event)
+    }
+
+    // MARK: - NSEvent fallback
+
+    private func installNSEventMonitors() {
+        let mask: NSEvent.EventTypeMask = [.keyDown]
+        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: mask) { [weak self] event in
+            self?.emit(from: event)
+        }
+        localMonitor = NSEvent.addLocalMonitorForEvents(matching: mask) { [weak self] event in
+            self?.emit(from: event)
+            return event
+        }
+    }
+
+    private func emit(from event: NSEvent) {
+        let keystroke = KeystrokeFormatter.Keystroke(event: event)
+        guard let label = KeystrokeFormatter.displayString(for: keystroke) else { return }
+        onKeyDisplayDetailed?(label, keystroke.isCommand)
+        onKeyDisplay?(label)
+    }
+}

--- a/Packages/EffectsKit/Sources/EffectsKit/KeyPressMonitor.swift
+++ b/Packages/EffectsKit/Sources/EffectsKit/KeyPressMonitor.swift
@@ -130,8 +130,10 @@ public final class KeyPressMonitor: @unchecked Sendable {
     }
 
     private func emit(from event: NSEvent) {
+        // Use the NSEvent overload so autorepeats (`isARepeat`) are dropped —
+        // the Keystroke-only path has no repeat flag and would flood the bezel.
+        guard let label = KeystrokeFormatter.displayString(for: event) else { return }
         let keystroke = KeystrokeFormatter.Keystroke(event: event)
-        guard let label = KeystrokeFormatter.displayString(for: keystroke) else { return }
         onKeyDisplayDetailed?(label, keystroke.isCommand)
         onKeyDisplay?(label)
     }

--- a/Packages/EffectsKit/Sources/EffectsKit/KeystrokeFormatter.swift
+++ b/Packages/EffectsKit/Sources/EffectsKit/KeystrokeFormatter.swift
@@ -2,6 +2,40 @@ import AppKit
 import Carbon.HIToolbox
 import CoreServices
 
+// Keystroke label mapping is adapted from KeyCastr
+// (https://github.com/keycastr/keycastr), which is licensed under the
+// BSD 3-Clause License. Portions of the special-key table and transform
+// rules follow `KCEventTransformer` / `KCKeystroke`.
+//
+// Copyright (c) 2009 Stephen Deken.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//  * Redistributions of source code must retain the above copyright notice,
+//    this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//  * Neither the name KeyCastr nor the names of its contributors may be used
+//    to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+// Full third-party notices: see THIRD_PARTY_NOTICES.md at the repository root.
+
 /// Maps key-down events into KeyCastr-style display labels.
 ///
 /// Aligned with KeyCastr `KCEventTransformer` / `KCKeystroke`:

--- a/Packages/EffectsKit/Sources/EffectsKit/KeystrokeFormatter.swift
+++ b/Packages/EffectsKit/Sources/EffectsKit/KeystrokeFormatter.swift
@@ -8,6 +8,7 @@ import CoreServices
 // rules follow `KCEventTransformer` / `KCKeystroke`.
 //
 // Copyright (c) 2009 Stephen Deken.
+// Copyright (c) 2017-2024 Andrew Kitchen.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/Packages/EffectsKit/Sources/EffectsKit/KeystrokeFormatter.swift
+++ b/Packages/EffectsKit/Sources/EffectsKit/KeystrokeFormatter.swift
@@ -1,0 +1,167 @@
+import AppKit
+import Carbon.HIToolbox
+import CoreServices
+
+/// Maps key-down events into KeyCastr-style display labels.
+///
+/// Aligned with KeyCastr `KCEventTransformer` / `KCKeystroke`:
+/// - Modifier order: ⌃ ⌥ ⇧ ⌘
+/// - “Command-ish” = ⌘ or ⌃ (uppercase + break bezel line upstream)
+/// - Body via `UCKeyTranslate` for the current keyboard layout
+/// - Special keys use KeyCastr’s keyCode → glyph table
+public enum KeystrokeFormatter {
+    public struct Keystroke: Sendable, Equatable {
+        public let keyCode: UInt16
+        public let characters: String
+        public let charactersIgnoringModifiers: String
+        public let modifierFlags: NSEvent.ModifierFlags
+
+        public init(
+            keyCode: UInt16,
+            characters: String,
+            charactersIgnoringModifiers: String,
+            modifierFlags: NSEvent.ModifierFlags
+        ) {
+            self.keyCode = keyCode
+            self.characters = characters
+            self.charactersIgnoringModifiers = charactersIgnoringModifiers
+            self.modifierFlags = modifierFlags.intersection(.deviceIndependentFlagsMask)
+        }
+
+        public init(event: NSEvent) {
+            self.init(
+                keyCode: event.keyCode,
+                characters: event.characters ?? "",
+                charactersIgnoringModifiers: event.charactersIgnoringModifiers ?? "",
+                modifierFlags: event.modifierFlags
+            )
+        }
+
+        /// KeyCastr: Control OR Command.
+        public var isCommand: Bool {
+            modifierFlags.contains(.control) || modifierFlags.contains(.command)
+        }
+
+        public var isModified: Bool {
+            !modifierFlags.intersection([.control, .command, .option, .shift]).isEmpty
+        }
+    }
+
+    public static func displayString(for event: NSEvent) -> String? {
+        guard event.type == .keyDown, !event.isARepeat else { return nil }
+        return displayString(for: Keystroke(event: event))
+    }
+
+    public static func displayString(for keystroke: Keystroke) -> String? {
+        if isModifierKeyCode(Int(keystroke.keyCode)) { return nil }
+        return transform(keystroke)
+    }
+
+    // MARK: - Transform (KeyCastr KCEventTransformer)
+
+    private static func transform(_ keystroke: Keystroke) -> String {
+        let flags = keystroke.modifierFlags
+        let hasOption = flags.contains(.option)
+        let hasShift = flags.contains(.shift)
+        let isCommand = keystroke.isCommand
+
+        // KeyCastr modifier order: Control, Option, Shift, Command.
+        var response = ""
+        if flags.contains(.control) { response += "⌃" }
+        if hasOption { response += "⌥" }
+        if hasShift { response += "⇧" }
+        if flags.contains(.command) { response += "⌘" }
+
+        // Bare shift-tab → left tab (KeyCastr special case).
+        if hasShift, !isCommand, !hasOption, Int(keystroke.keyCode) == kVK_Tab {
+            return "⇧⇤"
+        }
+
+        if let special = specialKeys[Int(keystroke.keyCode)] {
+            return response + special
+        }
+
+        var body = translateKeyCode(keystroke.keyCode)
+        if body.isEmpty {
+            body = keystroke.charactersIgnoringModifiers
+        }
+        if body.isEmpty {
+            body = keystroke.characters
+        }
+        if body.isEmpty {
+            body = "?"
+        }
+        response += body
+
+        // Commands / shifted keystrokes uppercased (KeyCastr skips keyCode 27).
+        if (isCommand || hasShift), keystroke.keyCode != 27 {
+            response = response.uppercased()
+        }
+        return response
+    }
+
+    private static func translateKeyCode(_ keyCode: UInt16) -> String {
+        guard let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue() else {
+            return ""
+        }
+        guard let cfDataPtr = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
+            return ""
+        }
+        let data = Unmanaged<CFData>.fromOpaque(cfDataPtr).takeUnretainedValue() as Data
+        return data.withUnsafeBytes { raw -> String in
+            guard let base = raw.bindMemory(to: UCKeyboardLayout.self).baseAddress else { return "" }
+            var deadKeyState: UInt32 = 0
+            var chars = [UniChar](repeating: 0, count: 4)
+            var actualLength = 0
+            let status = chars.withUnsafeMutableBufferPointer { buffer -> OSStatus in
+                var length = 0
+                let result = UCKeyTranslate(
+                    base,
+                    keyCode,
+                    UInt16(kUCKeyActionDisplay),
+                    0,
+                    UInt32(LMGetKbdType()),
+                    OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                    &deadKeyState,
+                    buffer.count,
+                    &length,
+                    buffer.baseAddress
+                )
+                actualLength = length
+                return result
+            }
+            guard status == noErr, actualLength > 0 else { return "" }
+            return String(utf16CodeUnits: chars, count: actualLength)
+        }
+    }
+
+    private static func isModifierKeyCode(_ keyCode: Int) -> Bool {
+        switch keyCode {
+        case kVK_Shift, kVK_RightShift,
+             kVK_Command, kVK_RightCommand,
+             kVK_Option, kVK_RightOption,
+             kVK_Control, kVK_RightControl,
+             kVK_Function, kVK_CapsLock:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// KeyCastr `_specialKeys` table.
+    /// Space uses U+2423 OPEN BOX (␣), matching KeyCastr — never the word "Space",
+    /// which glued into typing as `SpaceSpacezxcss`.
+    private static let specialKeys: [Int: String] = [
+        126: "↑", 125: "↓", 124: "→", 123: "←",
+        48: "⇥", 53: "⎋", 71: "⌧", 51: "⌫", 117: "⌦",
+        115: "↖", 119: "↘", 116: "⇞", 121: "⇟",
+        36: "↩", 76: "↩",
+        49: "␣", // open box (KeyCastr space glyph)
+        122: "F1", 120: "F2", 99: "F3", 118: "F4",
+        96: "F5", 97: "F6", 98: "F7", 100: "F8",
+        101: "F9", 109: "F10", 103: "F11", 111: "F12",
+        105: "F13", 107: "F14", 113: "F15", 106: "F16",
+        64: "F17", 79: "F18", 80: "F19", 90: "F20",
+        0x66: "英数", 0x68: "かな",
+    ]
+}

--- a/Packages/EffectsKit/Tests/EffectsKitTests/KeystrokeFormatterTests.swift
+++ b/Packages/EffectsKit/Tests/EffectsKitTests/KeystrokeFormatterTests.swift
@@ -1,0 +1,133 @@
+import AppKit
+import Carbon.HIToolbox
+import Testing
+@testable import EffectsKit
+
+@Suite("KeystrokeFormatter")
+struct KeystrokeFormatterTests {
+    @Test("Ignores non key-down events")
+    func ignoresNonKeyDown() {
+        let event = NSEvent.keyEvent(
+            with: .flagsChanged,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: UInt16(kVK_Command)
+        )
+        #expect(event.flatMap { KeystrokeFormatter.displayString(for: $0) } == nil)
+    }
+
+    @Test("Formats command-letter shortcuts")
+    func formatsCommandLetterShortcuts() throws {
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "c",
+            charactersIgnoringModifiers: "c",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_C)
+        ))
+        let label = try #require(KeystrokeFormatter.displayString(for: event))
+        #expect(label.contains("⌘"))
+        #expect(label.uppercased().contains("C"))
+    }
+
+    @Test("Formats special keys")
+    func formatsSpecialKeys() throws {
+        let space = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: " ",
+            charactersIgnoringModifiers: " ",
+            isARepeat: false,
+            keyCode: UInt16(kVK_Space)
+        ))
+        // KeyCastr uses U+2423 OPEN BOX, not the word "Space".
+        #expect(KeystrokeFormatter.displayString(for: space) == "␣")
+
+        let esc = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "\u{1B}",
+            charactersIgnoringModifiers: "\u{1B}",
+            isARepeat: false,
+            keyCode: UInt16(kVK_Escape)
+        ))
+        #expect(KeystrokeFormatter.displayString(for: esc) == "⎋")
+    }
+
+    @Test("Skips key repeats and pure modifier keys")
+    func skipsRepeatsAndModifiers() throws {
+        let repeatEvent = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "a",
+            charactersIgnoringModifiers: "a",
+            isARepeat: true,
+            keyCode: UInt16(kVK_ANSI_A)
+        ))
+        #expect(KeystrokeFormatter.displayString(for: repeatEvent) == nil)
+
+        let shiftOnly = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.shift],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: UInt16(kVK_Shift)
+        ))
+        #expect(KeystrokeFormatter.displayString(for: shiftOnly) == nil)
+    }
+
+    @Test("Keystroke isCommand matches KeyCastr Control-or-Command rule")
+    func isCommandRule() {
+        let cmd = KeystrokeFormatter.Keystroke(
+            keyCode: UInt16(kVK_ANSI_C),
+            characters: "c",
+            charactersIgnoringModifiers: "c",
+            modifierFlags: [.command]
+        )
+        #expect(cmd.isCommand)
+
+        let ctrl = KeystrokeFormatter.Keystroke(
+            keyCode: UInt16(kVK_ANSI_C),
+            characters: "c",
+            charactersIgnoringModifiers: "c",
+            modifierFlags: [.control]
+        )
+        #expect(ctrl.isCommand)
+
+        let plain = KeystrokeFormatter.Keystroke(
+            keyCode: UInt16(kVK_ANSI_C),
+            characters: "c",
+            charactersIgnoringModifiers: "c",
+            modifierFlags: []
+        )
+        #expect(!plain.isCommand)
+    }
+}

--- a/Packages/SharedKit/Sources/SharedKit/Permissions/PermissionManager.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Permissions/PermissionManager.swift
@@ -1,11 +1,13 @@
 import AppKit
 import AVFoundation
+import CoreGraphics
 import Observation
 @preconcurrency import ScreenCaptureKit
 
 public enum PermissionKind: String, CaseIterable, Sendable {
     case screenRecording
     case accessibility
+    case inputMonitoring
     case camera
     case microphone
 
@@ -15,6 +17,9 @@ public enum PermissionKind: String, CaseIterable, Sendable {
             return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!
         case .accessibility:
             return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
+        case .inputMonitoring:
+            // Input Monitoring pane (ListenEvent) — required for global keystroke visualizer.
+            return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent")!
         case .camera:
             return URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera")!
         case .microphone:
@@ -30,12 +35,14 @@ public final class PermissionManager {
     public private(set) var cameraGranted: Bool = false
     public private(set) var microphoneGranted: Bool = false
     public private(set) var accessibilityGranted: Bool = false
+    public private(set) var inputMonitoringGranted: Bool = false
 
     public init() {}
 
     public func refreshAll() async {
         await checkScreenRecordingPermission()
         checkAccessibilityPermission()
+        checkInputMonitoringPermission()
         checkCameraPermission()
         checkMicrophonePermission()
     }
@@ -101,6 +108,25 @@ public final class PermissionManager {
         accessibilityGranted = AXIsProcessTrustedWithOptions(options)
     }
 
+    // MARK: - Input Monitoring
+
+    public func checkInputMonitoringPermission() {
+        inputMonitoringGranted = CGPreflightListenEventAccess()
+    }
+
+    /// Request Input Monitoring so global keystroke monitors can receive events.
+    /// Returns whether access is currently granted after the request attempt.
+    @discardableResult
+    public func requestInputMonitoringPermission() -> Bool {
+        if CGPreflightListenEventAccess() {
+            inputMonitoringGranted = true
+            return true
+        }
+        let granted = CGRequestListenEventAccess()
+        inputMonitoringGranted = granted
+        return granted
+    }
+
     // MARK: - Open System Settings
 
     public func openScreenRecordingSettings() {
@@ -117,6 +143,10 @@ public final class PermissionManager {
 
     public func openAccessibilitySettings() {
         openSettings(for: .accessibility)
+    }
+
+    public func openInputMonitoringSettings() {
+        openSettings(for: .inputMonitoring)
     }
 
     public func openSettings(for kind: PermissionKind) {

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -304,32 +304,32 @@ public final class AppSettings: @unchecked Sendable {
         set { defaults.set(newValue, forKey: "showKeyPressesWhileRecording") }
     }
 
-    /// Last dragged origin of the key-press overlay (AppKit bottom-left screen coords).
-    /// `nil` means use the default bottom-left placement on the recording display.
-    public var keyPressOverlayOriginX: Double? {
+    /// Last dragged offset of the key-press overlay from the recording frame origin
+    /// (AppKit bottom-left). `nil` means default bottom-leading placement inside the capture.
+    public var keyPressOverlayOffsetX: Double? {
         get {
-            guard defaults.object(forKey: "keyPressOverlayOriginX") != nil else { return nil }
-            return defaults.double(forKey: "keyPressOverlayOriginX")
+            guard defaults.object(forKey: "keyPressOverlayOffsetX") != nil else { return nil }
+            return defaults.double(forKey: "keyPressOverlayOffsetX")
         }
         set {
             if let newValue {
-                defaults.set(newValue, forKey: "keyPressOverlayOriginX")
+                defaults.set(newValue, forKey: "keyPressOverlayOffsetX")
             } else {
-                defaults.removeObject(forKey: "keyPressOverlayOriginX")
+                defaults.removeObject(forKey: "keyPressOverlayOffsetX")
             }
         }
     }
 
-    public var keyPressOverlayOriginY: Double? {
+    public var keyPressOverlayOffsetY: Double? {
         get {
-            guard defaults.object(forKey: "keyPressOverlayOriginY") != nil else { return nil }
-            return defaults.double(forKey: "keyPressOverlayOriginY")
+            guard defaults.object(forKey: "keyPressOverlayOffsetY") != nil else { return nil }
+            return defaults.double(forKey: "keyPressOverlayOffsetY")
         }
         set {
             if let newValue {
-                defaults.set(newValue, forKey: "keyPressOverlayOriginY")
+                defaults.set(newValue, forKey: "keyPressOverlayOffsetY")
             } else {
-                defaults.removeObject(forKey: "keyPressOverlayOriginY")
+                defaults.removeObject(forKey: "keyPressOverlayOffsetY")
             }
         }
     }

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -297,6 +297,43 @@ public final class AppSettings: @unchecked Sendable {
         set { defaults.set(newValue, forKey: "highlightClicks") }
     }
 
+    /// When `true`, show a KeyCastr-style keystroke overlay while recording.
+    /// Opt-in (default off). Requires Input Monitoring permission.
+    public var showKeyPressesWhileRecording: Bool {
+        get { defaults.object(forKey: "showKeyPressesWhileRecording") as? Bool ?? false }
+        set { defaults.set(newValue, forKey: "showKeyPressesWhileRecording") }
+    }
+
+    /// Last dragged origin of the key-press overlay (AppKit bottom-left screen coords).
+    /// `nil` means use the default bottom-left placement on the recording display.
+    public var keyPressOverlayOriginX: Double? {
+        get {
+            guard defaults.object(forKey: "keyPressOverlayOriginX") != nil else { return nil }
+            return defaults.double(forKey: "keyPressOverlayOriginX")
+        }
+        set {
+            if let newValue {
+                defaults.set(newValue, forKey: "keyPressOverlayOriginX")
+            } else {
+                defaults.removeObject(forKey: "keyPressOverlayOriginX")
+            }
+        }
+    }
+
+    public var keyPressOverlayOriginY: Double? {
+        get {
+            guard defaults.object(forKey: "keyPressOverlayOriginY") != nil else { return nil }
+            return defaults.double(forKey: "keyPressOverlayOriginY")
+        }
+        set {
+            if let newValue {
+                defaults.set(newValue, forKey: "keyPressOverlayOriginY")
+            } else {
+                defaults.removeObject(forKey: "keyPressOverlayOriginY")
+            }
+        }
+    }
+
     public var cursorSmoothing: Bool {
         get { defaults.object(forKey: "cursorSmoothing") as? Bool ?? true }
         set { defaults.set(newValue, forKey: "cursorSmoothing") }

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/KeyPressOverlayPlacement.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/KeyPressOverlayPlacement.swift
@@ -60,16 +60,30 @@ public enum KeyPressOverlayPlacement {
         in recordingFrame: CGRect,
         margin: CGFloat = defaultMargin
     ) -> CGRect {
-        var result = frame
+        let recordingFrame = recordingFrame.standardized
+        var result = frame.standardized
+        result.size.width = max(0, min(result.width, recordingFrame.width))
+        result.size.height = max(0, min(result.height, recordingFrame.height))
+
+        // Preserve the requested margin when it fits. For a very small capture
+        // region, collapse it just enough to keep the entire HUD in-frame.
+        let horizontalMargin = min(
+            max(0, margin),
+            max(0, (recordingFrame.width - result.width) / 2)
+        )
+        let verticalMargin = min(
+            max(0, margin),
+            max(0, (recordingFrame.height - result.height) / 2)
+        )
         result.origin.x = clampedOrigin(
-            value: frame.origin.x,
-            lowerBound: recordingFrame.minX + margin,
-            upperBound: recordingFrame.maxX - frame.width - margin
+            value: result.origin.x,
+            lowerBound: recordingFrame.minX + horizontalMargin,
+            upperBound: recordingFrame.maxX - result.width - horizontalMargin
         )
         result.origin.y = clampedOrigin(
-            value: frame.origin.y,
-            lowerBound: recordingFrame.minY + margin,
-            upperBound: recordingFrame.maxY - frame.height - margin
+            value: result.origin.y,
+            lowerBound: recordingFrame.minY + verticalMargin,
+            upperBound: recordingFrame.maxY - result.height - verticalMargin
         )
         return result
     }

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/KeyPressOverlayPlacement.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/KeyPressOverlayPlacement.swift
@@ -1,0 +1,85 @@
+import CoreGraphics
+
+/// Geometry for the key-press HUD relative to the active **display/area** recording frame
+/// (AppKit bottom-left coordinates). Window-target recording is out of scope for this helper.
+public enum KeyPressOverlayPlacement {
+    public static let defaultMargin: CGFloat = 24
+    public static let defaultSize = CGSize(width: 80, height: 40)
+
+    /// Bottom-leading placement inside the recording frame.
+    public static func defaultOrigin(
+        recordingFrame: CGRect,
+        size: CGSize = defaultSize,
+        margin: CGFloat = defaultMargin
+    ) -> CGPoint {
+        CGPoint(
+            x: recordingFrame.minX + margin,
+            y: recordingFrame.minY + margin
+        )
+    }
+
+    /// Resolve origin from a saved offset within the recording frame (origin-relative),
+    /// falling back to the default corner when no offset is stored.
+    public static func origin(
+        savedOffsetX: Double?,
+        savedOffsetY: Double?,
+        recordingFrame: CGRect,
+        size: CGSize = defaultSize,
+        margin: CGFloat = defaultMargin
+    ) -> CGPoint {
+        let proposed: CGPoint
+        if let savedOffsetX, let savedOffsetY {
+            proposed = CGPoint(
+                x: recordingFrame.minX + CGFloat(savedOffsetX),
+                y: recordingFrame.minY + CGFloat(savedOffsetY)
+            )
+        } else {
+            proposed = defaultOrigin(recordingFrame: recordingFrame, size: size, margin: margin)
+        }
+        return clampedFrame(
+            CGRect(origin: proposed, size: size),
+            in: recordingFrame,
+            margin: margin
+        ).origin
+    }
+
+    /// Offset of a window origin relative to the recording frame (for persistence).
+    public static func offset(
+        windowOrigin: CGPoint,
+        recordingFrame: CGRect
+    ) -> (x: Double, y: Double) {
+        (
+            Double(windowOrigin.x - recordingFrame.minX),
+            Double(windowOrigin.y - recordingFrame.minY)
+        )
+    }
+
+    /// Keep the HUD fully inside the recording frame (hard clamp for area capture inclusion).
+    public static func clampedFrame(
+        _ frame: CGRect,
+        in recordingFrame: CGRect,
+        margin: CGFloat = defaultMargin
+    ) -> CGRect {
+        var result = frame
+        result.origin.x = clampedOrigin(
+            value: frame.origin.x,
+            lowerBound: recordingFrame.minX + margin,
+            upperBound: recordingFrame.maxX - frame.width - margin
+        )
+        result.origin.y = clampedOrigin(
+            value: frame.origin.y,
+            lowerBound: recordingFrame.minY + margin,
+            upperBound: recordingFrame.maxY - frame.height - margin
+        )
+        return result
+    }
+
+    private static func clampedOrigin(
+        value: CGFloat,
+        lowerBound: CGFloat,
+        upperBound: CGFloat
+    ) -> CGFloat {
+        guard lowerBound <= upperBound else { return lowerBound }
+        return max(lowerBound, min(value, upperBound))
+    }
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -180,6 +180,8 @@ struct AppSettingsTests {
         first.showKeyPressesWhileRecording = true
         let second = AppSettings(defaults: defaults)
         #expect(second.showKeyPressesWhileRecording == true)
+    }
+
     @Test("Camera PiP fade on hover is disabled by default")
     func defaultCameraPiPFadeOnHover() {
         let suite = "test.cameraPiPFadeOnHover.default"

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -162,6 +162,26 @@ struct AppSettingsTests {
         #expect(settings.playShutterSound == true)
     }
 
+    @Test("Show key presses while recording is disabled by default")
+    func defaultShowKeyPressesWhileRecording() {
+        let suite = "test.showKeyPressesWhileRecording.default"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.showKeyPressesWhileRecording == false)
+    }
+
+    @Test("Show key presses while recording persists across instances")
+    func showKeyPressesWhileRecordingPersists() {
+        let suite = "test.showKeyPressesWhileRecording.persists"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let first = AppSettings(defaults: defaults)
+        first.showKeyPressesWhileRecording = true
+        let second = AppSettings(defaults: defaults)
+        #expect(second.showKeyPressesWhileRecording == true)
+    }
+
     @Test("Diagnostic logging is disabled by default")
     func defaultDiagnosticLoggingEnabled() {
         let suite = "test.diagnosticLogging.default"

--- a/Packages/SharedKit/Tests/SharedKitTests/KeyPressOverlayPlacementTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/KeyPressOverlayPlacementTests.swift
@@ -67,6 +67,23 @@ struct KeyPressOverlayPlacementTests {
         #expect(clamped.maxY <= recording.maxY - margin + 0.001)
     }
 
+    @Test("Oversized HUD is fitted inside a tiny recording frame")
+    func oversizedHUDFitsTinyRecording() {
+        let tinyRecording = CGRect(x: 40, y: 80, width: 72, height: 36)
+        let oversized = CGRect(x: -200, y: 500, width: 180, height: 64)
+
+        let clamped = KeyPressOverlayPlacement.clampedFrame(
+            oversized,
+            in: tinyRecording,
+            margin: margin
+        )
+
+        #expect(clamped.minX >= tinyRecording.minX - 0.001)
+        #expect(clamped.minY >= tinyRecording.minY - 0.001)
+        #expect(clamped.maxX <= tinyRecording.maxX + 0.001)
+        #expect(clamped.maxY <= tinyRecording.maxY + 0.001)
+    }
+
     @Test("Offset round-trips against the recording frame")
     func offsetRoundTrip() {
         let windowOrigin = CGPoint(x: recording.minX + 33, y: recording.minY + 44)

--- a/Packages/SharedKit/Tests/SharedKitTests/KeyPressOverlayPlacementTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/KeyPressOverlayPlacementTests.swift
@@ -1,0 +1,89 @@
+import CoreGraphics
+import Testing
+@testable import SharedKit
+
+@Suite("KeyPressOverlayPlacement")
+struct KeyPressOverlayPlacementTests {
+    private let recording = CGRect(x: 100, y: 200, width: 800, height: 600)
+    private let size = CGSize(width: 120, height: 48)
+    private let margin: CGFloat = 24
+
+    @Test("Default origin is bottom-leading inside the recording frame")
+    func defaultOriginBottomLeading() {
+        let origin = KeyPressOverlayPlacement.defaultOrigin(
+            recordingFrame: recording,
+            size: size,
+            margin: margin
+        )
+        #expect(origin.x == recording.minX + margin)
+        #expect(origin.y == recording.minY + margin)
+    }
+
+    @Test("Saved offset restores relative to the current recording frame")
+    func savedOffsetIsRelative() {
+        let origin = KeyPressOverlayPlacement.origin(
+            savedOffsetX: 40,
+            savedOffsetY: 60,
+            recordingFrame: recording,
+            size: size,
+            margin: margin
+        )
+        #expect(origin.x == recording.minX + 40)
+        #expect(origin.y == recording.minY + 60)
+    }
+
+    @Test("Missing offset falls back to default corner")
+    func missingOffsetUsesDefault() {
+        let origin = KeyPressOverlayPlacement.origin(
+            savedOffsetX: nil,
+            savedOffsetY: nil,
+            recordingFrame: recording,
+            size: size,
+            margin: margin
+        )
+        #expect(origin == KeyPressOverlayPlacement.defaultOrigin(
+            recordingFrame: recording,
+            size: size,
+            margin: margin
+        ))
+    }
+
+    @Test("Clamp keeps the HUD inside the recording frame")
+    func clampKeepsHUDInside() {
+        let outside = CGRect(
+            x: recording.maxX + 50,
+            y: recording.minY - 80,
+            width: size.width,
+            height: size.height
+        )
+        let clamped = KeyPressOverlayPlacement.clampedFrame(
+            outside,
+            in: recording,
+            margin: margin
+        )
+        #expect(clamped.minX >= recording.minX + margin)
+        #expect(clamped.minY >= recording.minY + margin)
+        #expect(clamped.maxX <= recording.maxX - margin + 0.001)
+        #expect(clamped.maxY <= recording.maxY - margin + 0.001)
+    }
+
+    @Test("Offset round-trips against the recording frame")
+    func offsetRoundTrip() {
+        let windowOrigin = CGPoint(x: recording.minX + 33, y: recording.minY + 44)
+        let off = KeyPressOverlayPlacement.offset(
+            windowOrigin: windowOrigin,
+            recordingFrame: recording
+        )
+        #expect(off.x == 33)
+        #expect(off.y == 44)
+        let restored = KeyPressOverlayPlacement.origin(
+            savedOffsetX: off.x,
+            savedOffsetY: off.y,
+            recordingFrame: recording,
+            size: size,
+            margin: margin
+        )
+        #expect(restored.x == windowOrigin.x)
+        #expect(restored.y == windowOrigin.y)
+    }
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/PermissionKindTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/PermissionKindTests.swift
@@ -8,6 +8,7 @@ struct PermissionKindTests {
     func systemSettingsURLs() {
         #expect(PermissionKind.screenRecording.settingsURL.absoluteString.contains("Privacy_ScreenCapture"))
         #expect(PermissionKind.accessibility.settingsURL.absoluteString.contains("Privacy_Accessibility"))
+        #expect(PermissionKind.inputMonitoring.settingsURL.absoluteString.contains("Privacy_ListenEvent"))
         #expect(PermissionKind.camera.settingsURL.absoluteString.contains("Privacy_Camera"))
         #expect(PermissionKind.microphone.settingsURL.absoluteString.contains("Privacy_Microphone"))
     }

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -15,6 +15,7 @@ KeyCastr is licensed under the BSD 3-Clause License:
 
 ```
 Copyright (c) 2009 Stephen Deken.
+Copyright (c) 2017-2024 Andrew Kitchen.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,44 @@
+# Third-Party Notices
+
+This document reproduces licenses for third-party software used by Capso.
+
+---
+
+## KeyCastr
+
+Portions of Capso’s keystroke visualization (label transform rules and special-key
+glyph table in `Packages/EffectsKit/Sources/EffectsKit/KeystrokeFormatter.swift`,
+and the listen-only event-tap approach used by `KeyPressMonitor`) are adapted from
+[KeyCastr](https://github.com/keycastr/keycastr).
+
+KeyCastr is licensed under the BSD 3-Clause License:
+
+```
+Copyright (c) 2009 Stephen Deken.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+ * Neither the name KeyCastr nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+Source: https://github.com/keycastr/keycastr/blob/main/LICENSE.md

--- a/project.yml
+++ b/project.yml
@@ -67,6 +67,8 @@ targets:
       - path: App/Resources
         excludes:
           - "Info.plist"
+      - path: THIRD_PARTY_NOTICES.md
+        buildPhase: resources
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.awesomemacapps.capso


### PR DESCRIPTION
## What changed

Show pressed keys in a draggable, semi-transparent bezel during screen recording (opt-in). Capture via CGEventTap with NSEvent fallback, format labels like KeyCastr (including Space as ␣), and surface Input Monitoring in Preferences.

## Related issue

None

## Screenshots / recordings
<img width="1367" height="1040" alt="Capso Screenshot 2026-07-20 at 19 53 09" src="https://github.com/user-attachments/assets/74498ede-bec2-4d02-8866-122e59e3f76b" />
<img width="3429" height="2227" alt="Capso Screenshot 2026-07-20 at 19 53 43" src="https://github.com/user-attachments/assets/435c2a51-c0af-42b2-9319-804553426761" />
<img width="1391" height="1053" alt="Capso Screenshot 2026-07-20 at 19 53 19" src="https://github.com/user-attachments/assets/ebca67ca-96a3-41e1-bb88-f18c05ae65f2" />



## Checklist

- [ x] `xcodegen generate` run if `project.yml` or source layout changed
- [x ] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [ x] Tests for any touched package pass (`swift test --package-path Packages/<Kit>`)
- [x ] No new `TODO` / `FIXME` / debug prints left behind
- [x ] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x ] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)
