### PR TITLE
feat: pinch to zoom in the annotation editor

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -81,6 +81,12 @@ final class AnnotationCanvasNSView: NSView {
     /// Fired on commit / cancel.
     var onTextEditingEnded: (() -> Void)?
     var onInteractionChanged: ((Bool) -> Void)?
+    /// Fired for each trackpad pinch step. Passes the per-event magnification
+    /// delta and the focal location in this view's (flipped, top-left) coords.
+    /// Optional: when nil, `magnify(with:)` forwards to `super` so consumers that
+    /// don't opt in (the main editor's scroll container, the all-in-one overlay)
+    /// are unaffected.
+    var onMagnify: ((_ magnification: CGFloat, _ locationInView: CGPoint) -> Void)?
 
     func commitTextEditingIfNeeded() {
         commitTextEditing()
@@ -144,6 +150,42 @@ final class AnnotationCanvasNSView: NSView {
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         window?.makeFirstResponder(self)
+    }
+
+    // Trackpad pinch. Two-finger magnify is a distinct event stream from the
+    // one-finger mouse drags used for drawing, so this never interferes with
+    // annotation creation. Forwarded to the owner (which applies focal-point
+    // zoom); when no owner opts in we defer to the default responder-chain
+    // behavior so an enclosing scroll view can handle it instead.
+    override func magnify(with event: NSEvent) {
+        guard let onMagnify else {
+            // No gesture owner (main editor / all-in-one overlay). Hand off to an
+            // enclosing scroll view when there is one — the responder chain does
+            // not reliably forward `magnify` up through the SwiftUI hosting views,
+            // so without this an over-image pinch is swallowed.
+            if let scrollView = enclosingScrollView {
+                scrollView.magnify(with: event)
+            } else {
+                super.magnify(with: event)
+            }
+            return
+        }
+        let location = convert(event.locationInWindow, from: nil)
+        onMagnify(event.magnification, location)
+    }
+
+    // Two-finger scroll (pan). Like `magnify`, the SwiftUI hosting views don't
+    // reliably forward `scrollWheel` up the responder chain, so an over-image
+    // two-finger drag never reaches the enclosing scroll view. Hand it off
+    // explicitly so panning works over the image, not just the margins. The
+    // canvas itself has no use for scroll events. When there's no enclosing
+    // scroll view (inline / all-in-one overlays) we defer to the default.
+    override func scrollWheel(with event: NSEvent) {
+        if let scrollView = enclosingScrollView {
+            scrollView.scrollWheel(with: event)
+        } else {
+            super.scrollWheel(with: event)
+        }
     }
 
     private func toImagePoint(_ viewPoint: CGPoint) -> CGPoint {

--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -31,6 +31,19 @@ private enum SelectionAction {
     case decrementCounter
 }
 
+/// The parts of a scroll `NSEvent` a canvas owner needs to route the gesture
+/// itself. Used by surfaces with no enclosing `NSScrollView` (the inline
+/// editor), which have to implement pan / ⌘-scroll zoom on their own.
+struct CanvasScrollEvent {
+    let deltaX: CGFloat
+    let deltaY: CGFloat
+    /// Pointer location in the canvas's flipped, top-left coordinates.
+    let locationInView: CGPoint
+    let commandHeld: Bool
+    let isMomentum: Bool
+    let hasPreciseDeltas: Bool
+}
+
 private protocol PathEditableAnnotation: AnnotationObject {
     var start: CGPoint { get set }
     var end: CGPoint { get set }
@@ -87,6 +100,12 @@ final class AnnotationCanvasNSView: NSView {
     /// don't opt in (the main editor's scroll container, the all-in-one overlay)
     /// are unaffected.
     var onMagnify: ((_ magnification: CGFloat, _ locationInView: CGPoint) -> Void)?
+    /// Fired for each two-finger scroll / ⌘-scroll step. Owners that supply this
+    /// route the gesture themselves (pan vs zoom) via `CanvasScrollGesture`.
+    /// Optional: when nil, `scrollWheel(with:)` hands off to an enclosing scroll
+    /// view as before, so the main editor and the all-in-one overlay are
+    /// unaffected.
+    var onScroll: ((CanvasScrollEvent) -> Void)?
 
     func commitTextEditingIfNeeded() {
         commitTextEditing()
@@ -174,13 +193,25 @@ final class AnnotationCanvasNSView: NSView {
         onMagnify(event.magnification, location)
     }
 
-    // Two-finger scroll (pan). Like `magnify`, the SwiftUI hosting views don't
-    // reliably forward `scrollWheel` up the responder chain, so an over-image
-    // two-finger drag never reaches the enclosing scroll view. Hand it off
-    // explicitly so panning works over the image, not just the margins. The
-    // canvas itself has no use for scroll events. When there's no enclosing
-    // scroll view (inline / all-in-one overlays) we defer to the default.
+    // Two-finger scroll (pan) and ⌘-scroll (zoom). Like `magnify`, the SwiftUI
+    // hosting views don't reliably forward `scrollWheel` up the responder chain,
+    // so an over-image two-finger drag never reaches the enclosing scroll view.
+    // Hand it off explicitly so panning works over the image, not just the
+    // margins. The canvas itself has no use for scroll events.
     override func scrollWheel(with event: NSEvent) {
+        // An owner that routes the gesture itself (the inline editor, which has
+        // no scroll view to fall back on) gets it first.
+        if let onScroll {
+            onScroll(CanvasScrollEvent(
+                deltaX: event.scrollingDeltaX,
+                deltaY: event.scrollingDeltaY,
+                locationInView: convert(event.locationInWindow, from: nil),
+                commandHeld: event.modifierFlags.contains(.command),
+                isMomentum: event.momentumPhase != [],
+                hasPreciseDeltas: event.hasPreciseScrollingDeltas
+            ))
+            return
+        }
         if let scrollView = enclosingScrollView {
             scrollView.scrollWheel(with: event)
         } else {

--- a/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
@@ -29,6 +29,10 @@ struct AnnotationCanvasView: NSViewRepresentable {
     var onTextEditingStarted: ((CGFloat, Bool, Bool, Bool) -> Void)?
     /// Called when the inline text editor commits / dismisses.
     var onTextEditingEnded: (() -> Void)?
+    /// Called for each trackpad pinch step. Passes the per-event magnification
+    /// delta and the focal location in canvas (flipped, top-left) coordinates.
+    /// Optional — canvases that don't support gesture zoom simply leave it nil.
+    var onMagnify: ((CGFloat, CGPoint) -> Void)?
 
     /// Tools that stay active after each stroke so the user can keep drawing
     /// without reaching back to the toolbar (issue #75). Shape tools (arrow,
@@ -66,6 +70,10 @@ struct AnnotationCanvasView: NSViewRepresentable {
             onTextEditingStarted?(fontSize, hasFill, hasOutline, hasStroke)
         }
         view.onTextEditingEnded = { onTextEditingEnded?() }
+        // Pass the optional through directly: a nil here must stay nil so the
+        // NSView forwards pinch to an enclosing scroll view (main editor) instead
+        // of swallowing it in a no-op wrapper.
+        view.onMagnify = onMagnify
         return view
     }
 
@@ -98,6 +106,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
             onTextEditingStarted?(fontSize, hasFill, hasOutline, hasStroke)
         }
         nsView.onTextEditingEnded = { onTextEditingEnded?() }
+        nsView.onMagnify = onMagnify
         if context.coordinator.lastCommitEditingTrigger != commitEditingTrigger {
             context.coordinator.lastCommitEditingTrigger = commitEditingTrigger
             nsView.commitTextEditingIfNeeded()

--- a/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
@@ -33,6 +33,10 @@ struct AnnotationCanvasView: NSViewRepresentable {
     /// delta and the focal location in canvas (flipped, top-left) coordinates.
     /// Optional — canvases that don't support gesture zoom simply leave it nil.
     var onMagnify: ((CGFloat, CGPoint) -> Void)?
+    /// Called for each two-finger scroll / ⌘-scroll step, for canvases that
+    /// route the gesture themselves. Optional — leave nil to keep the default
+    /// hand-off to an enclosing scroll view.
+    var onScroll: ((CanvasScrollEvent) -> Void)?
 
     /// Tools that stay active after each stroke so the user can keep drawing
     /// without reaching back to the toolbar (issue #75). Shape tools (arrow,
@@ -74,6 +78,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
         // NSView forwards pinch to an enclosing scroll view (main editor) instead
         // of swallowing it in a no-op wrapper.
         view.onMagnify = onMagnify
+        view.onScroll = onScroll
         return view
     }
 
@@ -107,6 +112,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
         }
         nsView.onTextEditingEnded = { onTextEditingEnded?() }
         nsView.onMagnify = onMagnify
+        nsView.onScroll = onScroll
         if context.coordinator.lastCommitEditingTrigger != commitEditingTrigger {
             context.coordinator.lastCommitEditingTrigger = commitEditingTrigger
             nsView.commitTextEditingIfNeeded()

--- a/App/Sources/AnnotationEditor/AnnotationEditorView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorView.swift
@@ -2,6 +2,7 @@
 import AppKit
 import SwiftUI
 import AnnotationKit
+import CaptureKit
 import OCRKit
 import SharedKit
 
@@ -298,7 +299,10 @@ struct AnnotationEditorView: View {
 
     private var canvasArea: some View {
         GeometryReader { geo in
-            ScrollView([.horizontal, .vertical]) {
+            ZoomableScrollContainer(
+                zoomScale: $zoomScale,
+                contentSize: CGSize(width: previewWidth, height: previewHeight)
+            ) {
                 previewCanvas
             }
             .background(Color(white: 0.12))
@@ -532,11 +536,11 @@ struct AnnotationEditorView: View {
     }
 
     private func zoomIn() {
-        zoomScale = min(zoomScale * 1.25, 4.0)
+        zoomScale = CanvasZoom.clampScale(zoomScale * 1.25, min: 0.1, max: 4.0)
     }
 
     private func zoomOut() {
-        zoomScale = max(zoomScale / 1.25, 0.1)
+        zoomScale = CanvasZoom.clampScale(zoomScale / 1.25, min: 0.1, max: 4.0)
     }
 
     /// Update the selected object's style when color/lineWidth/filled changes

--- a/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
@@ -301,7 +301,8 @@ private struct InlineAnnotationEditorView: View {
             onInteractionChanged: handleCanvasInteractionChanged,
             onTextEditingStarted: handleTextEditingStarted,
             onTextEditingEnded: handleTextEditingEnded,
-            onMagnify: handleMagnify
+            onMagnify: handleMagnify,
+            onScroll: handleScroll
         )
         // Render at full (possibly enlarged) size, panned by the focal offset,
         // then clip to the fixed capture-footprint viewport so a zoomed canvas
@@ -396,13 +397,42 @@ private struct InlineAnnotationEditorView: View {
         interactionState.setCanvasInteraction(isInteracting)
     }
 
-    /// Focal-point pinch zoom: keeps the content point under the pinch fixed
-    /// while scaling, then constrains the pan so the canvas keeps covering its
-    /// viewport. `locInView` is in the canvas's flipped, top-left coordinates.
+    /// Trackpad pinch. `locInView` is in the canvas's flipped, top-left coords.
     private func handleMagnify(_ magnification: CGFloat, _ locInView: CGPoint) {
-        let oldScale = effectiveScale
-        let newUserZoom = CanvasZoom.clampScale(userZoom * (1 + magnification), min: 1.0, max: 8.0)
+        applyUserZoom(
+            CanvasZoom.clampScale(userZoom * (1 + magnification), min: 1.0, max: 8.0),
+            focalInView: locInView
+        )
+    }
+
+    /// This overlay has no enclosing scroll view, so it routes scroll events
+    /// itself: ⌘-scroll zooms toward the cursor, a plain two-finger scroll pans.
+    /// Both are swallowed either way, since there is nothing else to scroll here.
+    private func handleScroll(_ scroll: CanvasScrollEvent) {
+        switch CanvasScrollGesture.action(
+            commandHeld: scroll.commandHeld,
+            isMomentum: scroll.isMomentum,
+            verticalDelta: scroll.deltaY,
+            horizontalDelta: scroll.deltaX,
+            hasPreciseDeltas: scroll.hasPreciseDeltas
+        ) {
+        case let .zoom(factor):
+            applyUserZoom(
+                CanvasZoom.clampScale(userZoom * factor, min: 1.0, max: 8.0),
+                focalInView: scroll.locationInView
+            )
+        case let .pan(dx, dy):
+            panContent(dx: dx, dy: dy)
+        case .ignore:
+            break
+        }
+    }
+
+    /// Focal-point zoom: keeps the content point under `locInView` fixed while
+    /// scaling, then constrains the pan so the canvas keeps covering its viewport.
+    private func applyUserZoom(_ newUserZoom: CGFloat, focalInView locInView: CGPoint) {
         guard newUserZoom != userZoom else { return }
+        let oldScale = effectiveScale
         let newScale = displayScale * newUserZoom
 
         let origin = resolvedContentOrigin
@@ -415,17 +445,33 @@ private struct InlineAnnotationEditorView: View {
         )
 
         let newSize = CGSize(width: imageSize.width * newScale, height: imageSize.height * newScale)
-        // Clamp in viewport-relative space (origin - viewport top-left), then
-        // lift the result back into the ZStack's coordinate space.
+        userZoom = newUserZoom
+        contentOrigin = clampedOrigin(zoomed, contentSize: newSize)
+        didInitOrigin = true
+    }
+
+    /// Move the canvas by a scroll delta. No-ops at fit, where the canvas exactly
+    /// covers its viewport and there is nothing to reveal.
+    private func panContent(dx: CGFloat, dy: CGFloat) {
+        guard userZoom > 1 else { return }
+        let origin = resolvedContentOrigin
+        contentOrigin = clampedOrigin(
+            CGPoint(x: origin.x + dx, y: origin.y + dy),
+            contentSize: canvasSize
+        )
+        didInitOrigin = true
+    }
+
+    /// Clamp a content origin so the canvas keeps covering the viewport. Converts
+    /// into viewport-relative space for `CanvasZoom`, then back into the ZStack's
+    /// coordinate space.
+    private func clampedOrigin(_ origin: CGPoint, contentSize: CGSize) -> CGPoint {
         let relative = CanvasZoom.clampOffset(
-            CGPoint(x: zoomed.x - canvasRect.minX, y: zoomed.y - canvasRect.minY),
-            contentSize: newSize,
+            CGPoint(x: origin.x - canvasRect.minX, y: origin.y - canvasRect.minY),
+            contentSize: contentSize,
             viewportSize: canvasRect.size
         )
-
-        userZoom = newUserZoom
-        contentOrigin = CGPoint(x: relative.x + canvasRect.minX, y: relative.y + canvasRect.minY)
-        didInitOrigin = true
+        return CGPoint(x: relative.x + canvasRect.minX, y: relative.y + canvasRect.minY)
     }
 
     private func resetZoom() {

--- a/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
@@ -130,6 +130,13 @@ private struct InlineAnnotationEditorView: View {
     @State private var refreshTrigger = 0
     @State private var commitEditingTrigger = 0
     @State private var textRegions: [CGRect] = []
+    /// User-applied pinch zoom multiplier layered on top of `displayScale`.
+    /// 1.0 == the natural life-size fit; the overlay never zooms below fit.
+    @State private var userZoom: CGFloat = 1.0
+    /// Top-left of the (possibly enlarged) canvas in the ZStack's coordinate
+    /// space. Panned during focal zoom so the pinch point stays fixed.
+    @State private var contentOrigin: CGPoint = .zero
+    @State private var didInitOrigin = false
 
     private var imageSize: CGSize {
         CGSize(width: sourceImage.width, height: sourceImage.height)
@@ -140,6 +147,22 @@ private struct InlineAnnotationEditorView: View {
             imageSize: imageSize,
             screenRect: screenLocalRect
         ) ?? 1
+    }
+
+    /// The scale actually handed to the canvas: base fit scale times the user's
+    /// pinch zoom. Keeps `toImagePoint` / handle chrome correct at any zoom.
+    private var effectiveScale: CGFloat { displayScale * userZoom }
+
+    /// Size of the canvas at the current effective scale. Equals the viewport
+    /// (`canvasRect`) size at `userZoom == 1` and grows when zoomed in.
+    private var canvasSize: CGSize {
+        CGSize(width: imageSize.width * effectiveScale, height: imageSize.height * effectiveScale)
+    }
+
+    /// Content top-left, falling back to the viewport origin until the first
+    /// layout initializes it, so the canvas doesn't flash offset on appear.
+    private var resolvedContentOrigin: CGPoint {
+        didInitOrigin ? contentOrigin : canvasRect.origin
     }
 
     private var currentStyle: AnnotationKit.StrokeStyle {
@@ -205,6 +228,7 @@ private struct InlineAnnotationEditorView: View {
             dimmingOverlay
             canvas
             toolbar
+            resetZoomShortcut
         }
         .frame(width: screenSize.width, height: screenSize.height)
         .background(Color.clear)
@@ -237,19 +261,38 @@ private struct InlineAnnotationEditorView: View {
             textFillColor: textFillColor,
             textOutlineColor: textOutlineColor,
             textGlyphStrokeColor: textGlyphStrokeColor,
-            zoomScale: displayScale,
+            zoomScale: effectiveScale,
             refreshTrigger: refreshTrigger,
             textRegions: textRegions,
             commitEditingTrigger: commitEditingTrigger,
             onSwitchToSelect: switchToSelectTool,
             onInteractionChanged: handleCanvasInteractionChanged,
             onTextEditingStarted: handleTextEditingStarted,
-            onTextEditingEnded: handleTextEditingEnded
+            onTextEditingEnded: handleTextEditingEnded,
+            onMagnify: handleMagnify
         )
-        .frame(width: canvasRect.width, height: canvasRect.height)
+        // Render at full (possibly enlarged) size, panned by the focal offset,
+        // then clip to the fixed capture-footprint viewport so a zoomed canvas
+        // never covers the toolbar or spills across the screen.
+        .frame(width: canvasSize.width, height: canvasSize.height, alignment: .topLeading)
+        .offset(
+            x: resolvedContentOrigin.x - canvasRect.minX,
+            y: resolvedContentOrigin.y - canvasRect.minY
+        )
+        .frame(width: canvasRect.width, height: canvasRect.height, alignment: .topLeading)
         .clipShape(RoundedRectangle(cornerRadius: 6))
         .overlay(canvasBorder)
         .position(x: canvasRect.midX, y: canvasRect.midY)
+    }
+
+    /// Zero-footprint button carrying the ⌘0 "reset zoom" shortcut. Kept in the
+    /// hierarchy (opacity 0, no hit testing) so the shortcut stays live.
+    private var resetZoomShortcut: some View {
+        Button("", action: resetZoom)
+            .keyboardShortcut("0", modifiers: .command)
+            .opacity(0)
+            .allowsHitTesting(false)
+            .frame(width: 0, height: 0)
     }
 
     private var canvasBorder: some View {
@@ -284,6 +327,10 @@ private struct InlineAnnotationEditorView: View {
     }
 
     private func handleAppear() {
+        if !didInitOrigin {
+            contentOrigin = canvasRect.origin
+            didInitOrigin = true
+        }
         lineWidth = savedWidth(for: currentTool)
         strokePattern = savedStrokePattern
         Task {
@@ -315,6 +362,44 @@ private struct InlineAnnotationEditorView: View {
 
     private func handleCanvasInteractionChanged(_ isInteracting: Bool) {
         interactionState.setCanvasInteraction(isInteracting)
+    }
+
+    /// Focal-point pinch zoom: keeps the content point under the pinch fixed
+    /// while scaling, then constrains the pan so the canvas keeps covering its
+    /// viewport. `locInView` is in the canvas's flipped, top-left coordinates.
+    private func handleMagnify(_ magnification: CGFloat, _ locInView: CGPoint) {
+        let oldScale = effectiveScale
+        let newUserZoom = CanvasZoom.clampScale(userZoom * (1 + magnification), min: 1.0, max: 8.0)
+        guard newUserZoom != userZoom else { return }
+        let newScale = displayScale * newUserZoom
+
+        let origin = resolvedContentOrigin
+        let focal = CGPoint(x: origin.x + locInView.x, y: origin.y + locInView.y)
+        let zoomed = CanvasZoom.focalOffset(
+            oldScale: oldScale,
+            newScale: newScale,
+            focalPoint: focal,
+            currentOffset: origin
+        )
+
+        let newSize = CGSize(width: imageSize.width * newScale, height: imageSize.height * newScale)
+        // Clamp in viewport-relative space (origin - viewport top-left), then
+        // lift the result back into the ZStack's coordinate space.
+        let relative = CanvasZoom.clampOffset(
+            CGPoint(x: zoomed.x - canvasRect.minX, y: zoomed.y - canvasRect.minY),
+            contentSize: newSize,
+            viewportSize: canvasRect.size
+        )
+
+        userZoom = newUserZoom
+        contentOrigin = CGPoint(x: relative.x + canvasRect.minX, y: relative.y + canvasRect.minY)
+        didInitOrigin = true
+    }
+
+    private func resetZoom() {
+        userZoom = 1
+        contentOrigin = canvasRect.origin
+        didInitOrigin = true
     }
 
     private func switchToSelectTool() {

--- a/App/Sources/AnnotationEditor/ZoomableScrollContainer.swift
+++ b/App/Sources/AnnotationEditor/ZoomableScrollContainer.swift
@@ -161,22 +161,27 @@ final class FocalZoomScrollView: NSScrollView {
 
     // ⌘-scroll (or ⌘ + precise trackpad) zooms; plain scrolling pans as usual.
     override func scrollWheel(with event: NSEvent) {
-        // ⌘ (+ precise trackpad) zooms toward the cursor.
-        if event.modifierFlags.contains(.command), event.momentumPhase == [],
-           let factor = ScrollZoomBehavior.scaleFactor(
-               verticalDelta: event.scrollingDeltaY,
-               horizontalDelta: event.scrollingDeltaX,
-               hasPreciseDeltas: event.hasPreciseScrollingDeltas
-           ) {
+        switch CanvasScrollGesture.action(
+            commandHeld: event.modifierFlags.contains(.command),
+            isMomentum: event.momentumPhase != [],
+            verticalDelta: event.scrollingDeltaY,
+            horizontalDelta: event.scrollingDeltaX,
+            hasPreciseDeltas: event.hasPreciseScrollingDeltas
+        ) {
+        case let .zoom(factor):
             requestZoom(to: currentScale * factor, focalInWindow: event.locationInWindow)
-            return
+        case .pan:
+            // Pan by moving the clip origin directly. We can't defer to
+            // `super.scrollWheel`: NSScrollView's responsive scrolling ignores
+            // scrollWheel events delivered programmatically (as they are when the
+            // canvas hands off an over-image two-finger drag), so it would
+            // silently do nothing.
+            panContent(with: event)
+        case .ignore:
+            // A ⌘-scroll event with no usable scale change. Swallow it so one
+            // zoom gesture can't also shift the canvas.
+            break
         }
-        // Otherwise pan by moving the clip origin directly. We can't defer to
-        // `super.scrollWheel`: NSScrollView's responsive scrolling ignores
-        // scrollWheel events delivered programmatically (as they are when the
-        // canvas hands off an over-image two-finger drag), so it would silently
-        // do nothing.
-        panContent(with: event)
     }
 
     private func panContent(with event: NSEvent) {

--- a/App/Sources/AnnotationEditor/ZoomableScrollContainer.swift
+++ b/App/Sources/AnnotationEditor/ZoomableScrollContainer.swift
@@ -1,0 +1,252 @@
+// App/Sources/AnnotationEditor/ZoomableScrollContainer.swift
+import AppKit
+import SwiftUI
+import CaptureKit
+
+/// A scrollable, focal-point-zoomable host for the annotator canvas.
+///
+/// SwiftUI's `ScrollView` can't set an arbitrary programmatic content offset,
+/// which cursor-centered pinch zoom requires. This wraps an AppKit `NSScrollView`
+/// so we get scrollbars / two-finger pan / momentum for free while driving the
+/// scale through the shared `zoomScale` binding and holding the pinch point fixed
+/// via `CanvasZoom`. Rendering stays `zoomScale`-based exactly as before.
+///
+/// Flow: a gesture only *reports* the desired scale + focal point and writes the
+/// `zoomScale` binding. SwiftUI then re-renders the content at the new scale and
+/// `updateNSView` performs the document resize + focal reposition in one pass, so
+/// the document size and the rendered content never disagree mid-zoom.
+struct ZoomableScrollContainer<Content: View>: NSViewRepresentable {
+    @Binding var zoomScale: CGFloat
+    /// Full pixel size of the content at the current `zoomScale`
+    /// (i.e. the editor's `previewWidth` × `previewHeight`).
+    let contentSize: CGSize
+    let minScale: CGFloat
+    let maxScale: CGFloat
+    let content: Content
+
+    init(
+        zoomScale: Binding<CGFloat>,
+        contentSize: CGSize,
+        minScale: CGFloat = 0.1,
+        maxScale: CGFloat = 4.0,
+        @ViewBuilder content: () -> Content
+    ) {
+        self._zoomScale = zoomScale
+        self.contentSize = contentSize
+        self.minScale = minScale
+        self.maxScale = maxScale
+        self.content = content()
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> FocalZoomScrollView {
+        let scrollView = FocalZoomScrollView()
+        scrollView.contentView = CenteringClipView()
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = NSColor(white: 0.12, alpha: 1)
+        scrollView.minScale = minScale
+        scrollView.maxScale = maxScale
+        scrollView.currentScale = zoomScale
+
+        let documentView = FlippedContainerView()
+        documentView.frame = CGRect(origin: .zero, size: contentSize)
+        let hosting = NSHostingView(rootView: content)
+        hosting.frame = documentView.bounds
+        hosting.autoresizingMask = [.width, .height]
+        documentView.addSubview(hosting)
+        scrollView.documentView = documentView
+
+        context.coordinator.hostingView = hosting
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: FocalZoomScrollView, context: Context) {
+        context.coordinator.hostingView?.rootView = content
+        scrollView.minScale = minScale
+        scrollView.maxScale = maxScale
+
+        let coordinator = context.coordinator
+        // Report-only: the gesture records the focal point and writes the binding.
+        scrollView.onZoomRequest = { newScale, focal in
+            coordinator.pendingFocal = focal
+            zoomScale = newScale
+        }
+
+        // Apply any scale change here, once SwiftUI has re-rendered `content` at
+        // the new scale, so the document resize and the content match exactly.
+        if abs(zoomScale - scrollView.currentScale) > 0.0001 {
+            scrollView.applyScale(zoomScale, contentSize: contentSize, focal: coordinator.pendingFocal)
+            coordinator.pendingFocal = nil
+        } else {
+            scrollView.syncDocumentSize(contentSize)
+        }
+    }
+
+    @MainActor
+    final class Coordinator {
+        var hostingView: NSHostingView<Content>?
+        /// Focal point (viewport-relative) captured from the last gesture, or nil
+        /// for a button/Fit change (which recenters on the viewport center).
+        var pendingFocal: CGPoint?
+    }
+}
+
+/// A flipped container so the scroll view uses top-left origin coordinates,
+/// matching `CanvasZoom`'s content-origin convention.
+private final class FlippedContainerView: NSView {
+    override var isFlipped: Bool { true }
+}
+
+/// Clip view that centers the document view whenever it is smaller than the
+/// viewport, instead of pinning it to the top-left. Plain `NSScrollView` refuses
+/// negative scroll origins, so centering a small document has to happen here.
+private final class CenteringClipView: NSClipView {
+    override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect {
+        var rect = super.constrainBoundsRect(proposedBounds)
+        guard let documentView else { return rect }
+        let doc = documentView.frame.size
+        if doc.width < rect.width {
+            rect.origin.x = (doc.width - rect.width) / 2
+        }
+        if doc.height < rect.height {
+            rect.origin.y = (doc.height - rect.height) / 2
+        }
+        return rect
+    }
+}
+
+/// `NSScrollView` subclass that turns trackpad pinch and ⌘-scroll into a zoom
+/// *request* (new scale + focal point). The representable applies it.
+final class FocalZoomScrollView: NSScrollView {
+    var currentScale: CGFloat = 1
+    var minScale: CGFloat = 0.1
+    var maxScale: CGFloat = 4.0
+    /// Reports a desired (newScale, focalInViewport). Focal is in viewport-relative
+    /// coordinates (0...viewportSize, top-left origin).
+    var onZoomRequest: ((CGFloat, CGPoint) -> Void)?
+
+    // Re-center on every layout pass. `constrainBoundsRect` alone is timing
+    // dependent (it can run before the viewport has a real size and isn't
+    // reliably re-invoked afterwards), which left small images pinned top-left.
+    // `tile()` is called by AppKit whenever the scroll view lays out, so this is
+    // the dependable hook.
+    override func tile() {
+        super.tile()
+        recenterIfContentFits()
+    }
+
+    /// Center the document on any axis where it is smaller than the viewport.
+    /// No-ops on axes where the content is larger, so it never fights panning.
+    func recenterIfContentFits() {
+        guard let documentView else { return }
+        let doc = documentView.frame.size
+        let clip = contentView.bounds.size
+        guard clip.width > 0, clip.height > 0 else { return }
+        var origin = contentView.bounds.origin
+        if doc.width <= clip.width { origin.x = (doc.width - clip.width) / 2 }
+        if doc.height <= clip.height { origin.y = (doc.height - clip.height) / 2 }
+        guard origin != contentView.bounds.origin else { return }
+        contentView.setBoundsOrigin(origin)
+        reflectScrolledClipView(contentView)
+    }
+
+    // Trackpad pinch — `event.magnification` is a per-event delta.
+    override func magnify(with event: NSEvent) {
+        requestZoom(to: currentScale * (1 + event.magnification), focalInWindow: event.locationInWindow)
+    }
+
+    // ⌘-scroll (or ⌘ + precise trackpad) zooms; plain scrolling pans as usual.
+    override func scrollWheel(with event: NSEvent) {
+        // ⌘ (+ precise trackpad) zooms toward the cursor.
+        if event.modifierFlags.contains(.command), event.momentumPhase == [],
+           let factor = ScrollZoomBehavior.scaleFactor(
+               verticalDelta: event.scrollingDeltaY,
+               horizontalDelta: event.scrollingDeltaX,
+               hasPreciseDeltas: event.hasPreciseScrollingDeltas
+           ) {
+            requestZoom(to: currentScale * factor, focalInWindow: event.locationInWindow)
+            return
+        }
+        // Otherwise pan by moving the clip origin directly. We can't defer to
+        // `super.scrollWheel`: NSScrollView's responsive scrolling ignores
+        // scrollWheel events delivered programmatically (as they are when the
+        // canvas hands off an over-image two-finger drag), so it would silently
+        // do nothing.
+        panContent(with: event)
+    }
+
+    private func panContent(with event: NSEvent) {
+        guard let documentView else { return }
+        let clipView = contentView
+        let doc = documentView.frame.size
+        let viewport = clipView.bounds.size
+        var origin = clipView.bounds.origin
+        origin.x = pannedAxis(origin.x - event.scrollingDeltaX, doc: doc.width, viewport: viewport.width)
+        origin.y = pannedAxis(origin.y - event.scrollingDeltaY, doc: doc.height, viewport: viewport.height)
+        clipView.scroll(to: origin)
+        reflectScrolledClipView(clipView)
+    }
+
+    /// Constrain a panned origin on one axis. When the content fits, hold the
+    /// centered position (matching `recenterIfContentFits`) instead of clamping
+    /// to 0, which would snap a centered image to the edge on the first drag.
+    private func pannedAxis(_ value: CGFloat, doc: CGFloat, viewport: CGFloat) -> CGFloat {
+        guard doc > viewport else { return (doc - viewport) / 2 }
+        return min(max(0, value), doc - viewport)
+    }
+
+    private func requestZoom(to proposed: CGFloat, focalInWindow: NSPoint) {
+        let newScale = CanvasZoom.clampScale(proposed, min: minScale, max: maxScale)
+        guard newScale != currentScale else { return }
+        let clipView = contentView
+        // `convert(from: nil)` yields a point in the clip's bounds space, which
+        // includes the scroll offset; subtract it for the viewport-relative focal.
+        let inClipBounds = clipView.convert(focalInWindow, from: nil)
+        let focal = CGPoint(
+            x: inClipBounds.x - clipView.bounds.origin.x,
+            y: inClipBounds.y - clipView.bounds.origin.y
+        )
+        onZoomRequest?(newScale, focal)
+    }
+
+    /// Resize the document to `contentSize` and reposition so `focal` (or the
+    /// viewport center when nil) stays fixed, then record the new scale.
+    func applyScale(_ newScale: CGFloat, contentSize: CGSize, focal: CGPoint?) {
+        guard let documentView, currentScale > 0 else {
+            syncDocumentSize(contentSize)
+            currentScale = newScale
+            return
+        }
+        let oldScale = currentScale
+        let clipView = contentView
+        let viewport = clipView.bounds.size
+        let f = focal ?? CGPoint(x: viewport.width / 2, y: viewport.height / 2)
+        let currentOffset = CGPoint(x: -clipView.bounds.origin.x, y: -clipView.bounds.origin.y)
+
+        documentView.setFrameSize(contentSize)
+
+        let newOffset = CanvasZoom.focalOffset(
+            oldScale: oldScale,
+            newScale: newScale,
+            focalPoint: f,
+            currentOffset: currentOffset
+        )
+        let clamped = CanvasZoom.clampOffset(newOffset, contentSize: contentSize, viewportSize: viewport)
+        clipView.scroll(to: CGPoint(x: -clamped.x, y: -clamped.y))
+        reflectScrolledClipView(clipView)
+
+        currentScale = newScale
+        recenterIfContentFits()
+    }
+
+    /// Resize the document view without disturbing the scroll position.
+    func syncDocumentSize(_ size: CGSize) {
+        guard let documentView, documentView.frame.size != size else { return }
+        documentView.setFrameSize(size)
+        recenterIfContentFits()
+    }
+}

--- a/App/Tests/AnnotationZoomEventRoutingTests.swift
+++ b/App/Tests/AnnotationZoomEventRoutingTests.swift
@@ -1,0 +1,184 @@
+import AppKit
+import XCTest
+@testable import Capso
+import AnnotationKit
+import CaptureKit
+
+/// Event-routing coverage for the annotator's zoomable surfaces: the main
+/// editor's scroll container must never let a ⌘-scroll leak into a pan, and the
+/// inline editor (which has no scroll view) must receive scroll events itself.
+@MainActor
+final class AnnotationZoomEventRoutingTests: XCTestCase {
+
+    // MARK: - Main editor scroll container
+
+    func testCommandScrollMomentumNeitherZoomsNorPans() throws {
+        let (scrollView, _) = makeScrollView()
+        var zoomRequests: [CGFloat] = []
+        scrollView.onZoomRequest = { scale, _ in zoomRequests.append(scale) }
+        let originBefore = scrollView.contentView.bounds.origin
+
+        scrollView.scrollWheel(with: try scrollEvent(deltaY: 12, command: true, momentum: true))
+
+        XCTAssertTrue(zoomRequests.isEmpty, "momentum must not zoom")
+        XCTAssertEqual(scrollView.contentView.bounds.origin, originBefore, "momentum must not pan")
+    }
+
+    func testMostlyHorizontalCommandScrollNeitherZoomsNorPans() throws {
+        let (scrollView, _) = makeScrollView()
+        var zoomRequests: [CGFloat] = []
+        scrollView.onZoomRequest = { scale, _ in zoomRequests.append(scale) }
+        let originBefore = scrollView.contentView.bounds.origin
+
+        scrollView.scrollWheel(with: try scrollEvent(deltaY: 3, deltaX: 40, command: true))
+
+        XCTAssertTrue(zoomRequests.isEmpty)
+        XCTAssertEqual(scrollView.contentView.bounds.origin, originBefore)
+    }
+
+    func testCommandScrollWithUsableDeltaRequestsZoomWithoutPanning() throws {
+        let (scrollView, _) = makeScrollView()
+        var zoomRequests: [CGFloat] = []
+        scrollView.onZoomRequest = { scale, _ in zoomRequests.append(scale) }
+        let originBefore = scrollView.contentView.bounds.origin
+
+        scrollView.scrollWheel(with: try scrollEvent(deltaY: 12, command: true))
+
+        XCTAssertEqual(zoomRequests.count, 1)
+        XCTAssertGreaterThan(try XCTUnwrap(zoomRequests.first), scrollView.currentScale)
+        XCTAssertEqual(scrollView.contentView.bounds.origin, originBefore, "zooming must not also pan")
+    }
+
+    func testPlainScrollStillPans() throws {
+        let (scrollView, _) = makeScrollView()
+        var zoomRequests: [CGFloat] = []
+        scrollView.onZoomRequest = { scale, _ in zoomRequests.append(scale) }
+        let originBefore = scrollView.contentView.bounds.origin
+
+        scrollView.scrollWheel(with: try scrollEvent(deltaY: -40))
+
+        XCTAssertTrue(zoomRequests.isEmpty, "a plain scroll must not zoom")
+        XCTAssertNotEqual(scrollView.contentView.bounds.origin, originBefore, "a plain scroll must pan")
+    }
+
+    // MARK: - Canvas hand-off
+
+    func testCanvasForwardsScrollToTheOwnerWhenOneIsSet() throws {
+        let view = makeCanvas()
+        var received: [CanvasScrollEvent] = []
+        view.onScroll = { received.append($0) }
+
+        view.scrollWheel(with: try scrollEvent(deltaY: 12, deltaX: -3, command: true))
+
+        let scroll = try XCTUnwrap(received.first)
+        XCTAssertEqual(received.count, 1)
+        XCTAssertEqual(scroll.deltaY, 12, accuracy: 0.001)
+        XCTAssertEqual(scroll.deltaX, -3, accuracy: 0.001)
+        XCTAssertTrue(scroll.commandHeld)
+        XCTAssertFalse(scroll.isMomentum)
+        XCTAssertTrue(scroll.hasPreciseDeltas)
+    }
+
+    func testCanvasReportsMomentumSoOwnersCanSwallowIt() throws {
+        let view = makeCanvas()
+        var received: [CanvasScrollEvent] = []
+        view.onScroll = { received.append($0) }
+
+        view.scrollWheel(with: try scrollEvent(deltaY: 12, command: true, momentum: true))
+
+        XCTAssertTrue(try XCTUnwrap(received.first).isMomentum)
+    }
+
+    func testCanvasHandsScrollToTheEnclosingScrollViewWhenNoOwnerIsSet() throws {
+        let (scrollView, canvas) = makeScrollView(withCanvas: true)
+        let view = try XCTUnwrap(canvas)
+        XCTAssertNil(view.onScroll)
+        let originBefore = scrollView.contentView.bounds.origin
+
+        view.scrollWheel(with: try scrollEvent(deltaY: -40))
+
+        XCTAssertNotEqual(
+            scrollView.contentView.bounds.origin,
+            originBefore,
+            "with no owner the canvas must hand scrolling to the enclosing scroll view"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// A scroll view whose document is larger than the viewport, parked away from
+    /// every edge so a stray pan in any direction moves the clip and is visible to
+    /// the assertions. (Parked at the top-left, an unwanted upward pan clamps to a
+    /// no-op and the test passes for the wrong reason.)
+    private func makeScrollView(withCanvas: Bool = false) -> (FocalZoomScrollView, AnnotationCanvasNSView?) {
+        let viewport = CGRect(x: 0, y: 0, width: 400, height: 300)
+        let scrollView = FocalZoomScrollView(frame: viewport)
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = true
+
+        let document = NSView(frame: CGRect(x: 0, y: 0, width: 1600, height: 1200))
+        var canvas: AnnotationCanvasNSView?
+        if withCanvas {
+            let view = AnnotationCanvasNSView(frame: document.bounds)
+            view.document = AnnotationDocument(imageSize: document.bounds.size)
+            document.addSubview(view)
+            canvas = view
+        }
+        scrollView.documentView = document
+        scrollView.layoutSubtreeIfNeeded()
+
+        let hostWindow = NSWindow(
+            contentRect: viewport,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        hostWindow.contentView?.addSubview(scrollView)
+
+        scrollView.contentView.scroll(to: CGPoint(x: 400, y: 400))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        return (scrollView, canvas)
+    }
+
+    private func makeCanvas() -> AnnotationCanvasNSView {
+        let frame = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let view = AnnotationCanvasNSView(frame: frame)
+        view.document = AnnotationDocument(imageSize: frame.size)
+        let hostWindow = NSWindow(
+            contentRect: frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        hostWindow.contentView = view
+        return view
+    }
+
+    /// Synthesizes a continuous (trackpad-style) scroll event. `NSEvent` has no
+    /// public initializer for scroll events, so this goes through `CGEvent`.
+    private func scrollEvent(
+        deltaY: Int32,
+        deltaX: Int32 = 0,
+        command: Bool = false,
+        momentum: Bool = false,
+        precise: Bool = true
+    ) throws -> NSEvent {
+        let cgEvent = try XCTUnwrap(CGEvent(
+            scrollWheelEvent2Source: nil,
+            units: .pixel,
+            wheelCount: 2,
+            wheel1: deltaY,
+            wheel2: deltaX,
+            wheel3: 0
+        ))
+        if command {
+            cgEvent.flags = .maskCommand
+        }
+        cgEvent.setIntegerValueField(.scrollWheelEventIsContinuous, value: precise ? 1 : 0)
+        if momentum {
+            // Any non-zero momentum phase marks a post-fling glide event.
+            cgEvent.setIntegerValueField(.scrollWheelEventMomentumPhase, value: 2)
+        }
+        return try XCTUnwrap(NSEvent(cgEvent: cgEvent))
+    }
+}

--- a/Packages/CaptureKit/Sources/CaptureKit/CanvasScrollGesture.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/CanvasScrollGesture.swift
@@ -1,0 +1,43 @@
+import CoreGraphics
+
+/// Routes one scroll event to the behavior a zoomable canvas should apply.
+///
+/// Shared by the annotator's main scroll container and the inline overlay so the
+/// two surfaces agree on what ⌘-scroll means. Command-scroll is treated as a
+/// zoom gesture end to end: the events inside it that carry no usable scale
+/// change (momentum, or a small / mostly-horizontal delta) resolve to `.ignore`
+/// rather than falling through to a pan, which would shift the canvas in the
+/// middle of a zoom.
+public enum CanvasScrollGesture {
+    public enum Action: Sendable, Equatable {
+        /// Zoom by `factor`, anchored on the pointer.
+        case zoom(factor: CGFloat)
+        /// Pan the content by this delta, in `NSEvent.scrollingDelta`'s sign
+        /// convention (positive y scrolls content down).
+        case pan(dx: CGFloat, dy: CGFloat)
+        /// Part of a ⌘-scroll gesture with no usable scale change. Callers must
+        /// swallow it instead of panning.
+        case ignore
+    }
+
+    public static func action(
+        commandHeld: Bool,
+        isMomentum: Bool,
+        verticalDelta: CGFloat,
+        horizontalDelta: CGFloat,
+        hasPreciseDeltas: Bool
+    ) -> Action {
+        guard commandHeld else {
+            return .pan(dx: horizontalDelta, dy: verticalDelta)
+        }
+        guard !isMomentum,
+              let factor = ScrollZoomBehavior.scaleFactor(
+                  verticalDelta: verticalDelta,
+                  horizontalDelta: horizontalDelta,
+                  hasPreciseDeltas: hasPreciseDeltas
+              ) else {
+            return .ignore
+        }
+        return .zoom(factor: factor)
+    }
+}

--- a/Packages/CaptureKit/Sources/CaptureKit/CanvasZoom.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/CanvasZoom.swift
@@ -1,0 +1,70 @@
+import CoreGraphics
+
+/// Pure, layout-agnostic zoom math shared by the annotator's zoomable surfaces
+/// (the main editor window and the inline overlay). Kept as a stateless enum of
+/// static functions, mirroring `ScrollZoomBehavior`, so the geometry can be unit
+/// tested in isolation from any AppKit/SwiftUI plumbing.
+public enum CanvasZoom {
+    /// Clamp a proposed scale (or zoom multiplier) into `[lower, upper]`.
+    ///
+    /// The main window clamps an absolute scale (e.g. `0.1...4.0`); the inline
+    /// overlay clamps a `userZoom` multiplier layered on top of its fixed
+    /// display scale (e.g. `1.0...8.0`).
+    public static func clampScale(_ proposed: CGFloat, min lower: CGFloat, max upper: CGFloat) -> CGFloat {
+        Swift.min(Swift.max(proposed, lower), upper)
+    }
+
+    /// Focal-point-preserving content offset, in the **content-origin**
+    /// convention: `offset` is the content's top-left position (as fed to a
+    /// SwiftUI `.offset`, where positive is down/right). Returns the new offset
+    /// that keeps the content point under `focalPoint` visually fixed as the
+    /// scale changes from `oldScale` to `newScale`.
+    ///
+    /// Derivation: with `r = newScale / oldScale`, the content point under the
+    /// focus stays put when `newOffset = focalPoint * (1 - r) + currentOffset * r`.
+    /// Both `focalPoint` and `currentOffset` must be expressed in the same
+    /// coordinate frame; the formula is translation-covariant, so any consistent
+    /// frame works.
+    ///
+    /// An `NSClipView.bounds.origin` is the negation of a content origin, so an
+    /// AppKit caller negates on the way in and back out.
+    public static func focalOffset(
+        oldScale: CGFloat,
+        newScale: CGFloat,
+        focalPoint: CGPoint,
+        currentOffset: CGPoint
+    ) -> CGPoint {
+        guard oldScale > 0 else { return currentOffset }
+        let r = newScale / oldScale
+        return CGPoint(
+            x: focalPoint.x * (1 - r) + currentOffset.x * r,
+            y: focalPoint.y * (1 - r) + currentOffset.y * r
+        )
+    }
+
+    /// Constrain a content offset (content-origin convention, viewport-relative:
+    /// `0` means the content's top-left sits at the viewport's top-left) so the
+    /// scaled content keeps covering the viewport. When an axis of the content is
+    /// smaller than the viewport it is centered on that axis.
+    public static func clampOffset(
+        _ offset: CGPoint,
+        contentSize: CGSize,
+        viewportSize: CGSize
+    ) -> CGPoint {
+        CGPoint(
+            x: clampAxis(offset.x, content: contentSize.width, viewport: viewportSize.width),
+            y: clampAxis(offset.y, content: contentSize.height, viewport: viewportSize.height)
+        )
+    }
+
+    private static func clampAxis(_ value: CGFloat, content: CGFloat, viewport: CGFloat) -> CGFloat {
+        if content <= viewport {
+            // Content narrower than the viewport: center it.
+            return (viewport - content) / 2
+        }
+        // Content larger than the viewport: valid origins run from
+        // `viewport - content` (bottom/right edge flush) up to `0` (top/left flush).
+        let lower = viewport - content
+        return Swift.min(Swift.max(value, lower), 0)
+    }
+}

--- a/Packages/CaptureKit/Tests/CaptureKitTests/CanvasScrollGestureTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/CanvasScrollGestureTests.swift
@@ -1,0 +1,150 @@
+import Testing
+import Foundation
+import CoreGraphics
+@testable import CaptureKit
+
+@Suite("CanvasScrollGesture")
+struct CanvasScrollGestureTests {
+    @Test("A plain scroll pans by the event deltas")
+    func plainScrollPans() {
+        let action = CanvasScrollGesture.action(
+            commandHeld: false,
+            isMomentum: false,
+            verticalDelta: -18,
+            horizontalDelta: 4,
+            hasPreciseDeltas: true
+        )
+
+        #expect(action == .pan(dx: 4, dy: -18))
+    }
+
+    @Test("A plain momentum scroll still pans, so flings keep gliding")
+    func plainMomentumScrollPans() {
+        let action = CanvasScrollGesture.action(
+            commandHeld: false,
+            isMomentum: true,
+            verticalDelta: -6,
+            horizontalDelta: 0,
+            hasPreciseDeltas: true
+        )
+
+        #expect(action == .pan(dx: 0, dy: -6))
+    }
+
+    @Test("A plain scroll pans even when the delta is tiny or horizontal")
+    func plainScrollPansRegardlessOfShape() {
+        let tiny = CanvasScrollGesture.action(
+            commandHeld: false,
+            isMomentum: false,
+            verticalDelta: 0.2,
+            horizontalDelta: 0,
+            hasPreciseDeltas: true
+        )
+        let horizontal = CanvasScrollGesture.action(
+            commandHeld: false,
+            isMomentum: false,
+            verticalDelta: 1,
+            horizontalDelta: 30,
+            hasPreciseDeltas: true
+        )
+
+        #expect(tiny == .pan(dx: 0, dy: 0.2))
+        #expect(horizontal == .pan(dx: 30, dy: 1))
+    }
+
+    @Test("Command-scroll with a usable delta zooms")
+    func commandScrollZooms() {
+        let action = CanvasScrollGesture.action(
+            commandHeld: true,
+            isMomentum: false,
+            verticalDelta: 10,
+            horizontalDelta: 0,
+            hasPreciseDeltas: true
+        )
+
+        guard case let .zoom(factor) = action else {
+            Issue.record("expected a zoom, got \(action)")
+            return
+        }
+        #expect(factor > 1)
+    }
+
+    @Test("Command-scroll downward zooms out")
+    func commandScrollZoomsOut() {
+        let action = CanvasScrollGesture.action(
+            commandHeld: true,
+            isMomentum: false,
+            verticalDelta: -10,
+            horizontalDelta: 0,
+            hasPreciseDeltas: true
+        )
+
+        guard case let .zoom(factor) = action else {
+            Issue.record("expected a zoom, got \(action)")
+            return
+        }
+        #expect(factor < 1)
+    }
+
+    // The regression this type exists for: these three used to fall through to a
+    // pan, so one ⌘-scroll gesture could zoom and then shift the canvas.
+
+    @Test("Command-scroll momentum is ignored, never panned")
+    func commandScrollMomentumIsIgnored() {
+        let action = CanvasScrollGesture.action(
+            commandHeld: true,
+            isMomentum: true,
+            verticalDelta: 12,
+            horizontalDelta: 0,
+            hasPreciseDeltas: true
+        )
+
+        #expect(action == .ignore)
+    }
+
+    @Test("Command-scroll with a delta too small to scale is ignored")
+    func commandScrollSmallDeltaIsIgnored() {
+        let action = CanvasScrollGesture.action(
+            commandHeld: true,
+            isMomentum: false,
+            verticalDelta: 0.3,
+            horizontalDelta: 0,
+            hasPreciseDeltas: true
+        )
+
+        #expect(action == .ignore)
+    }
+
+    @Test("Mostly horizontal command-scroll is ignored")
+    func commandScrollHorizontalIsIgnored() {
+        let action = CanvasScrollGesture.action(
+            commandHeld: true,
+            isMomentum: false,
+            verticalDelta: 4,
+            horizontalDelta: 40,
+            hasPreciseDeltas: true
+        )
+
+        #expect(action == .ignore)
+    }
+
+    @Test("No command-scroll event ever resolves to a pan")
+    func commandScrollNeverPans() {
+        for vertical in stride(from: -30.0, through: 30.0, by: 0.7) {
+            for horizontal in [-40.0, -1.0, 0.0, 1.0, 40.0] {
+                for momentum in [true, false] {
+                    let action = CanvasScrollGesture.action(
+                        commandHeld: true,
+                        isMomentum: momentum,
+                        verticalDelta: CGFloat(vertical),
+                        horizontalDelta: CGFloat(horizontal),
+                        hasPreciseDeltas: true
+                    )
+                    if case .pan = action {
+                        Issue.record("⌘-scroll panned at dy=\(vertical) dx=\(horizontal) momentum=\(momentum)")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Packages/CaptureKit/Tests/CaptureKitTests/CanvasZoomTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/CanvasZoomTests.swift
@@ -1,0 +1,137 @@
+import CoreGraphics
+import Testing
+@testable import CaptureKit
+
+@Suite("CanvasZoom")
+struct CanvasZoomTests {
+    private let tolerance: CGFloat = 1e-6
+
+    private func expectClose(_ a: CGPoint, _ b: CGPoint) {
+        #expect(abs(a.x - b.x) < tolerance)
+        #expect(abs(a.y - b.y) < tolerance)
+    }
+
+    // MARK: - clampScale
+
+    @Test("clampScale clamps to the upper bound")
+    func clampScaleUpper() {
+        #expect(CanvasZoom.clampScale(5.0, min: 0.1, max: 4.0) == 4.0)
+    }
+
+    @Test("clampScale clamps to the lower bound")
+    func clampScaleLower() {
+        #expect(CanvasZoom.clampScale(0.05, min: 0.1, max: 4.0) == 0.1)
+    }
+
+    @Test("clampScale passes values already in range")
+    func clampScaleInRange() {
+        #expect(CanvasZoom.clampScale(1.3, min: 0.1, max: 4.0) == 1.3)
+    }
+
+    @Test("clampScale honors a userZoom floor of 1.0")
+    func clampScaleUserZoomFloor() {
+        #expect(CanvasZoom.clampScale(0.5, min: 1.0, max: 8.0) == 1.0)
+    }
+
+    @Test("clampScale honors a userZoom ceiling of 8.0")
+    func clampScaleUserZoomCeiling() {
+        #expect(CanvasZoom.clampScale(20, min: 1.0, max: 8.0) == 8.0)
+    }
+
+    // MARK: - focalOffset (content-origin convention)
+
+    @Test("focalOffset leaves the offset unchanged when the scale does not change")
+    func focalOffsetNoChange() {
+        let result = CanvasZoom.focalOffset(
+            oldScale: 2, newScale: 2,
+            focalPoint: CGPoint(x: 100, y: 100),
+            currentOffset: CGPoint(x: 0, y: 0)
+        )
+        expectClose(result, CGPoint(x: 0, y: 0))
+    }
+
+    @Test("focalOffset holds the focal point fixed when zooming in x2")
+    func focalOffsetZoomIn() {
+        let result = CanvasZoom.focalOffset(
+            oldScale: 1, newScale: 2,
+            focalPoint: CGPoint(x: 100, y: 100),
+            currentOffset: CGPoint(x: 0, y: 0)
+        )
+        expectClose(result, CGPoint(x: -100, y: -100))
+    }
+
+    @Test("focalOffset holds the focal point fixed when zooming out x0.5")
+    func focalOffsetZoomOut() {
+        let result = CanvasZoom.focalOffset(
+            oldScale: 2, newScale: 1,
+            focalPoint: CGPoint(x: 100, y: 100),
+            currentOffset: CGPoint(x: 0, y: 0)
+        )
+        expectClose(result, CGPoint(x: 50, y: 50))
+    }
+
+    @Test("focalOffset accounts for a non-zero current offset")
+    func focalOffsetNonZeroCurrent() {
+        let result = CanvasZoom.focalOffset(
+            oldScale: 1, newScale: 2,
+            focalPoint: CGPoint(x: 50, y: 50),
+            currentOffset: CGPoint(x: 20, y: 10)
+        )
+        expectClose(result, CGPoint(x: -10, y: -30))
+    }
+
+    @Test("focalOffset guards against a zero old scale")
+    func focalOffsetZeroOldScale() {
+        let current = CGPoint(x: 7, y: 9)
+        let result = CanvasZoom.focalOffset(
+            oldScale: 0, newScale: 2,
+            focalPoint: CGPoint(x: 50, y: 50),
+            currentOffset: current
+        )
+        expectClose(result, current)
+    }
+
+    // MARK: - clampOffset
+
+    @Test("clampOffset leaves an in-range offset untouched")
+    func clampOffsetInRange() {
+        // content 400, viewport 200 -> valid origin range is [-200, 0]
+        let result = CanvasZoom.clampOffset(
+            CGPoint(x: -50, y: -50),
+            contentSize: CGSize(width: 400, height: 400),
+            viewportSize: CGSize(width: 200, height: 200)
+        )
+        expectClose(result, CGPoint(x: -50, y: -50))
+    }
+
+    @Test("clampOffset clamps an over-scrolled positive offset")
+    func clampOffsetPositiveClamp() {
+        // content 400, viewport 200 -> origin range is [-200, 0]
+        let result = CanvasZoom.clampOffset(
+            CGPoint(x: 300, y: 300),
+            contentSize: CGSize(width: 400, height: 400),
+            viewportSize: CGSize(width: 200, height: 200)
+        )
+        expectClose(result, CGPoint(x: 0, y: 0))
+    }
+
+    @Test("clampOffset clamps an over-scrolled negative offset")
+    func clampOffsetNegativeClamp() {
+        let result = CanvasZoom.clampOffset(
+            CGPoint(x: -300, y: -300),
+            contentSize: CGSize(width: 400, height: 400),
+            viewportSize: CGSize(width: 200, height: 200)
+        )
+        expectClose(result, CGPoint(x: -200, y: -200))
+    }
+
+    @Test("clampOffset centers content smaller than the viewport")
+    func clampOffsetCentersSmallContent() {
+        let result = CanvasZoom.clampOffset(
+            CGPoint(x: 999, y: -999),
+            contentSize: CGSize(width: 100, height: 100),
+            viewportSize: CGSize(width: 200, height: 200)
+        )
+        expectClose(result, CGPoint(x: 50, y: 50))
+    }
+}


### PR DESCRIPTION
## What changed

Adds trackpad pinch to zoom in the annotation editor, centered on the cursor so the point under your fingers stays put.

- Pinch to zoom on the canvas, in both the main editor window and the inline in-place editor
- cmd + scroll also zooms toward the cursor
- Two finger drag pans once you're zoomed in past the window size
- The image now stays centered in the editor when it fits the window, instead of pinning to the top left
- The +/- and Fit buttons and existing keyboard shortcuts still work, and now share the same zoom clamping (0.1x to 4x)

How it's put together:
- The zoom math is a small pure helper, `CanvasZoom` in CaptureKit, sitting next to the existing `ScrollZoomBehavior`, with unit tests
- The main window wraps an AppKit `NSScrollView` because SwiftUI's `ScrollView` can't set a programmatic content offset, which cursor centered zoom needs. It centers the image when it fits and pans by moving the clip origin directly
- The inline editor has no scroll view, so it layers a userZoom multiplier on top of its fixed display scale with a manual pan offset, clipped to the capture footprint
- The pinch gesture is picked up in the shared canvas view via an optional callback, so other users of that view are unaffected

## Related issue

Closes #207

## Screenshots / recordings

<p align="center">
  <img width="600" height="437" alt="Capso Recording 2026-07-23 at 22 18 36-small" src="https://github.com/user-attachments/assets/a5e30d09-2864-4585-810e-b5c1bec2b062" />
</p>

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass (`swift test --package-path Packages/CaptureKit`)
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per CONTRIBUTING.md

