### PR TITLE
feat: add screenshot clipboard format setting

### DIFF
--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -1792,7 +1792,10 @@ final class CaptureCoordinator {
     }
 
     private func copyImageToClipboard(_ image: CGImage) {
-        ImageUtilities.copyPNGToPasteboard(image)
+        ImageUtilities.copyToPasteboard(
+            image,
+            format: settings.screenshotClipboardFormat
+        )
     }
 
     private func saveImageToFile(_ result: CaptureResult) {

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -1792,10 +1792,7 @@ final class CaptureCoordinator {
     }
 
     private func copyImageToClipboard(_ image: CGImage) {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        let nsImage = NSImage(cgImage: image, size: NSSize(width: image.width, height: image.height))
-        pasteboard.writeObjects([nsImage])
+        ImageUtilities.copyPNGToPasteboard(image)
     }
 
     private func saveImageToFile(_ result: CaptureResult) {

--- a/App/Sources/History/HistoryCoordinator.swift
+++ b/App/Sources/History/HistoryCoordinator.swift
@@ -601,7 +601,10 @@ final class HistoryCoordinator {
     }
 
     private func copyImageToClipboard(_ image: CGImage) {
-        ImageUtilities.copyPNGToPasteboard(image)
+        ImageUtilities.copyToPasteboard(
+            image,
+            format: settings.screenshotClipboardFormat
+        )
     }
 
     private func pinImage(
@@ -677,7 +680,7 @@ final class HistoryCoordinator {
 
         case .area, .fullscreen, .window:
             guard let image = Self.loadCGImage(from: sourceURL) else { return }
-            ImageUtilities.copyPNGToPasteboard(image)
+            copyImageToClipboard(image)
         }
     }
 

--- a/App/Sources/History/HistoryCoordinator.swift
+++ b/App/Sources/History/HistoryCoordinator.swift
@@ -601,9 +601,7 @@ final class HistoryCoordinator {
     }
 
     private func copyImageToClipboard(_ image: CGImage) {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.writeObjects([ImageUtilities.nsImage(from: image)])
+        ImageUtilities.copyPNGToPasteboard(image)
     }
 
     private func pinImage(
@@ -670,16 +668,16 @@ final class HistoryCoordinator {
 
     func copyToClipboard(_ entry: HistoryEntry) {
         guard let sourceURL = fullImageURL(for: entry) else { return }
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
 
         switch entry.captureMode {
         case .recording, .gif:
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
             pasteboard.writeObjects([sourceURL as NSURL])
 
         case .area, .fullscreen, .window:
-            guard let nsImage = NSImage(contentsOf: sourceURL) else { return }
-            pasteboard.writeObjects([nsImage])
+            guard let image = Self.loadCGImage(from: sourceURL) else { return }
+            ImageUtilities.copyPNGToPasteboard(image)
         }
     }
 

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -104,6 +104,17 @@ final class PreferencesViewModel {
             }
         }
     }
+    var screenshotClipboardFormat: ScreenshotClipboardFormat {
+        get {
+            access(keyPath: \.screenshotClipboardFormat)
+            return settings.screenshotClipboardFormat
+        }
+        set {
+            withMutation(keyPath: \.screenshotClipboardFormat) {
+                settings.screenshotClipboardFormat = newValue
+            }
+        }
+    }
     var screenshotAutoSave: Bool {
         get {
             access(keyPath: \.screenshotAutoSave)

--- a/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
@@ -28,6 +28,20 @@ struct ScreenshotSettingsView: View {
                             .toggleStyle(.switch)
                             .controlSize(.small)
                     }
+                    SettingRow(
+                        label: "Clipboard Format",
+                        sublabel: "Used whenever a screenshot is copied",
+                        showDivider: true
+                    ) {
+                        Picker("", selection: $viewModel.screenshotClipboardFormat) {
+                            Text("PNG").tag(ScreenshotClipboardFormat.png)
+                            Text("JPEG").tag(ScreenshotClipboardFormat.jpeg)
+                            Text("TIFF").tag(ScreenshotClipboardFormat.tiff)
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                        .frame(width: 110)
+                    }
                     SettingRow(label: "Auto Save", sublabel: "Save to file automatically", showDivider: true) {
                         Toggle("", isOn: $viewModel.screenshotAutoSave)
                             .toggleStyle(.switch)

--- a/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
@@ -40,7 +40,7 @@ struct ScreenshotSettingsView: View {
                         }
                         .labelsHidden()
                         .pickerStyle(.menu)
-                        .frame(width: 110)
+                        .fixedSize(horizontal: true, vertical: false)
                     }
                     SettingRow(label: "Auto Save", sublabel: "Save to file automatically", showDivider: true) {
                         Toggle("", isOn: $viewModel.screenshotAutoSave)

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -8,6 +8,12 @@ public enum ScreenshotFormat: String, CaseIterable, Sendable {
     case jpeg
 }
 
+public enum ScreenshotClipboardFormat: String, CaseIterable, Sendable {
+    case png
+    case jpeg
+    case tiff
+}
+
 public enum ScreenshotOutputPreset: String, CaseIterable, Sendable {
     case losslessPNG
     case standardJPEG
@@ -444,6 +450,15 @@ public final class AppSettings: @unchecked Sendable {
     public var screenshotAutoCopy: Bool {
         get { defaults.object(forKey: "screenshotAutoCopy") as? Bool ?? false }
         set { defaults.set(newValue, forKey: "screenshotAutoCopy") }
+    }
+
+    public var screenshotClipboardFormat: ScreenshotClipboardFormat {
+        get {
+            guard let raw = defaults.string(forKey: "screenshotClipboardFormat"),
+                  let value = ScreenshotClipboardFormat(rawValue: raw) else { return .tiff }
+            return value
+        }
+        set { defaults.set(newValue.rawValue, forKey: "screenshotClipboardFormat") }
     }
 
     public var screenshotAutoSave: Bool {

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -455,7 +455,7 @@ public final class AppSettings: @unchecked Sendable {
     public var screenshotClipboardFormat: ScreenshotClipboardFormat {
         get {
             guard let raw = defaults.string(forKey: "screenshotClipboardFormat"),
-                  let value = ScreenshotClipboardFormat(rawValue: raw) else { return .tiff }
+                  let value = ScreenshotClipboardFormat(rawValue: raw) else { return .png }
             return value
         }
         set { defaults.set(newValue.rawValue, forKey: "screenshotClipboardFormat") }

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ImageUtilities.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ImageUtilities.swift
@@ -3,6 +3,8 @@ import AppKit
 import CoreGraphics
 
 public enum ImageUtilities {
+    static let jpegPasteboardType = NSPasteboard.PasteboardType("public.jpeg")
+
     public static func nsImage(from cgImage: CGImage) -> NSImage {
         let size = NSSize(width: cgImage.width, height: cgImage.height)
         return NSImage(cgImage: cgImage, size: size)
@@ -17,21 +19,50 @@ public enum ImageUtilities {
         return rep.representation(using: .png, properties: [:])
     }
 
-    /// Copies an image to the pasteboard as PNG data.
+    public static func tiffData(from cgImage: CGImage) -> Data? {
+        let rep = NSBitmapImageRep(cgImage: cgImage)
+        return rep.representation(using: .tiff, properties: [:])
+    }
+
+    /// Copies an explicitly encoded image to the pasteboard.
     ///
-    /// Writing an `NSImage` directly lets AppKit serialize it as TIFF, which
-    /// makes clipboard consumers treat fresh screenshots as TIFF images even
-    /// though Capso's default screenshot export format is PNG.
+    /// Writing an `NSImage` directly lets AppKit choose TIFF. Encoding first
+    /// keeps the pasteboard type aligned with the user's clipboard preference.
+    @discardableResult
+    public static func copyToPasteboard(
+        _ cgImage: CGImage,
+        format: ScreenshotClipboardFormat,
+        jpegQuality: Double = 0.85,
+        pasteboard: NSPasteboard = .general
+    ) -> Bool {
+        let data: Data?
+        let pasteboardType: NSPasteboard.PasteboardType
+
+        switch format {
+        case .png:
+            data = pngData(from: cgImage)
+            pasteboardType = .png
+        case .jpeg:
+            data = jpegData(from: cgImage, quality: jpegQuality)
+            pasteboardType = jpegPasteboardType
+        case .tiff:
+            data = tiffData(from: cgImage)
+            pasteboardType = .tiff
+        }
+
+        guard let data else { return false }
+        let item = NSPasteboardItem()
+        guard item.setData(data, forType: pasteboardType) else { return false }
+        pasteboard.clearContents()
+        return pasteboard.writeObjects([item])
+    }
+
     @discardableResult
     public static func copyPNGToPasteboard(
         _ cgImage: CGImage,
         pasteboard: NSPasteboard = .general
     ) -> Bool {
-        guard let data = pngData(from: cgImage) else { return false }
-        let item = NSPasteboardItem()
-        guard item.setData(data, forType: .png) else { return false }
-        pasteboard.clearContents()
-        return pasteboard.writeObjects([item])
+        copyToPasteboard(cgImage, format: .png, pasteboard: pasteboard)
     }
 
     public static func jpegData(from cgImage: CGImage, quality: Double = 0.85) -> Data? {

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ImageUtilities.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ImageUtilities.swift
@@ -17,6 +17,23 @@ public enum ImageUtilities {
         return rep.representation(using: .png, properties: [:])
     }
 
+    /// Copies an image to the pasteboard as PNG data.
+    ///
+    /// Writing an `NSImage` directly lets AppKit serialize it as TIFF, which
+    /// makes clipboard consumers treat fresh screenshots as TIFF images even
+    /// though Capso's default screenshot export format is PNG.
+    @discardableResult
+    public static func copyPNGToPasteboard(
+        _ cgImage: CGImage,
+        pasteboard: NSPasteboard = .general
+    ) -> Bool {
+        guard let data = pngData(from: cgImage) else { return false }
+        let item = NSPasteboardItem()
+        guard item.setData(data, forType: .png) else { return false }
+        pasteboard.clearContents()
+        return pasteboard.writeObjects([item])
+    }
+
     public static func jpegData(from cgImage: CGImage, quality: Double = 0.85) -> Data? {
         let rep = NSBitmapImageRep(cgImage: cgImage)
         return rep.representation(using: .jpeg, properties: [.compressionFactor: quality])

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ImageUtilities.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ImageUtilities.swift
@@ -57,14 +57,6 @@ public enum ImageUtilities {
         return pasteboard.writeObjects([item])
     }
 
-    @discardableResult
-    public static func copyPNGToPasteboard(
-        _ cgImage: CGImage,
-        pasteboard: NSPasteboard = .general
-    ) -> Bool {
-        copyToPasteboard(cgImage, format: .png, pasteboard: pasteboard)
-    }
-
     public static func jpegData(from cgImage: CGImage, quality: Double = 0.85) -> Data? {
         let rep = NSBitmapImageRep(cgImage: cgImage)
         return rep.representation(using: .jpeg, properties: [.compressionFactor: quality])

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -37,6 +37,21 @@ struct AppSettingsTests {
         #expect(ScreenshotOutputPreset.compactJPEG.jpegQuality == 0.70)
     }
 
+    @Test("Screenshot clipboard format defaults to TIFF and persists")
+    func screenshotClipboardFormatDefaultsAndPersists() {
+        let suite = "test.screenshotClipboardFormat"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let first = AppSettings(defaults: defaults)
+        #expect(first.screenshotClipboardFormat == .tiff)
+
+        first.screenshotClipboardFormat = .jpeg
+
+        let second = AppSettings(defaults: defaults)
+        #expect(second.screenshotClipboardFormat == .jpeg)
+    }
+
     @Test("Screenshot output preset falls back to legacy JPEG format")
     func screenshotOutputPresetLegacyFormatFallback() {
         let suite = "test.screenshotOutputPreset.legacy"

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -37,14 +37,14 @@ struct AppSettingsTests {
         #expect(ScreenshotOutputPreset.compactJPEG.jpegQuality == 0.70)
     }
 
-    @Test("Screenshot clipboard format defaults to TIFF and persists")
+    @Test("Screenshot clipboard format defaults to PNG and persists")
     func screenshotClipboardFormatDefaultsAndPersists() {
         let suite = "test.screenshotClipboardFormat"
         let defaults = UserDefaults(suiteName: suite)!
         defaults.removePersistentDomain(forName: suite)
 
         let first = AppSettings(defaults: defaults)
-        #expect(first.screenshotClipboardFormat == .tiff)
+        #expect(first.screenshotClipboardFormat == .png)
 
         first.screenshotClipboardFormat = .jpeg
 

--- a/Packages/SharedKit/Tests/SharedKitTests/ImageUtilitiesTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ImageUtilitiesTests.swift
@@ -24,6 +24,24 @@ struct ImageUtilitiesTests {
         #expect(resized.width == 9)
         #expect(resized.height == 6)
     }
+
+    @Test("Screenshot clipboard data prefers PNG over TIFF")
+    func screenshotClipboardDataPrefersPNG() throws {
+        let pasteboard = NSPasteboard(
+            name: NSPasteboard.Name("CapsoImageUtilitiesTests.\(UUID().uuidString)")
+        )
+        let image = try makeSolidImage(
+            width: 8,
+            height: 6,
+            color: CGColor(red: 0, green: 1, blue: 0, alpha: 1)
+        )
+
+        #expect(ImageUtilities.copyPNGToPasteboard(image, pasteboard: pasteboard))
+        let declaredTypes = pasteboard.types ?? []
+        #expect(declaredTypes.first == .png)
+        #expect(declaredTypes.contains(.png))
+        #expect(pasteboard.data(forType: .png) != nil)
+    }
 }
 
 private func makeSolidImage(width: Int, height: Int, color: CGColor) throws -> CGImage {

--- a/Packages/SharedKit/Tests/SharedKitTests/ImageUtilitiesTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ImageUtilitiesTests.swift
@@ -25,22 +25,28 @@ struct ImageUtilitiesTests {
         #expect(resized.height == 6)
     }
 
-    @Test("Screenshot clipboard data prefers PNG over TIFF")
-    func screenshotClipboardDataPrefersPNG() throws {
-        let pasteboard = NSPasteboard(
-            name: NSPasteboard.Name("CapsoImageUtilitiesTests.\(UUID().uuidString)")
-        )
+    @Test("Screenshot clipboard writes the selected image format")
+    func screenshotClipboardWritesSelectedFormat() throws {
         let image = try makeSolidImage(
             width: 8,
             height: 6,
             color: CGColor(red: 0, green: 1, blue: 0, alpha: 1)
         )
+        let cases: [(ScreenshotClipboardFormat, NSPasteboard.PasteboardType)] = [
+            (.png, .png),
+            (.jpeg, ImageUtilities.jpegPasteboardType),
+            (.tiff, .tiff),
+        ]
 
-        #expect(ImageUtilities.copyPNGToPasteboard(image, pasteboard: pasteboard))
-        let declaredTypes = pasteboard.types ?? []
-        #expect(declaredTypes.first == .png)
-        #expect(declaredTypes.contains(.png))
-        #expect(pasteboard.data(forType: .png) != nil)
+        for (format, expectedType) in cases {
+            let pasteboard = NSPasteboard(
+                name: NSPasteboard.Name("CapsoImageUtilitiesTests.\(UUID().uuidString)")
+            )
+
+            #expect(ImageUtilities.copyToPasteboard(image, format: format, pasteboard: pasteboard))
+            #expect(pasteboard.types?.first == expectedType)
+            #expect(pasteboard.data(forType: expectedType) != nil)
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

Capso writes screenshots to the pasteboard through `NSImage`. AppKit typically serializes the image as TIFF.

Native macOS apps generally accept TIFF, but many cross-platform clipboard consumers expect PNG or JPEG. Claude Code and OpenCode, for example, do not always render or ingest TIFF clipboard data correctly.

## Changes

Capso now provides a `Clipboard Format` setting under `Screenshots > After Capture` with three options:

- PNG
- JPEG
- TIFF

PNG is the default for broad compatibility with browsers, coding tools, and other cross-platform clipboard consumers. Users can still select JPEG or TIFF when needed.

Screenshot copy paths now encode the image in the selected format and write the matching pasteboard type through `NSPasteboardItem`. This avoids letting AppKit choose the format implicitly.

The setting covers:

- New captures
- Quick Access and annotation actions
- Screenshot History

Video clipboard behavior does not change.

Related to #205. This change addresses the image-format compatibility described there, but it does not add a path-only clipboard mode.

## Validation

- [x] `swift test --package-path Packages/SharedKit` - 164 tests passed
- [x] Unsigned macOS build completed with the `Capso` Xcode scheme
- [x] Tests cover PNG, JPEG, and TIFF pasteboard data
- [x] Tests cover preference persistence and the PNG default
- [x] Verified the selector in the installed local build

## Screenshots

| Available formats | Format selector |
| --- | --- |
| <img width="1326" height="944" alt="image" src="https://github.com/user-attachments/assets/dbbe4267-7766-46cd-923d-91029091ca53" />| <img width="1347" height="936" alt="image" src="https://github.com/user-attachments/assets/0fed2c38-bd1b-4aa5-8ee2-f69442e87b50" /> |
