### PR TITLE
feat: hold Shift for a 1:1 square area selection

### DIFF
--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -15,6 +15,7 @@ final class CaptureAllInOneToolbarWindow {
     private var annotationOverlay: CaptureAllInOneAnnotationOverlay?
     private var globalEscMonitor: Any?
     private var localEscMonitor: Any?
+    private var localFlagsMonitor: Any?
     private var globalSelectionMouseMonitor: Any?
     private var localSelectionMouseMonitor: Any?
     private var screenLocalSelectionRect: CGRect
@@ -470,6 +471,13 @@ final class CaptureAllInOneToolbarWindow {
         localEscMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             self?.handleKeyboardEvent(event)
         }
+        // The toolbar panel can be key while the selection is being dragged, so
+        // route flags changes to the selection view here too. Double delivery
+        // (view + monitor) is a no-op.
+        localFlagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+            self?.selectionOverlayView?.handleFlagsChanged(event)
+            return event
+        }
     }
 
     private func removeKeyboardMonitor() {
@@ -480,6 +488,10 @@ final class CaptureAllInOneToolbarWindow {
         if let localEscMonitor {
             NSEvent.removeMonitor(localEscMonitor)
             self.localEscMonitor = nil
+        }
+        if let localFlagsMonitor {
+            NSEvent.removeMonitor(localFlagsMonitor)
+            self.localFlagsMonitor = nil
         }
     }
 
@@ -1126,7 +1138,9 @@ private struct UtilityShortcutBadge: View {
     }
 }
 
-private final class AllInOneSelectionOverlayView: NSView {
+/// Internal rather than file-private so interaction tests can drive its
+/// mouse/flags handling directly.
+final class AllInOneSelectionOverlayView: NSView {
     var onSelectionPreviewChanged: ((CGRect) -> Void)?
     var onSelectionChanged: ((CGRect) -> Void)?
     var onCancel: (() -> Void)?
@@ -1291,6 +1305,13 @@ private final class AllInOneSelectionOverlayView: NSView {
         window?.makeFirstResponder(self)
 
         let point = convert(event.locationInWindow, from: nil)
+        // Seed the pointer and Shift state before any early return (including
+        // the fixed-size move path) so a Shift press that lands before the first
+        // mouseDragged recomputes from this press point instead of `.zero` or the
+        // previous drag's endpoint.
+        lastDragPoint = point
+        squareLock = event.modifierFlags.contains(.shift)
+
         if let fixedSize = activePreset.fixedPixelSize {
             if CaptureSelectionGeometry.hitTarget(
                 at: point,
@@ -1338,19 +1359,20 @@ private final class AllInOneSelectionOverlayView: NSView {
         updateSelectionForDrag(to: point)
     }
 
-    // Holding or releasing Shift mid-drag re-runs the current drag against the
-    // last pointer location so the square lock engages/releases live.
     override func flagsChanged(with event: NSEvent) {
+        handleFlagsChanged(event)
+        super.flagsChanged(with: event)
+    }
+
+    /// Holding or releasing Shift mid-drag re-runs the current drag against the
+    /// last pointer location so the square lock engages/releases live. Shared
+    /// entry for the view's `flagsChanged` and the window's local flags monitor,
+    /// so the toggle lands even when this view is not first responder.
+    func handleFlagsChanged(_ event: NSEvent) {
         let nextSquareLock = event.modifierFlags.contains(.shift)
-        guard nextSquareLock != squareLock else {
-            super.flagsChanged(with: event)
-            return
-        }
+        guard nextSquareLock != squareLock else { return }
         squareLock = nextSquareLock
-        if case .none = dragOperation {
-            super.flagsChanged(with: event)
-            return
-        }
+        if case .none = dragOperation { return }
         updateSelectionForDrag(to: lastDragPoint)
     }
 

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -1151,6 +1151,10 @@ private final class AllInOneSelectionOverlayView: NSView {
     private let hitSlop: CGFloat = 26
     private var dragOperation: DragOperation = .none
     private var trackingArea: NSTrackingArea?
+    /// Whether Shift is currently held, locking the drag to a 1:1 square.
+    private var squareLock = false
+    /// Last pointer location during a drag, so a live Shift toggle can recompute.
+    private var lastDragPoint: CGPoint = .zero
 
     init(
         frame: CGRect,
@@ -1329,6 +1333,34 @@ private final class AllInOneSelectionOverlayView: NSView {
 
     override func mouseDragged(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
+        lastDragPoint = point
+        squareLock = event.modifierFlags.contains(.shift)
+        updateSelectionForDrag(to: point)
+    }
+
+    // Holding or releasing Shift mid-drag re-runs the current drag against the
+    // last pointer location so the square lock engages/releases live.
+    override func flagsChanged(with event: NSEvent) {
+        let nextSquareLock = event.modifierFlags.contains(.shift)
+        guard nextSquareLock != squareLock else {
+            super.flagsChanged(with: event)
+            return
+        }
+        squareLock = nextSquareLock
+        if case .none = dragOperation {
+            super.flagsChanged(with: event)
+            return
+        }
+        updateSelectionForDrag(to: lastDragPoint)
+    }
+
+    /// Applies the active drag operation for a pointer location, honoring the
+    /// resolved aspect ratio (Shift locks to 1:1, otherwise the preset ratio).
+    private func updateSelectionForDrag(to point: CGPoint) {
+        let ratio = CaptureSelectionGeometry.selectionAspectRatio(
+            presetRatio: activePreset.isFixedSize ? nil : activePreset.ratio,
+            squareLock: squareLock
+        )
 
         switch dragOperation {
         case .none:
@@ -1340,7 +1372,7 @@ private final class AllInOneSelectionOverlayView: NSView {
                 in: bounds
             )
         case let .resize(handle, startRect):
-            if let ratio = activePreset.ratio, !activePreset.isFixedSize {
+            if let ratio {
                 selectionRect = CaptureSelectionGeometry.resize(
                     startRect,
                     handle: handle,
@@ -1359,7 +1391,7 @@ private final class AllInOneSelectionOverlayView: NSView {
                 )
             }
         case let .create(startPoint):
-            if let ratio = activePreset.ratio, !activePreset.isFixedSize {
+            if let ratio {
                 selectionRect = CaptureSelectionGeometry.rect(
                     from: startPoint,
                     to: point,

--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -46,6 +46,11 @@ final class CaptureOverlayView: NSView {
     private var isDragging = false
     private var dragStart: NSPoint = .zero
     private var dragEnd: NSPoint = .zero
+    /// Whether Shift is currently held, locking the area drag to a 1:1 square.
+    private var squareLock = false
+    /// Last raw (unconstrained) pointer location during an area drag, so a live
+    /// Shift toggle can recompute the constrained corner.
+    private var lastRawEnd: NSPoint = .zero
     private var currentMouseLocation: NSPoint?
 
     /// The currently active capture preset. Starts from settings and can be
@@ -835,7 +840,11 @@ final class CaptureOverlayView: NSView {
 
     /// Apply aspect-ratio constraint to a raw drag endpoint, clamped to view bounds.
     private func constrainedDragEnd(rawEnd: NSPoint) -> NSPoint {
-        guard let ratio = activePreset.ratio, !activePreset.isFixedSize else {
+        let resolvedRatio = CaptureSelectionGeometry.selectionAspectRatio(
+            presetRatio: activePreset.isFixedSize ? nil : activePreset.ratio,
+            squareLock: squareLock
+        )
+        guard let ratio = resolvedRatio else {
             return rawEnd
         }
 
@@ -893,6 +902,8 @@ final class CaptureOverlayView: NSView {
     override func mouseDragged(with event: NSEvent) {
         guard case .area = mode else { return }
         let rawEnd = convert(event.locationInWindow, from: nil)
+        lastRawEnd = rawEnd
+        squareLock = event.modifierFlags.contains(.shift)
         dragEnd = constrainedDragEnd(rawEnd: rawEnd)
         // Reticle tracks the constrained corner so it stays on the selection edge
         currentMouseLocation = dragEnd
@@ -911,6 +922,7 @@ final class CaptureOverlayView: NSView {
         // Fixed-size mode already captured in mouseDown — skip mouseUp
         guard !activePreset.isFixedSize else { return }
         let rawEnd = convert(event.locationInWindow, from: nil)
+        squareLock = event.modifierFlags.contains(.shift)
         dragEnd = constrainedDragEnd(rawEnd: rawEnd)
         isDragging = false
 
@@ -985,7 +997,20 @@ final class CaptureOverlayView: NSView {
 
     override func flagsChanged(with event: NSEvent) {
         handleFlagsChanged(event)
+        updateSquareLockDuringDrag(with: event)
         super.flagsChanged(with: event)
+    }
+
+    /// Toggling Shift mid-drag re-runs the constraint against the last pointer
+    /// location so the 1:1 square lock engages/releases live.
+    private func updateSquareLockDuringDrag(with event: NSEvent) {
+        guard case .area = mode, isDragging else { return }
+        let shiftNow = event.modifierFlags.contains(.shift)
+        guard shiftNow != squareLock else { return }
+        squareLock = shiftNow
+        dragEnd = constrainedDragEnd(rawEnd: lastRawEnd)
+        currentMouseLocation = dragEnd
+        needsDisplay = true
     }
 
     /// Shared entry for both the view's `flagsChanged` and the window's local

--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -636,7 +636,9 @@ final class CaptureOverlayView: NSView {
         )
     }
 
-    private var selectionRect: CGRect {
+    /// The live selection built from the drag anchors. Internal so interaction
+    /// tests can assert mid-drag state.
+    var selectionRect: CGRect {
         let x = min(dragStart.x, dragEnd.x)
         let y = min(dragStart.y, dragEnd.y)
         let w = abs(dragEnd.x - dragStart.x)
@@ -800,9 +802,16 @@ final class CaptureOverlayView: NSView {
     override func mouseDown(with event: NSEvent) {
         switch mode {
         case .area:
+            let loc = convert(event.locationInWindow, from: nil)
+            // Seed the pointer and Shift state before any early return so a
+            // Shift press that lands before the first mouseDragged recomputes
+            // from this press point instead of `.zero` or the previous drag's
+            // endpoint.
+            lastRawEnd = loc
+            squareLock = event.modifierFlags.contains(.shift)
+
             // Fixed-size: no drag — capture immediately centered on cursor
             if let fixedSize = activePreset.fixedPixelSize {
-                let loc = convert(event.locationInWindow, from: nil)
                 let fixedRect = CGRect(
                     x: loc.x - CGFloat(fixedSize.width) / 2,
                     y: loc.y - CGFloat(fixedSize.height) / 2,
@@ -815,7 +824,7 @@ final class CaptureOverlayView: NSView {
             }
 
             isDragging = true
-            dragStart = convert(event.locationInWindow, from: nil)
+            dragStart = loc
             dragEnd = dragStart
             needsDisplay = true
 
@@ -997,7 +1006,6 @@ final class CaptureOverlayView: NSView {
 
     override func flagsChanged(with event: NSEvent) {
         handleFlagsChanged(event)
-        updateSquareLockDuringDrag(with: event)
         super.flagsChanged(with: event)
     }
 
@@ -1014,8 +1022,10 @@ final class CaptureOverlayView: NSView {
     }
 
     /// Shared entry for both the view's `flagsChanged` and the window's local
-    /// flags monitor so Shift-release confirmation stays reliable.
+    /// flags monitor so Shift-release confirmation and the live square lock stay
+    /// reliable even when the dragging view is not first responder.
     func handleFlagsChanged(_ event: NSEvent, allowsNonKeyConfirmation: Bool = false) {
+        updateSquareLockDuringDrag(with: event)
         guard allowsMultiWindowSelection else { return }
         let shiftNow = event.modifierFlags.contains(.shift)
         if (isShiftHeld || allowsNonKeyConfirmation) && !shiftNow {

--- a/App/Sources/Capture/CaptureOverlayWindow.swift
+++ b/App/Sources/Capture/CaptureOverlayWindow.swift
@@ -140,13 +140,14 @@ final class CaptureOverlayWindow: NSPanel {
         localEscMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             self?.handleLocalKeyEvent(event) ?? event
         }
-        // Ensure Shift release confirms multi-window capture even if the view
-        // is not first responder (e.g. after clicking across screens).
-        if allowsMultiWindowSelection {
-            localFlagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
-                self?.overlayView.handleFlagsChanged(event)
-                return event
-            }
+        // Ensure Shift-driven behavior still runs when the view is not first
+        // responder (e.g. after clicking across screens): multi-window
+        // confirmation on release, and the live 1:1 square lock during a drag.
+        // Installed for every overlay since the square lock is not gated on
+        // multi-window selection. Double delivery (view + monitor) is a no-op.
+        localFlagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+            self?.overlayView.handleFlagsChanged(event)
+            return event
         }
     }
 

--- a/App/Tests/CaptureOverlayInteractionTests.swift
+++ b/App/Tests/CaptureOverlayInteractionTests.swift
@@ -190,6 +190,178 @@ final class CaptureOverlayInteractionTests: XCTestCase {
         XCTAssertNil(selectedWindowIDs)
     }
 
+    // MARK: - Shift square lock
+
+    func testShiftPressedBeforeFirstDragKeepsSelectionAnchoredAtPressPoint() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+
+        let view = makeAreaOverlayView(settings: settings)
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 180, y: 140)))
+        view.flagsChanged(with: try makeFlagsChangedEvent(modifierFlags: .shift))
+
+        // Nothing has moved yet, so the square lock must resolve to an empty
+        // selection at the press point — not jump toward the screen origin.
+        XCTAssertEqual(view.selectionRect, CGRect(x: 180, y: 140, width: 0, height: 0))
+    }
+
+    func testShiftDuringDragSquaresSelectionFromLastPointerLocation() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+
+        let view = makeAreaOverlayView(settings: settings)
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 180, y: 140)))
+        view.mouseDragged(with: try makeMouseEvent(.leftMouseDragged, at: NSPoint(x: 300, y: 200)))
+        XCTAssertEqual(view.selectionRect, CGRect(x: 180, y: 140, width: 120, height: 60))
+
+        view.flagsChanged(with: try makeFlagsChangedEvent(modifierFlags: .shift))
+        XCTAssertEqual(view.selectionRect, CGRect(x: 180, y: 140, width: 120, height: 120))
+
+        view.flagsChanged(with: try makeFlagsChangedEvent(modifierFlags: []))
+        XCTAssertEqual(view.selectionRect, CGRect(x: 180, y: 140, width: 120, height: 60))
+    }
+
+    func testSecondDragDoesNotReusePreviousDragEndpoint() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+
+        let view = makeAreaOverlayView(settings: settings)
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 180, y: 140)))
+        view.mouseDragged(with: try makeMouseEvent(.leftMouseDragged, at: NSPoint(x: 400, y: 300)))
+        view.mouseUp(with: try makeMouseEvent(.leftMouseUp, at: NSPoint(x: 400, y: 300)))
+
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 100, y: 100)))
+        view.flagsChanged(with: try makeFlagsChangedEvent(modifierFlags: .shift))
+
+        XCTAssertEqual(view.selectionRect, CGRect(x: 100, y: 100, width: 0, height: 0))
+    }
+
+    func testFlagsMonitorPathAppliesSquareLockWhenViewIsNotFirstResponder() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+
+        let view = makeAreaOverlayView(settings: settings, allowsMultiWindowSelection: false)
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 180, y: 140)))
+        view.mouseDragged(with: try makeMouseEvent(.leftMouseDragged, at: NSPoint(x: 300, y: 200)))
+
+        // The window's local flags monitor calls handleFlagsChanged directly,
+        // bypassing the view's flagsChanged responder path.
+        view.handleFlagsChanged(try makeFlagsChangedEvent(modifierFlags: .shift))
+
+        XCTAssertEqual(view.selectionRect, CGRect(x: 180, y: 140, width: 120, height: 120))
+    }
+
+    func testAllInOneShiftBeforeFirstDragCreatesSquareAtPressPoint() throws {
+        let (view, previews) = makeAllInOneOverlayView(activePreset: .freeform)
+
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 120, y: 100)))
+        view.handleFlagsChanged(try makeFlagsChangedEvent(modifierFlags: .shift))
+
+        // No movement yet, so the square collapses to the minimum size anchored
+        // at the press point instead of being derived from `.zero`.
+        XCTAssertEqual(try XCTUnwrap(previews.last), CGRect(x: 120, y: 100, width: 24, height: 24))
+    }
+
+    func testAllInOneShiftBeforeFirstDragKeepsFixedSizeSelectionCentered() throws {
+        let (view, previews) = makeAllInOneOverlayView(
+            activePreset: .fixedSize(width: 200, height: 100, name: nil)
+        )
+
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 700, y: 500)))
+        let centered = try XCTUnwrap(previews.last)
+        XCTAssertEqual(centered, CGRect(x: 600, y: 450, width: 200, height: 100))
+
+        // Shift before the first drag must not move the fixed-size selection.
+        view.handleFlagsChanged(try makeFlagsChangedEvent(modifierFlags: .shift))
+        XCTAssertEqual(previews.last, centered)
+    }
+
+    func testAllInOneSecondDragDoesNotReusePreviousDragEndpoint() throws {
+        let (view, previews) = makeAllInOneOverlayView(activePreset: .freeform)
+
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 120, y: 100)))
+        view.mouseDragged(with: try makeMouseEvent(.leftMouseDragged, at: NSPoint(x: 400, y: 300)))
+        view.mouseUp(with: try makeMouseEvent(.leftMouseUp, at: NSPoint(x: 400, y: 300)))
+
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 200, y: 450)))
+        view.handleFlagsChanged(try makeFlagsChangedEvent(modifierFlags: .shift))
+
+        // A minimum square at the new press point — the previous drag's endpoint
+        // (400, 300) must not size this one.
+        XCTAssertEqual(try XCTUnwrap(previews.last), CGRect(x: 200, y: 426, width: 24, height: 24))
+    }
+
+    private func makeAreaOverlayView(
+        settings: AppSettings,
+        allowsMultiWindowSelection: Bool = true
+    ) -> CaptureOverlayView {
+        let frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        let view = CaptureOverlayView(
+            frame: frame,
+            settings: settings,
+            safeAreaTopInset: 0,
+            allowsMultiWindowSelection: allowsMultiWindowSelection
+        )
+        let hostWindow = NSWindow(
+            contentRect: frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        hostWindow.contentView = view
+        view.setMode(.area)
+        return view
+    }
+
+    /// Hosts the all-in-one selection overlay and records every live preview it
+    /// publishes, which is how the window observes selection changes.
+    private func makeAllInOneOverlayView(
+        activePreset: CapturePreset
+    ) -> (AllInOneSelectionOverlayView, PreviewRecorder) {
+        let frame = CGRect(x: 0, y: 0, width: 800, height: 600)
+        let view = AllInOneSelectionOverlayView(
+            frame: frame,
+            selectionRect: CGRect(x: 200, y: 160, width: 300, height: 200),
+            minSelectionSize: CGSize(width: 24, height: 24),
+            activePreset: activePreset
+        )
+        let hostWindow = NSWindow(
+            contentRect: frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        hostWindow.contentView = view
+
+        let recorder = PreviewRecorder()
+        view.onSelectionPreviewChanged = { recorder.rects.append($0) }
+        return (view, recorder)
+    }
+
+    @MainActor
+    private final class PreviewRecorder {
+        var rects: [CGRect] = []
+        var last: CGRect? { rects.last }
+    }
+
+    private func makeMouseEvent(
+        _ type: NSEvent.EventType,
+        at location: NSPoint,
+        modifierFlags: NSEvent.ModifierFlags = []
+    ) throws -> NSEvent {
+        try XCTUnwrap(NSEvent.mouseEvent(
+            with: type,
+            location: location,
+            modifierFlags: modifierFlags,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ))
+    }
+
     private func makeSettings() -> (AppSettings, String) {
         let suiteName = "CaptureOverlayInteractionTests.\(UUID().uuidString)"
         return (AppSettings(defaults: UserDefaults(suiteName: suiteName)!), suiteName)

--- a/Packages/CaptureKit/Sources/CaptureKit/CaptureSelectionGeometry.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/CaptureSelectionGeometry.swift
@@ -17,6 +17,13 @@ public enum CaptureSelectionHitTarget: Sendable, Equatable {
 }
 
 public enum CaptureSelectionGeometry {
+    /// The aspect ratio to apply while creating or resizing a selection.
+    /// Holding Shift locks the selection to a 1:1 square, overriding any active
+    /// preset ratio; otherwise the preset ratio (if any) is used.
+    public static func selectionAspectRatio(presetRatio: CGFloat?, squareLock: Bool) -> CGFloat? {
+        squareLock ? 1 : presetRatio
+    }
+
     public static func rect(
         from startPoint: CGPoint,
         to currentPoint: CGPoint,

--- a/Packages/CaptureKit/Tests/CaptureKitTests/CaptureSelectionGeometryTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/CaptureSelectionGeometryTests.swift
@@ -188,4 +188,56 @@ struct CaptureSelectionGeometryTests {
 
         #expect(fixed == CGRect(x: 200, y: 160, width: 300, height: 200))
     }
+
+    // MARK: - Shift-to-square aspect ratio resolution
+
+    @Test("Without square lock a free drag keeps no aspect ratio")
+    func resolverFreeDragHasNoRatio() {
+        #expect(CaptureSelectionGeometry.selectionAspectRatio(presetRatio: nil, squareLock: false) == nil)
+    }
+
+    @Test("Without square lock an active preset ratio passes through")
+    func resolverPresetRatioPassesThrough() {
+        let preset: CGFloat = 16.0 / 9.0
+        #expect(CaptureSelectionGeometry.selectionAspectRatio(presetRatio: preset, squareLock: false) == preset)
+    }
+
+    @Test("Square lock forces a 1:1 ratio with no preset")
+    func resolverSquareLockForcesOneToOne() {
+        #expect(CaptureSelectionGeometry.selectionAspectRatio(presetRatio: nil, squareLock: true) == 1)
+    }
+
+    @Test("Square lock overrides an active preset ratio")
+    func resolverSquareLockOverridesPreset() {
+        #expect(CaptureSelectionGeometry.selectionAspectRatio(presetRatio: 16.0 / 9.0, squareLock: true) == 1)
+    }
+
+    @Test("A square-locked up-left drag still produces a square")
+    func squareLockUpLeftDragIsSquare() {
+        let created = CaptureSelectionGeometry.rect(
+            from: CGPoint(x: 200, y: 200),
+            to: CGPoint(x: 120, y: 150),
+            in: bounds,
+            minSize: minSize,
+            aspectRatio: 1
+        )
+
+        #expect(abs(created.width - created.height) < 1e-6)
+        #expect(created.width > 0)
+        #expect(bounds.contains(created))
+    }
+
+    @Test("A tiny square-locked drag respects the minimum size and stays square")
+    func squareLockTinyDragRespectsMinimum() {
+        let created = CaptureSelectionGeometry.rect(
+            from: CGPoint(x: 100, y: 100),
+            to: CGPoint(x: 105, y: 102),
+            in: bounds,
+            minSize: minSize,
+            aspectRatio: 1
+        )
+
+        #expect(abs(created.width - created.height) < 1e-6)
+        #expect(created.width >= minSize.width)
+    }
 }


### PR DESCRIPTION
## What changed

Adds a Shift modifier that locks the area-selection drag to a 1:1 square, the way the marquee tool works in most design apps.

- Hold Shift while dragging out an area to constrain the selection to a square
- Release Shift and it goes back to a free (or preset-ratio) drag
- Toggling Shift mid-drag updates the selection live against the last cursor position
- Works in both selection overlays: the main all-in-one capture and the OCR / recording overlay

How it's put together:
- The Shift-vs-preset decision is a small pure helper, `CaptureSelectionGeometry.selectionAspectRatio(presetRatio:squareLock:)`, sitting next to the existing selection geometry, with unit tests. Shift wins with 1:1, otherwise the preset ratio (if any) is used
- Both overlays just read `event.modifierFlags.contains(.shift)` and feed the resolved ratio into the existing, already-tested `rect(...aspectRatio:)` / `resize(...aspectRatio:)` math
- Shift is ignored for fixed-size presets, and releasing it returns to the prior behavior

## Related issue

Closes #209

## Screenshots / recordings

<p align="center">
  <img width="600" height="449" alt="Capso Recording 2026-07-23 at 22 57 31 - 600px" src="https://github.com/user-attachments/assets/52fac7fa-cc45-42e2-8b91-47686e2a754c" />
</p>

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass (`swift test --package-path Packages/CaptureKit`)
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per CONTRIBUTING.md
