### PR TITLE
fix: repair capture shortcuts and GIF editor export

### DIFF
--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -902,6 +902,32 @@ final class CaptureCoordinator {
         windowLayer != 0
     }
 
+    nonisolated static func frozenWindowCaptureRect(
+        windowRect: CGRect,
+        screenSize: CGSize,
+        windowLayer: Int,
+        appName: String,
+        appBundleIdentifier: String?,
+        captureWindowShadow: Bool
+    ) -> CGRect {
+        let hasIdentifiedApplication = !appName.isEmpty
+            || !(appBundleIdentifier?.isEmpty ?? true)
+        let includesNativeShadow = captureWindowShadow
+            && hasIdentifiedApplication
+            && windowLayer > 0
+            && windowLayer < Int(CGWindowLevelForKey(.screenSaverWindow))
+            && windowLayer != Int(CGWindowLevelForKey(.mainMenuWindow))
+        guard includesNativeShadow else { return windowRect }
+
+        let shorterSide = min(windowRect.width, windowRect.height)
+        let padding = max(30, shorterSide * 0.04) + 20
+        let screenBounds = CGRect(origin: .zero, size: screenSize)
+        let paddedRect = windowRect
+            .insetBy(dx: -padding, dy: -padding)
+            .intersection(screenBounds)
+        return paddedRect.isNull || paddedRect.isEmpty ? windowRect : paddedRect
+    }
+
     private func captureFrozenScreens() -> [(NSScreen, CGImage)] {
         NSScreen.screens.compactMap { screen in
             guard let image = Self.syncCaptureDisplay(screen.displayID) else { return nil }
@@ -1333,8 +1359,16 @@ final class CaptureCoordinator {
             fromTopLeftCaptureRect: displayLocalRect,
             screenHeight: displayBounds.height
         )
+        let captureRect = Self.frozenWindowCaptureRect(
+            windowRect: screenLocalRect,
+            screenSize: displayBounds.size,
+            windowLayer: window.windowLayer,
+            appName: window.appName,
+            appBundleIdentifier: window.appBundleIdentifier,
+            captureWindowShadow: settings.captureWindowShadow
+        )
         guard let frozenResult = frozenAreaResult(
-            rect: screenLocalRect,
+            rect: captureRect,
             screen: screen,
             frozenImage: frozenImage
         ) else {

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -844,6 +844,13 @@ final class CaptureCoordinator {
             return
         }
 
+        let selectableWindowsByID: [CGWindowID: WindowInfo]
+        if case let .windowSelection(windows) = mode {
+            selectableWindowsByID = Dictionary(uniqueKeysWithValues: windows.map { ($0.id, $0) })
+        } else {
+            selectableWindowsByID = [:]
+        }
+
         showFreezeWindows(frozenScreens)
 
         // Step 2: Create transparent overlay windows (top layer) for selection
@@ -864,8 +871,19 @@ final class CaptureCoordinator {
                 }
             }
             overlay.onWindowSelected = { [weak self] windowID in
-                self?.dismissOverlay()
-                self?.performWindowCapture(windowID: windowID)
+                guard let self else { return }
+                self.dismissOverlay()
+                if let window = selectableWindowsByID[windowID],
+                   Self.shouldUseFrozenWindowCapture(windowLayer: window.windowLayer),
+                   let result = self.frozenWindowResult(
+                       window: window,
+                       screen: screen,
+                       frozenImage: frozenImage
+                   ) {
+                    self.handleCaptureResult(result)
+                } else {
+                    self.performWindowCapture(windowID: windowID)
+                }
             }
             overlay.onWindowsSelected = { [weak self] windowIDs in
                 self?.dismissOverlay()
@@ -878,6 +896,10 @@ final class CaptureCoordinator {
             overlay.activate(mode: mode)
             overlayWindows.append(overlay)
         }
+    }
+
+    nonisolated static func shouldUseFrozenWindowCapture(windowLayer: Int) -> Bool {
+        windowLayer != 0
     }
 
     private func captureFrozenScreens() -> [(NSScreen, CGImage)] {
@@ -1289,6 +1311,43 @@ final class CaptureCoordinator {
             image: image,
             mode: .area,
             captureRect: captureRect,
+            displayID: screen.displayID
+        )
+    }
+
+    private func frozenWindowResult(
+        window: WindowInfo,
+        screen: NSScreen,
+        frozenImage: CGImage
+    ) -> CaptureResult? {
+        let displayBounds = CGDisplayBounds(screen.displayID)
+        let displayLocalRect = CaptureDisplayGeometry.displayLocalRect(
+            fromGlobalTopLeftRect: window.frame,
+            displayBounds: displayBounds
+        )
+        guard !displayLocalRect.isNull, !displayLocalRect.isEmpty else {
+            return nil
+        }
+
+        let screenLocalRect = CaptureDisplayGeometry.screenLocalRect(
+            fromTopLeftCaptureRect: displayLocalRect,
+            screenHeight: displayBounds.height
+        )
+        guard let frozenResult = frozenAreaResult(
+            rect: screenLocalRect,
+            screen: screen,
+            frozenImage: frozenImage
+        ) else {
+            return nil
+        }
+
+        return CaptureResult(
+            image: frozenResult.image,
+            mode: .window,
+            captureRect: window.frame,
+            windowName: window.title,
+            appName: window.appName.isEmpty ? nil : window.appName,
+            appBundleIdentifier: window.appBundleIdentifier,
             displayID: screen.displayID
         )
     }

--- a/App/Sources/Editor/EditorCoordinator.swift
+++ b/App/Sources/Editor/EditorCoordinator.swift
@@ -13,6 +13,7 @@ final class EditorCoordinator {
     // MARK: - Project
 
     var project: RecordingProject
+    let outputFormat: EditorOutputFormat
 
     // MARK: - Playback
 
@@ -44,8 +45,9 @@ final class EditorCoordinator {
 
     // MARK: - Init
 
-    init(project: RecordingProject) {
+    init(project: RecordingProject, outputFormat: EditorOutputFormat) {
         self.project = project
+        self.outputFormat = outputFormat
         let asset = AVURLAsset(url: project.sourceVideoURL)
         self.playerItem = AVPlayerItem(asset: asset)
         self.player = AVPlayer(playerItem: playerItem)
@@ -529,8 +531,12 @@ final class EditorCoordinator {
             exportStatusMessage = nil
         }
 
+        if format == .gif {
+            return try await exportGIF(quality: quality, destination: destination)
+        }
+
         if hasCompositingEffects {
-            let rendered = try await exportWithCompositor(format: format, quality: quality, destination: destination)
+            let rendered = try await exportWithCompositor(quality: quality, destination: destination)
             if !project.trimRegions.isEmpty {
                 let cutDestination = destination
                 let uncutDestination = rendered.deletingLastPathComponent()
@@ -555,7 +561,7 @@ final class EditorCoordinator {
             }
             return rendered
         } else {
-            if format == .mp4, !project.trimRegions.isEmpty {
+            if !project.trimRegions.isEmpty {
                 return try await CutExporter.exportMP4(
                     source: project.sourceVideoURL,
                     trimRegions: project.trimRegions,
@@ -573,7 +579,7 @@ final class EditorCoordinator {
                 }
             }
 
-            let options = ExportOptions(format: format, quality: quality, destination: destination)
+            let options = ExportOptions(format: .mp4, quality: quality, destination: destination)
             return try await VideoExporter.export(
                 source: project.sourceVideoURL,
                 options: options
@@ -590,8 +596,62 @@ final class EditorCoordinator {
         }
     }
 
+    private func exportGIF(quality: ExportQuality, destination: URL) async throws -> URL {
+        var source = project.sourceVideoURL
+        var temporaryFiles: [URL] = []
+        defer {
+            for url in temporaryFiles {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+
+        if hasCompositingEffects {
+            let compositedURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("\(UUID().uuidString)-composited")
+                .appendingPathExtension("mp4")
+            temporaryFiles.append(compositedURL)
+            source = try await exportWithCompositor(quality: quality, destination: compositedURL)
+        }
+
+        if !project.trimRegions.isEmpty {
+            let trimmedURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent("\(UUID().uuidString)-trimmed")
+                .appendingPathExtension("mp4")
+            temporaryFiles.append(trimmedURL)
+            source = try await CutExporter.exportMP4(
+                source: source,
+                trimRegions: project.trimRegions,
+                quality: quality,
+                destination: trimmedURL
+            ) { [weak self] progress in
+                Task { @MainActor in
+                    self?.exportProgress = progress
+                }
+            } status: { [weak self] status in
+                Task { @MainActor in
+                    self?.exportProgress = status.fractionCompleted
+                    self?.exportStatusMessage = status.stage.userDescription
+                }
+            }
+        }
+
+        let options = ExportOptions(format: .gif, quality: quality, destination: destination)
+        return try await VideoExporter.export(
+            source: source,
+            options: options
+        ) { [weak self] progress in
+            Task { @MainActor in
+                self?.exportProgress = progress
+            }
+        } status: { [weak self] status in
+            Task { @MainActor in
+                self?.exportProgress = status.fractionCompleted
+                self?.exportStatusMessage = status.stage.userDescription
+            }
+        }
+    }
+
     private func exportWithCompositor(
-        format: ExportFormat,
         quality: ExportQuality,
         destination: URL
     ) async throws -> URL {

--- a/App/Sources/Editor/EditorOutputFormat.swift
+++ b/App/Sources/Editor/EditorOutputFormat.swift
@@ -1,0 +1,37 @@
+import ExportKit
+import RecordingKit
+import UniformTypeIdentifiers
+
+enum EditorOutputFormat: Equatable, Sendable {
+    case mp4
+    case gif
+
+    init(recordingFormat: RecordingKit.RecordingFormat) {
+        self = recordingFormat == .gif ? .gif : .mp4
+    }
+
+    var exportFormat: ExportFormat {
+        switch self {
+        case .mp4: .mp4
+        case .gif: .gif
+        }
+    }
+
+    var contentType: UTType {
+        switch self {
+        case .mp4: .mpeg4Movie
+        case .gif: .gif
+        }
+    }
+
+    var fileExtension: String {
+        switch self {
+        case .mp4: "mp4"
+        case .gif: "gif"
+        }
+    }
+
+    var defaultFilename: String {
+        "Recording.\(fileExtension)"
+    }
+}

--- a/App/Sources/Editor/EditorPlaybackControls.swift
+++ b/App/Sources/Editor/EditorPlaybackControls.swift
@@ -97,9 +97,10 @@ struct EditorPlaybackControls: View {
     }
 
     private func exportToFile() {
+        let outputFormat = coordinator.outputFormat
         let panel = NSSavePanel()
-        panel.allowedContentTypes = [.mpeg4Movie]
-        panel.nameFieldStringValue = "Recording.mp4"
+        panel.allowedContentTypes = [outputFormat.contentType]
+        panel.nameFieldStringValue = outputFormat.defaultFilename
         panel.canCreateDirectories = true
 
         guard panel.runModal() == .OK, let url = panel.url else { return }
@@ -107,7 +108,7 @@ struct EditorPlaybackControls: View {
         Task {
             do {
                 _ = try await coordinator.exportVideo(
-                    format: .mp4,
+                    format: outputFormat.exportFormat,
                     quality: .maximum,
                     destination: url
                 )
@@ -120,13 +121,16 @@ struct EditorPlaybackControls: View {
     }
 
     private func exportToClipboard() {
+        let outputFormat = coordinator.outputFormat
         let tempDir = FileManager.default.temporaryDirectory
-        let tempURL = tempDir.appendingPathComponent("\(UUID().uuidString).mp4")
+        let tempURL = tempDir
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension(outputFormat.fileExtension)
 
         Task {
             do {
                 let url = try await coordinator.exportVideo(
-                    format: .mp4,
+                    format: outputFormat.exportFormat,
                     quality: .maximum,
                     destination: tempURL
                 )

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -585,7 +585,8 @@ final class RecordingCoordinator {
                         tempURL: tempURL,
                         cursorTelemetryURL: cursorTelemetryURL,
                         showsCursor: settings.showCursor,
-                        recordingAreaSize: result.size
+                        recordingAreaSize: result.size,
+                        outputFormat: EditorOutputFormat(recordingFormat: format)
                     )
                 } else {
                     // Quick-preview flow: show thumbnail preview with Save/Copy/Discard
@@ -721,7 +722,8 @@ final class RecordingCoordinator {
         tempURL: URL,
         cursorTelemetryURL: URL?,
         showsCursor: Bool,
-        recordingAreaSize: CGSize
+        recordingAreaSize: CGSize,
+        outputFormat: EditorOutputFormat
     ) {
         Task {
             let asset = AVURLAsset(url: tempURL)
@@ -738,7 +740,7 @@ final class RecordingCoordinator {
                 recordingAreaSize: recordingAreaSize
             )
 
-            let coordinator = EditorCoordinator(project: project)
+            let coordinator = EditorCoordinator(project: project, outputFormat: outputFormat)
             coordinator.onClose = { [weak self] in
                 self?.editorWindow?.close()
                 self?.editorWindow = nil

--- a/App/Sources/Recording/RecordingToolbarWindow.swift
+++ b/App/Sources/Recording/RecordingToolbarWindow.swift
@@ -1,13 +1,25 @@
 // App/Sources/Recording/RecordingToolbarWindow.swift
 import AppKit
+import Observation
 import SwiftUI
 import SharedKit
+
+@Observable
+@MainActor
+private final class RecordingToolbarState {
+    var cameraEnabled = false
+    var selectedCameraID: String?
+    var micEnabled = false
+    var systemAudioEnabled = true
+}
 
 /// Floating toolbar shown after area selection, before recording starts.
 @MainActor
 final class RecordingToolbarWindow: NSPanel {
     private let settings: AppSettings
     private let onCancelAction: () -> Void
+    private let onRecordAction: (RecordingFormatChoice, Bool, String?, Bool, Bool) -> Void
+    private let toolbarState = RecordingToolbarState()
 
     init(
         selectionRect: CGRect,
@@ -21,6 +33,7 @@ final class RecordingToolbarWindow: NSPanel {
     ) {
         self.settings = settings
         self.onCancelAction = onCancel
+        self.onRecordAction = onRecord
         let width: CGFloat = 240
         let height: CGFloat = 220
 
@@ -50,6 +63,7 @@ final class RecordingToolbarWindow: NSPanel {
             width: outputSize.width,
             height: outputSize.height,
             settings: settings,
+            state: toolbarState,
             onRecord: onRecord,
             onCameraToggled: onCameraToggled,
             onChangeArea: onChangeArea,
@@ -82,6 +96,21 @@ final class RecordingToolbarWindow: NSPanel {
             onCancelAction()
             return
         }
+        if event.keyCode == 36 { // Return
+            let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            guard modifiers.isEmpty || modifiers == .option else {
+                super.keyDown(with: event)
+                return
+            }
+            onRecordAction(
+                modifiers == .option ? .gif : .video,
+                toolbarState.cameraEnabled,
+                toolbarState.selectedCameraID,
+                toolbarState.micEnabled,
+                toolbarState.systemAudioEnabled
+            )
+            return
+        }
         super.keyDown(with: event)
     }
 
@@ -93,42 +122,51 @@ private struct RecordingToolbarWrapper: View {
     let width: Int
     let height: Int
     let settings: AppSettings
+    @Bindable var state: RecordingToolbarState
     let onRecord: (RecordingFormatChoice, Bool, String?, Bool, Bool) -> Void
     let onCameraToggled: (Bool, String?) async -> Bool
     let onChangeArea: () -> Void
     let onCancel: () -> Void
     let onCameraSettingsChanged: () -> Void
 
-    @State private var cameraEnabled = false
-    @State private var selectedCameraID: String?
-    @State private var micEnabled = false
-    @State private var systemAudioEnabled = true
     @State private var cameraToggleTask: Task<Void, Never>?
 
     var body: some View {
         RecordingToolbarView(
             width: width,
             height: height,
-            cameraEnabled: $cameraEnabled,
-            selectedCameraID: $selectedCameraID,
-            micEnabled: $micEnabled,
-            systemAudioEnabled: $systemAudioEnabled,
+            cameraEnabled: $state.cameraEnabled,
+            selectedCameraID: $state.selectedCameraID,
+            micEnabled: $state.micEnabled,
+            systemAudioEnabled: $state.systemAudioEnabled,
             settings: settings,
             onRecordVideo: {
-                onRecord(.video, cameraEnabled, selectedCameraID, micEnabled, systemAudioEnabled)
+                onRecord(
+                    .video,
+                    state.cameraEnabled,
+                    state.selectedCameraID,
+                    state.micEnabled,
+                    state.systemAudioEnabled
+                )
             },
             onRecordGIF: {
-                onRecord(.gif, cameraEnabled, selectedCameraID, micEnabled, systemAudioEnabled)
+                onRecord(
+                    .gif,
+                    state.cameraEnabled,
+                    state.selectedCameraID,
+                    state.micEnabled,
+                    state.systemAudioEnabled
+                )
             },
             onChangeArea: onChangeArea,
             onCancel: onCancel,
             onCameraSettingsChanged: onCameraSettingsChanged
         )
-        .onChange(of: cameraEnabled) { _, newValue in
-            updateCamera(enabled: newValue, deviceID: selectedCameraID)
+        .onChange(of: state.cameraEnabled) { _, newValue in
+            updateCamera(enabled: newValue, deviceID: state.selectedCameraID)
         }
-        .onChange(of: selectedCameraID) { _, newValue in
-            if cameraEnabled {
+        .onChange(of: state.selectedCameraID) { _, newValue in
+            if state.cameraEnabled {
                 updateCamera(enabled: true, deviceID: newValue)
             }
         }
@@ -143,8 +181,8 @@ private struct RecordingToolbarWrapper: View {
             let didApply = await onCameraToggled(enabled, deviceID)
             guard !Task.isCancelled else { return }
             if enabled && !didApply {
-                cameraEnabled = false
-                selectedCameraID = nil
+                state.cameraEnabled = false
+                state.selectedCameraID = nil
             }
         }
     }

--- a/App/Tests/EditorGIFExportTests.swift
+++ b/App/Tests/EditorGIFExportTests.swift
@@ -1,0 +1,126 @@
+import AVFoundation
+import EditorKit
+import ImageIO
+import UniformTypeIdentifiers
+import XCTest
+@testable import Capso
+
+final class EditorGIFExportTests: XCTestCase {
+    func testCompositedGIFExportProducesGIFData() async throws {
+        let sourceURL = try EditorVideoFixture.make()
+        let destinationURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-editor-\(UUID().uuidString)")
+            .appendingPathExtension("gif")
+        defer {
+            try? FileManager.default.removeItem(at: sourceURL)
+            try? FileManager.default.removeItem(at: destinationURL)
+        }
+
+        var backgroundStyle = BackgroundStyle.default
+        backgroundStyle.enabled = true
+        let project = RecordingProject(
+            sourceVideoURL: sourceURL,
+            showsCursor: false,
+            videoDuration: 0.4,
+            videoSize: CGSize(width: 160, height: 120),
+            recordingAreaSize: CGSize(width: 160, height: 120),
+            backgroundStyle: backgroundStyle
+        )
+        let coordinator = await MainActor.run {
+            EditorCoordinator(project: project, outputFormat: .gif)
+        }
+        let exportFormat = await MainActor.run {
+            coordinator.outputFormat.exportFormat
+        }
+
+        let exportedURL = try await coordinator.exportVideo(
+            format: exportFormat,
+            quality: .maximum,
+            destination: destinationURL
+        )
+
+        let imageSource = try XCTUnwrap(CGImageSourceCreateWithURL(exportedURL as CFURL, nil))
+        XCTAssertEqual(CGImageSourceGetType(imageSource) as String?, UTType.gif.identifier)
+        XCTAssertGreaterThan(CGImageSourceGetCount(imageSource), 1)
+    }
+}
+
+private enum EditorVideoFixture {
+    enum FixtureError: Error {
+        case writerSetupFailed
+        case pixelBufferCreationFailed
+        case writerFinishFailed(Error?)
+    }
+
+    static func make() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-editor-source-\(UUID().uuidString)")
+            .appendingPathExtension("mov")
+        let writer = try AVAssetWriter(outputURL: url, fileType: .mov)
+        let width = 160
+        let height = 120
+        let fps: Int32 = 15
+        let input = AVAssetWriterInput(mediaType: .video, outputSettings: [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: width,
+            AVVideoHeightKey: height,
+        ])
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+                kCVPixelBufferWidthKey as String: width,
+                kCVPixelBufferHeightKey as String: height,
+            ]
+        )
+
+        guard writer.canAdd(input) else { throw FixtureError.writerSetupFailed }
+        writer.add(input)
+        guard writer.startWriting() else { throw FixtureError.writerSetupFailed }
+        writer.startSession(atSourceTime: .zero)
+
+        for frame in 0..<6 {
+            while !input.isReadyForMoreMediaData {
+                Thread.sleep(forTimeInterval: 0.001)
+            }
+            guard let pixelBuffer = makePixelBuffer(width: width, height: height) else {
+                throw FixtureError.pixelBufferCreationFailed
+            }
+            let presentationTime = CMTime(value: Int64(frame), timescale: fps)
+            guard adaptor.append(pixelBuffer, withPresentationTime: presentationTime) else {
+                throw FixtureError.writerFinishFailed(writer.error)
+            }
+        }
+        input.markAsFinished()
+
+        let finished = DispatchGroup()
+        finished.enter()
+        writer.finishWriting { finished.leave() }
+        finished.wait()
+        guard writer.status == .completed else {
+            throw FixtureError.writerFinishFailed(writer.error)
+        }
+        return url
+    }
+
+    private static func makePixelBuffer(width: Int, height: Int) -> CVPixelBuffer? {
+        var pixelBuffer: CVPixelBuffer?
+        guard CVPixelBufferCreate(
+            kCFAllocatorDefault,
+            width,
+            height,
+            kCVPixelFormatType_32BGRA,
+            nil,
+            &pixelBuffer
+        ) == kCVReturnSuccess, let pixelBuffer else {
+            return nil
+        }
+
+        CVPixelBufferLockBaseAddress(pixelBuffer, [])
+        if let address = CVPixelBufferGetBaseAddress(pixelBuffer) {
+            memset(address, 0x44, CVPixelBufferGetDataSize(pixelBuffer))
+        }
+        CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+        return pixelBuffer
+    }
+}

--- a/App/Tests/EditorOutputFormatTests.swift
+++ b/App/Tests/EditorOutputFormatTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import Capso
+
+final class EditorOutputFormatTests: XCTestCase {
+    func testGIFUsesGIFSaveAndExportConfiguration() {
+        let format = EditorOutputFormat(recordingFormat: .gif)
+
+        XCTAssertEqual(format, .gif)
+        XCTAssertEqual(format.defaultFilename, "Recording.gif")
+        XCTAssertEqual(format.fileExtension, "gif")
+        XCTAssertEqual(format.contentType.identifier, "com.compuserve.gif")
+        XCTAssertEqual(format.exportFormat.rawValue, "gif")
+    }
+
+    func testVideoUsesMP4SaveAndExportConfiguration() {
+        let format = EditorOutputFormat(recordingFormat: .video)
+
+        XCTAssertEqual(format, .mp4)
+        XCTAssertEqual(format.defaultFilename, "Recording.mp4")
+        XCTAssertEqual(format.fileExtension, "mp4")
+        XCTAssertEqual(format.contentType.identifier, "public.mpeg-4")
+        XCTAssertEqual(format.exportFormat.rawValue, "mp4")
+    }
+}

--- a/App/Tests/RecordingToolbarShortcutTests.swift
+++ b/App/Tests/RecordingToolbarShortcutTests.swift
@@ -83,6 +83,51 @@ final class CaptureWindowPolicyTests: XCTestCase {
         XCTAssertTrue(CaptureCoordinator.shouldUseFrozenWindowCapture(windowLayer: 27))
         XCTAssertFalse(CaptureCoordinator.shouldUseFrozenWindowCapture(windowLayer: 0))
     }
+
+    func testElevatedApplicationWindowIncludesNativeShadowPadding() {
+        let windowRect = CGRect(x: 100, y: 100, width: 240, height: 160)
+
+        let captureRect = CaptureCoordinator.frozenWindowCaptureRect(
+            windowRect: windowRect,
+            screenSize: CGSize(width: 1920, height: 1080),
+            windowLayer: 27,
+            appName: "Control Center",
+            appBundleIdentifier: "com.apple.controlcenter",
+            captureWindowShadow: true
+        )
+
+        XCTAssertEqual(captureRect, CGRect(x: 50, y: 50, width: 340, height: 260))
+    }
+
+    func testDisabledShadowKeepsExactFrozenWindowRect() {
+        let windowRect = CGRect(x: 100, y: 100, width: 240, height: 160)
+
+        let captureRect = CaptureCoordinator.frozenWindowCaptureRect(
+            windowRect: windowRect,
+            screenSize: CGSize(width: 1920, height: 1080),
+            windowLayer: 27,
+            appName: "Control Center",
+            appBundleIdentifier: "com.apple.controlcenter",
+            captureWindowShadow: false
+        )
+
+        XCTAssertEqual(captureRect, windowRect)
+    }
+
+    func testSystemMenuBarKeepsExactRectWhenShadowIsEnabled() {
+        let menuBarRect = CGRect(x: 0, y: 1050, width: 1920, height: 30)
+
+        let captureRect = CaptureCoordinator.frozenWindowCaptureRect(
+            windowRect: menuBarRect,
+            screenSize: CGSize(width: 1920, height: 1080),
+            windowLayer: Int(CGWindowLevelForKey(.mainMenuWindow)),
+            appName: "",
+            appBundleIdentifier: "",
+            captureWindowShadow: true
+        )
+
+        XCTAssertEqual(captureRect, menuBarRect)
+    }
 }
 
 @MainActor

--- a/App/Tests/RecordingToolbarShortcutTests.swift
+++ b/App/Tests/RecordingToolbarShortcutTests.swift
@@ -1,0 +1,98 @@
+import AppKit
+import XCTest
+@testable import Capso
+import SharedKit
+
+@MainActor
+final class RecordingToolbarShortcutTests: XCTestCase {
+    func testReturnStartsVideoRecording() throws {
+        let harness = try makeHarness()
+        defer { harness.cleanUp() }
+
+        let event = try makeReturnEvent(
+            modifierFlags: [],
+            windowNumber: harness.window.windowNumber
+        )
+
+        NSApp.sendEvent(event)
+        XCTAssertEqual(harness.recordedFormats(), [.video])
+    }
+
+    func testOptionReturnStartsGIFRecording() throws {
+        let harness = try makeHarness()
+        defer { harness.cleanUp() }
+
+        let event = try makeReturnEvent(
+            modifierFlags: .option,
+            windowNumber: harness.window.windowNumber
+        )
+
+        NSApp.sendEvent(event)
+        XCTAssertEqual(harness.recordedFormats(), [.gif])
+    }
+
+    private func makeHarness() throws -> RecordingToolbarHarness {
+        let suiteName = "RecordingToolbarShortcutTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        let settings = AppSettings(defaults: defaults)
+        let screen = try XCTUnwrap(NSScreen.main)
+        var recordedFormats: [RecordingFormatChoice] = []
+
+        let window = RecordingToolbarWindow(
+            selectionRect: CGRect(x: 100, y: 100, width: 640, height: 480),
+            screen: screen,
+            settings: settings,
+            onRecord: { format, _, _, _, _ in
+                recordedFormats.append(format)
+            },
+            onCameraToggled: { _, _ in true },
+            onChangeArea: {},
+            onCancel: {},
+            onCameraSettingsChanged: {}
+        )
+        window.show()
+
+        return RecordingToolbarHarness(
+            window: window,
+            suiteName: suiteName,
+            recordedFormats: { recordedFormats }
+        )
+    }
+
+    private func makeReturnEvent(
+        modifierFlags: NSEvent.ModifierFlags,
+        windowNumber: Int
+    ) throws -> NSEvent {
+        try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifierFlags,
+            timestamp: 0,
+            windowNumber: windowNumber,
+            context: nil,
+            characters: "\r",
+            charactersIgnoringModifiers: "\r",
+            isARepeat: false,
+            keyCode: 36
+        ))
+    }
+}
+
+final class CaptureWindowPolicyTests: XCTestCase {
+    func testElevatedWindowsUseTheFrozenDisplayCapture() {
+        XCTAssertTrue(CaptureCoordinator.shouldUseFrozenWindowCapture(windowLayer: 27))
+        XCTAssertFalse(CaptureCoordinator.shouldUseFrozenWindowCapture(windowLayer: 0))
+    }
+}
+
+@MainActor
+private struct RecordingToolbarHarness {
+    let window: RecordingToolbarWindow
+    let suiteName: String
+    let recordedFormats: () -> [RecordingFormatChoice]
+
+    func cleanUp() {
+        window.close()
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+    }
+}

--- a/Packages/CaptureKit/Sources/CaptureKit/WindowInfo.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/WindowInfo.swift
@@ -52,6 +52,7 @@ public enum ContentEnumerator {
                     isOnScreen: window.isOnScreen,
                     title: trimmedTitle,
                     appName: appName,
+                    appBundleIdentifier: window.owningApplication?.bundleIdentifier,
                     hasOwningApplication: window.owningApplication != nil,
                     windowLayer: window.windowLayer,
                     isOwnAppWindow: window.owningApplication?.bundleIdentifier == myBundleID
@@ -65,12 +66,15 @@ public enum ContentEnumerator {
         isOnScreen: Bool,
         title: String,
         appName: String,
+        appBundleIdentifier: String?,
         hasOwningApplication: Bool,
         windowLayer: Int,
         isOwnAppWindow: Bool
     ) -> Bool {
         let hasUsableLabel = !title.isEmpty || !appName.isEmpty
-        let isSystemMenuBar = !hasOwningApplication
+        let hasIdentifiedOwningApplication = !appName.isEmpty
+            || !(appBundleIdentifier?.isEmpty ?? true)
+        let isSystemMenuBar = !hasIdentifiedOwningApplication
             && windowLayer == Int(CGWindowLevelForKey(.mainMenuWindow))
         let isElevatedApplicationWindow = hasOwningApplication
             && windowLayer > 0
@@ -81,7 +85,7 @@ public enum ContentEnumerator {
         return hasUsableSize
             && isOnScreen
             && (hasOwningApplication || isSystemMenuBar)
-            && hasUsableLabel
+            && (hasUsableLabel || isSystemMenuBar)
             && (windowLayer == 0
                 || isOwnAppWindow
                 || isElevatedApplicationWindow

--- a/Packages/CaptureKit/Sources/CaptureKit/WindowInfo.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/WindowInfo.swift
@@ -6,6 +6,7 @@ public struct WindowInfo: Identifiable, Sendable {
     public let id: CGWindowID
     public let title: String
     public let appName: String
+    public let appBundleIdentifier: String?
     public let frame: CGRect
     public let isOnScreen: Bool
     public let windowLayer: Int
@@ -16,6 +17,7 @@ public struct WindowInfo: Identifiable, Sendable {
         self.id = scWindow.windowID
         self.title = trimmedTitle.isEmpty ? fallbackTitle : trimmedTitle
         self.appName = scWindow.owningApplication?.applicationName ?? ""
+        self.appBundleIdentifier = scWindow.owningApplication?.bundleIdentifier
         self.frame = scWindow.frame
         self.isOnScreen = scWindow.isOnScreen
         self.windowLayer = scWindow.windowLayer
@@ -44,17 +46,46 @@ public enum ContentEnumerator {
             .filter { window in
                 let trimmedTitle = window.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
                 let appName = window.owningApplication?.applicationName ?? ""
-                let hasUsableLabel = !trimmedTitle.isEmpty || !appName.isEmpty
-                let isOwnAppWindow = window.owningApplication?.bundleIdentifier == myBundleID
 
-                return window.frame.width > 100
-                    && window.frame.height > 50
-                    && window.isOnScreen
-                    && window.owningApplication != nil
-                    && hasUsableLabel
-                    && (window.windowLayer == 0 || isOwnAppWindow)
+                return isCaptureCandidate(
+                    frame: window.frame,
+                    isOnScreen: window.isOnScreen,
+                    title: trimmedTitle,
+                    appName: appName,
+                    hasOwningApplication: window.owningApplication != nil,
+                    windowLayer: window.windowLayer,
+                    isOwnAppWindow: window.owningApplication?.bundleIdentifier == myBundleID
+                )
             }
             .map { WindowInfo(from: $0) }
+    }
+
+    static func isCaptureCandidate(
+        frame: CGRect,
+        isOnScreen: Bool,
+        title: String,
+        appName: String,
+        hasOwningApplication: Bool,
+        windowLayer: Int,
+        isOwnAppWindow: Bool
+    ) -> Bool {
+        let hasUsableLabel = !title.isEmpty || !appName.isEmpty
+        let isSystemMenuBar = !hasOwningApplication
+            && windowLayer == Int(CGWindowLevelForKey(.mainMenuWindow))
+        let isElevatedApplicationWindow = hasOwningApplication
+            && windowLayer > 0
+            && windowLayer < Int(CGWindowLevelForKey(.screenSaverWindow))
+        let hasUsableSize = frame.width > 100
+            && (frame.height > 50 || (isSystemMenuBar && frame.height >= 20))
+
+        return hasUsableSize
+            && isOnScreen
+            && (hasOwningApplication || isSystemMenuBar)
+            && hasUsableLabel
+            && (windowLayer == 0
+                || isOwnAppWindow
+                || isElevatedApplicationWindow
+                || isSystemMenuBar)
     }
 
     public static func displays() async throws -> [DisplayInfo] {

--- a/Packages/CaptureKit/Tests/CaptureKitTests/WindowCaptureCandidateTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/WindowCaptureCandidateTests.swift
@@ -4,14 +4,29 @@ import Testing
 
 @Suite("Window capture candidates")
 struct WindowCaptureCandidateTests {
-    @Test("Includes the system menu bar without an owning application")
-    func includesSystemMenuBar() {
+    @Test("Includes an unlabeled system menu bar without an owning application")
+    func includesUnlabeledSystemMenuBar() {
         #expect(ContentEnumerator.isCaptureCandidate(
             frame: CGRect(x: 0, y: 0, width: 1920, height: 30),
             isOnScreen: true,
+            title: "",
+            appName: "",
+            appBundleIdentifier: nil,
+            hasOwningApplication: false,
+            windowLayer: Int(CGWindowLevelForKey(.mainMenuWindow)),
+            isOwnAppWindow: false
+        ))
+    }
+
+    @Test("Includes a system menu bar with an unidentified owning application")
+    func includesSystemMenuBarWithPlaceholderOwner() {
+        #expect(ContentEnumerator.isCaptureCandidate(
+            frame: CGRect(x: 0, y: 0, width: 1728, height: 33),
+            isOnScreen: true,
             title: "Menubar",
             appName: "",
-            hasOwningApplication: false,
+            appBundleIdentifier: "",
+            hasOwningApplication: true,
             windowLayer: Int(CGWindowLevelForKey(.mainMenuWindow)),
             isOwnAppWindow: false
         ))
@@ -24,6 +39,7 @@ struct WindowCaptureCandidateTests {
             isOnScreen: true,
             title: "",
             appName: "Control Center",
+            appBundleIdentifier: "com.apple.controlcenter",
             hasOwningApplication: true,
             windowLayer: 27,
             isOwnAppWindow: false
@@ -37,6 +53,7 @@ struct WindowCaptureCandidateTests {
             isOnScreen: true,
             title: "StatusIndicator",
             appName: "",
+            appBundleIdentifier: nil,
             hasOwningApplication: false,
             windowLayer: Int(CGWindowLevelForKey(.cursorWindow)),
             isOwnAppWindow: false

--- a/Packages/CaptureKit/Tests/CaptureKitTests/WindowCaptureCandidateTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/WindowCaptureCandidateTests.swift
@@ -1,0 +1,45 @@
+import CoreGraphics
+import Testing
+@testable import CaptureKit
+
+@Suite("Window capture candidates")
+struct WindowCaptureCandidateTests {
+    @Test("Includes the system menu bar without an owning application")
+    func includesSystemMenuBar() {
+        #expect(ContentEnumerator.isCaptureCandidate(
+            frame: CGRect(x: 0, y: 0, width: 1920, height: 30),
+            isOnScreen: true,
+            title: "Menubar",
+            appName: "",
+            hasOwningApplication: false,
+            windowLayer: Int(CGWindowLevelForKey(.mainMenuWindow)),
+            isOwnAppWindow: false
+        ))
+    }
+
+    @Test("Includes elevated application popovers")
+    func includesElevatedApplicationPopover() {
+        #expect(ContentEnumerator.isCaptureCandidate(
+            frame: CGRect(x: 840, y: 30, width: 240, height: 160),
+            isOnScreen: true,
+            title: "",
+            appName: "Control Center",
+            hasOwningApplication: true,
+            windowLayer: 27,
+            isOwnAppWindow: false
+        ))
+    }
+
+    @Test("Excludes tiny ownerless status windows")
+    func excludesTinyOwnerlessStatusWindow() {
+        #expect(!ContentEnumerator.isCaptureCandidate(
+            frame: CGRect(x: 1896, y: 1, width: 28, height: 28),
+            isOnScreen: true,
+            title: "StatusIndicator",
+            appName: "",
+            hasOwningApplication: false,
+            windowLayer: Int(CGWindowLevelForKey(.cursorWindow)),
+            isOwnAppWindow: false
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

- restore window capture when the desktop has no regular app windows
- include the macOS menu bar and elevated menu-bar popovers in window capture while cropping from the frozen display image
- make Return start video recording and Option-Return start GIF recording from the recording toolbar
- preserve the selected GIF format when the full recording editor opens
- save and copy edited GIF recordings as real GIF data, including recordings that require compositing or trimming

## Root cause

Window capture filtered out system-owned and elevated windows, and direct capture of menu-bar surfaces produced incorrect Liquid Glass output. The recording toolbar also did not handle Return shortcuts at the window event boundary.

Separately, the full recording editor discarded the recording format and hard-coded MP4 for Save and Copy. Its compositor always renders an MP4 intermediate, so GIF output also needs a final GIF encoding stage rather than only changing the filename extension.

## Impact

Users can capture the menu bar and its popovers, use the advertised recording shortcuts, and save a GIF recording from the full editor without receiving an MP4 instead.

## Validation

- `swift test --package-path Packages/CaptureKit` — 48 tests passed
- `xcodebuild test -project Capso.xcodeproj -scheme Capso -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` — 35 tests passed
- GIF regression test generates a composited recording, exports it through the editor, and verifies the result is a multi-frame GIF with ImageIO

Closes #204

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches capture geometry, window filtering, and multi-stage export pipelines; behavior is covered by new tests but changes user-visible capture and export output.
> 
> **Overview**
> Fixes **window capture** when only system or elevated surfaces are available, and restores **recording toolbar** and **GIF editor** behavior that was broken or missing.
> 
> **Capture:** Window enumeration now allows the menu bar and elevated popovers (e.g. Control Center) via `ContentEnumerator.isCaptureCandidate`, with `appBundleIdentifier` on `WindowInfo`. On the frozen overlay, non–layer-0 windows crop from the frozen display instead of ScreenCaptureKit, with optional shadow padding for elevated app windows.
> 
> **Recording toolbar:** **Return** starts video and **Option-Return** starts GIF; toolbar mic/camera state is shared through `RecordingToolbarState` so shortcuts use the same settings as the buttons.
> 
> **Editor:** `EditorOutputFormat` carries MP4 vs GIF from the recording into Save/Copy panels and export. GIF export runs compositing and trim through MP4 intermediates, then encodes real GIF via `exportGIF`. Tests cover output format mapping, toolbar shortcuts, frozen window policy, capture candidates, and composited GIF export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b46f59089d733b64ec6588141433b0a4ae647b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->