### PR TITLE
feat: hold Shift to constrain annotation objects while drawing

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -96,6 +96,10 @@ final class AnnotationCanvasNSView: NSView {
 
     private var dragStart: CGPoint?
     private var dragCurrent: CGPoint?
+    /// Whether Shift is held, constraining the creation drag: box tools lock to
+    /// 1:1 and line tools snap to 45°. Seeded on mouse down so a Shift press
+    /// that precedes the drag is honored.
+    private var squareLock = false
     private var isDragging = false {
         didSet {
             guard isDragging != oldValue else { return }
@@ -332,7 +336,7 @@ final class AnnotationCanvasNSView: NSView {
                 }
             }
 
-            if let start = dragStart, let current = dragCurrent,
+            if let start = dragStart, let current = previewDragEnd,
                isDragging, activeResizeHandle == nil,
                currentTool != .select, currentTool != .freehand, currentTool != .text, currentTool != .highlighter {
                 drawPreview(ctx: ctx, from: start, to: current)
@@ -651,6 +655,22 @@ final class AnnotationCanvasNSView: NSView {
         return nil
     }
 
+    /// The drag endpoint after the active tool's Shift constraint. Both the live
+    /// preview and the committed object go through this, so a square preview can
+    /// never commit as a free rectangle.
+    private func constrainedCreationEnd(from start: CGPoint, to end: CGPoint) -> CGPoint {
+        guard squareLock else { return end }
+        return AnnotationDragConstraint.constrainedEnd(from: start, to: end, tool: currentTool)
+    }
+
+    /// The endpoint the in-progress preview is drawn to: the live pointer
+    /// position with the active tool's Shift constraint applied. Internal so
+    /// interaction tests can assert on what the user sees mid-drag.
+    var previewDragEnd: CGPoint? {
+        guard let start = dragStart, let current = dragCurrent else { return nil }
+        return constrainedCreationEnd(from: start, to: current)
+    }
+
     private func drawPreview(ctx: CGContext, from start: CGPoint, to end: CGPoint) {
         ctx.saveGState()
         ctx.setStrokeColor(currentStyle.color.cgColor)
@@ -715,6 +735,7 @@ final class AnnotationCanvasNSView: NSView {
         let point = toImagePoint(convert(event.locationInWindow, from: nil))
         dragStart = point
         dragCurrent = point
+        squareLock = event.modifierFlags.contains(.shift)
         isDragging = true
         activeResizeHandle = nil
         resizeOriginalTextFontSize = nil
@@ -815,6 +836,7 @@ final class AnnotationCanvasNSView: NSView {
     override func mouseDragged(with event: NSEvent) {
         let point = toImagePoint(convert(event.locationInWindow, from: nil))
         dragCurrent = point
+        squareLock = event.modifierFlags.contains(.shift)
 
         if isResizingTextEditor,
            let editor = textEditor,
@@ -995,7 +1017,11 @@ final class AnnotationCanvasNSView: NSView {
         guard let doc = document, let start = dragStart else {
             isDragging = false; return
         }
-        let end = toImagePoint(convert(event.locationInWindow, from: nil))
+        squareLock = event.modifierFlags.contains(.shift)
+        let end = constrainedCreationEnd(
+            from: start,
+            to: toImagePoint(convert(event.locationInWindow, from: nil))
+        )
 
         if activeResizeHandle != nil {
             dragObjectID = nil
@@ -1092,6 +1118,21 @@ final class AnnotationCanvasNSView: NSView {
         if currentTool != .select {
             onObjectCreated?()
         }
+    }
+
+    /// Holding or releasing Shift mid-drag re-runs the constraint against the
+    /// last pointer location, so the preview locks and unlocks live. The preview
+    /// is rebuilt from `dragStart`/`dragCurrent` on every draw, so a redraw is
+    /// all this needs.
+    override func flagsChanged(with event: NSEvent) {
+        let nextSquareLock = event.modifierFlags.contains(.shift)
+        if nextSquareLock != squareLock {
+            squareLock = nextSquareLock
+            if isDragging, AnnotationDragConstraint.kind(for: currentTool) != .none {
+                needsDisplay = true
+            }
+        }
+        super.flagsChanged(with: event)
     }
 
     override func keyDown(with event: NSEvent) {

--- a/App/Tests/AnnotationCanvasInteractionTests.swift
+++ b/App/Tests/AnnotationCanvasInteractionTests.swift
@@ -1,0 +1,157 @@
+import AppKit
+import XCTest
+@testable import Capso
+import AnnotationKit
+
+@MainActor
+final class AnnotationCanvasInteractionTests: XCTestCase {
+    func testShiftDragCommitsASquareRectangle() throws {
+        let (view, document) = makeCanvas(tool: .rectangle)
+
+        drag(view, from: NSPoint(x: 100, y: 400), to: NSPoint(x: 300, y: 320), modifierFlags: .shift)
+
+        let rect = try XCTUnwrap(document.objects.first as? RectangleObject).rect
+        XCTAssertEqual(rect.width, rect.height, accuracy: 0.001)
+        XCTAssertEqual(rect.width, 200, accuracy: 0.001)
+    }
+
+    func testFreeDragKeepsTheRectangleUnconstrained() throws {
+        let (view, document) = makeCanvas(tool: .rectangle)
+
+        drag(view, from: NSPoint(x: 100, y: 400), to: NSPoint(x: 300, y: 320))
+
+        let rect = try XCTUnwrap(document.objects.first as? RectangleObject).rect
+        XCTAssertEqual(rect.width, 200, accuracy: 0.001)
+        XCTAssertEqual(rect.height, 80, accuracy: 0.001)
+    }
+
+    func testShiftDragCommitsACircularEllipse() throws {
+        let (view, document) = makeCanvas(tool: .ellipse)
+
+        drag(view, from: NSPoint(x: 120, y: 420), to: NSPoint(x: 260, y: 380), modifierFlags: .shift)
+
+        let rect = try XCTUnwrap(document.objects.first as? EllipseObject).rect
+        XCTAssertEqual(rect.width, rect.height, accuracy: 0.001)
+        XCTAssertEqual(rect.width, 140, accuracy: 0.001)
+    }
+
+    func testShiftDragSnapsANearHorizontalLineFlat() throws {
+        let (view, document) = makeCanvas(tool: .line)
+
+        drag(view, from: NSPoint(x: 100, y: 300), to: NSPoint(x: 280, y: 288), modifierFlags: .shift)
+
+        let line = try XCTUnwrap(document.objects.first as? LineObject)
+        XCTAssertEqual(line.end.y, line.start.y, accuracy: 0.001)
+        // The 45° snap rotates the drag rather than projecting it, so the line
+        // keeps the length the pointer implied.
+        let length = hypot(line.end.x - line.start.x, line.end.y - line.start.y)
+        XCTAssertEqual(length, hypot(180, 12), accuracy: 0.001)
+    }
+
+    func testTogglingShiftMidDragUpdatesThePreviewLive() throws {
+        let (view, _) = makeCanvas(tool: .rectangle)
+
+        view.mouseDown(with: mouseEvent(.leftMouseDown, at: NSPoint(x: 100, y: 400)))
+        view.mouseDragged(with: mouseEvent(.leftMouseDragged, at: NSPoint(x: 300, y: 320)))
+
+        // The canvas is flipped, so the mouse-down at window y 400 anchors the
+        // drag at image y 200 (view height 600).
+        let anchor = CGPoint(x: 100, y: 200)
+
+        let freeEnd = try XCTUnwrap(view.previewDragEnd)
+        XCTAssertNotEqual(abs(freeEnd.x - anchor.x), abs(freeEnd.y - anchor.y), accuracy: 0.001)
+
+        view.flagsChanged(with: flagsChangedEvent(modifierFlags: .shift))
+        let lockedEnd = try XCTUnwrap(view.previewDragEnd)
+        XCTAssertEqual(abs(lockedEnd.x - anchor.x), abs(lockedEnd.y - anchor.y), accuracy: 0.001)
+
+        view.flagsChanged(with: flagsChangedEvent(modifierFlags: []))
+        XCTAssertEqual(try XCTUnwrap(view.previewDragEnd), freeEnd)
+    }
+
+    func testShiftDoesNotConstrainThePreviewForFreehand() throws {
+        let (view, _) = makeCanvas(tool: .freehand)
+
+        view.mouseDown(with: mouseEvent(.leftMouseDown, at: NSPoint(x: 100, y: 400)))
+        view.mouseDragged(with: mouseEvent(.leftMouseDragged, at: NSPoint(x: 300, y: 320)))
+        let free = try XCTUnwrap(view.previewDragEnd)
+
+        view.flagsChanged(with: flagsChangedEvent(modifierFlags: .shift))
+        XCTAssertEqual(try XCTUnwrap(view.previewDragEnd), free, "Freehand strokes are not constrained by Shift")
+    }
+
+    func testShiftHeldBeforeMouseDownStillConstrainsTheDrag() throws {
+        let (view, document) = makeCanvas(tool: .rectangle)
+
+        // Shift is already down when the drag starts, so no flagsChanged arrives
+        // during it — the lock has to come from mouseDown's modifier flags.
+        view.mouseDown(with: mouseEvent(.leftMouseDown, at: NSPoint(x: 100, y: 400), modifierFlags: .shift))
+        view.mouseUp(with: mouseEvent(.leftMouseUp, at: NSPoint(x: 300, y: 320), modifierFlags: .shift))
+
+        let rect = try XCTUnwrap(document.objects.first as? RectangleObject).rect
+        XCTAssertEqual(rect.width, rect.height, accuracy: 0.001)
+    }
+
+    // MARK: - Helpers
+
+    private func makeCanvas(tool: AnnotationTool) -> (AnnotationCanvasNSView, AnnotationDocument) {
+        let frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        let document = AnnotationDocument(imageSize: frame.size)
+        let view = AnnotationCanvasNSView(frame: frame)
+        view.document = document
+        view.currentTool = tool
+
+        let hostWindow = NSWindow(
+            contentRect: frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        hostWindow.contentView = view
+        return (view, document)
+    }
+
+    private func drag(
+        _ view: AnnotationCanvasNSView,
+        from start: NSPoint,
+        to end: NSPoint,
+        modifierFlags: NSEvent.ModifierFlags = []
+    ) {
+        view.mouseDown(with: mouseEvent(.leftMouseDown, at: start, modifierFlags: modifierFlags))
+        view.mouseDragged(with: mouseEvent(.leftMouseDragged, at: end, modifierFlags: modifierFlags))
+        view.mouseUp(with: mouseEvent(.leftMouseUp, at: end, modifierFlags: modifierFlags))
+    }
+
+    private func mouseEvent(
+        _ type: NSEvent.EventType,
+        at location: NSPoint,
+        modifierFlags: NSEvent.ModifierFlags = []
+    ) -> NSEvent {
+        NSEvent.mouseEvent(
+            with: type,
+            location: location,
+            modifierFlags: modifierFlags,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        )!
+    }
+
+    private func flagsChangedEvent(modifierFlags: NSEvent.ModifierFlags) -> NSEvent {
+        NSEvent.keyEvent(
+            with: .flagsChanged,
+            location: .zero,
+            modifierFlags: modifierFlags,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "",
+            charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: 56
+        )!
+    }
+}

--- a/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationDragConstraint.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationDragConstraint.swift
@@ -1,0 +1,76 @@
+// Packages/AnnotationKit/Sources/AnnotationKit/AnnotationDragConstraint.swift
+import CoreGraphics
+import Foundation
+
+/// How a Shift-held creation drag is constrained for a given tool.
+public enum AnnotationDragConstraintKind: Sendable, Equatable {
+    /// Box tools lock to 1:1 — a square rectangle, a circular ellipse.
+    case square
+    /// Line-like tools snap to 45° increments.
+    case angle
+    /// Shift has no effect (freehand strokes, text, counters).
+    case none
+}
+
+/// Shift-drag constraints applied while creating annotation objects. Kept as
+/// pure geometry so the live preview and the committed object can share it.
+public enum AnnotationDragConstraint {
+    public static func kind(for tool: AnnotationTool) -> AnnotationDragConstraintKind {
+        switch tool {
+        case .rectangle, .ellipse, .pixelate:
+            return .square
+        case .arrow, .line:
+            return .angle
+        case .select, .text, .freehand, .highlighter, .counter:
+            return .none
+        }
+    }
+
+    /// The drag endpoint to use for `tool` when Shift is held. Returns `end`
+    /// unchanged for tools Shift does not constrain.
+    public static func constrainedEnd(
+        from start: CGPoint,
+        to end: CGPoint,
+        tool: AnnotationTool
+    ) -> CGPoint {
+        switch kind(for: tool) {
+        case .square:
+            return squaredEnd(from: start, to: end)
+        case .angle:
+            return angleSnappedEnd(from: start, to: end)
+        case .none:
+            return end
+        }
+    }
+
+    /// Moves `end` so the box anchored at `start` is square, keeping the drag's
+    /// direction on both axes. The axis with the larger delta sets the side
+    /// length, matching the capture overlay's square lock.
+    public static func squaredEnd(from start: CGPoint, to end: CGPoint) -> CGPoint {
+        let dx = end.x - start.x
+        let dy = end.y - start.y
+        let side = max(abs(dx), abs(dy))
+
+        return CGPoint(
+            x: start.x + (dx < 0 ? -side : side),
+            y: start.y + (dy < 0 ? -side : side)
+        )
+    }
+
+    /// Rotates `end` to the nearest 45° increment around `start`, preserving the
+    /// drag length so the line keeps the size the pointer implies.
+    public static func angleSnappedEnd(from start: CGPoint, to end: CGPoint) -> CGPoint {
+        let dx = end.x - start.x
+        let dy = end.y - start.y
+        let length = hypot(dx, dy)
+        guard length > 0 else { return end }
+
+        let increment = CGFloat.pi / 4
+        let snappedAngle = (atan2(dy, dx) / increment).rounded() * increment
+
+        return CGPoint(
+            x: start.x + cos(snappedAngle) * length,
+            y: start.y + sin(snappedAngle) * length
+        )
+    }
+}

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationDragConstraintTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationDragConstraintTests.swift
@@ -1,0 +1,135 @@
+import Testing
+import Foundation
+import CoreGraphics
+@testable import AnnotationKit
+
+@Suite("AnnotationDragConstraint")
+struct AnnotationDragConstraintTests {
+    private let start = CGPoint(x: 100, y: 100)
+
+    // MARK: - Tool mapping
+
+    @Test("Box tools lock to a square")
+    func squareTools() {
+        for tool in [AnnotationTool.rectangle, .ellipse, .pixelate] {
+            #expect(AnnotationDragConstraint.kind(for: tool) == .square)
+        }
+    }
+
+    @Test("Line-like tools snap by angle")
+    func angleTools() {
+        for tool in [AnnotationTool.arrow, .line] {
+            #expect(AnnotationDragConstraint.kind(for: tool) == .angle)
+        }
+    }
+
+    @Test("Freehand, text, counter and select are unconstrained")
+    func unconstrainedTools() {
+        for tool in [AnnotationTool.select, .text, .freehand, .highlighter, .counter] {
+            #expect(AnnotationDragConstraint.kind(for: tool) == .none)
+            let end = CGPoint(x: 260, y: 140)
+            #expect(AnnotationDragConstraint.constrainedEnd(from: start, to: end, tool: tool) == end)
+        }
+    }
+
+    // MARK: - Square lock
+
+    @Test("The larger axis sets the side length")
+    func squareUsesLargerAxis() {
+        let end = AnnotationDragConstraint.squaredEnd(from: start, to: CGPoint(x: 260, y: 140))
+        #expect(end == CGPoint(x: 260, y: 260))
+    }
+
+    @Test("A square drag keeps each axis direction")
+    func squarePreservesDirection() {
+        let upLeft = AnnotationDragConstraint.squaredEnd(from: start, to: CGPoint(x: 20, y: 60))
+        #expect(upLeft == CGPoint(x: 20, y: 20))
+
+        let downLeft = AnnotationDragConstraint.squaredEnd(from: start, to: CGPoint(x: 40, y: 130))
+        #expect(downLeft == CGPoint(x: 40, y: 160))
+    }
+
+    @Test("A square drag with no movement stays at the anchor")
+    func squareWithoutMovement() {
+        #expect(AnnotationDragConstraint.squaredEnd(from: start, to: start) == start)
+    }
+
+    @Test("Squaring a rectangle drag produces equal width and height")
+    func squaredRectIsSquare() {
+        let end = AnnotationDragConstraint.constrainedEnd(
+            from: start,
+            to: CGPoint(x: 340, y: 190),
+            tool: .rectangle
+        )
+        let rect = CGRect(
+            x: min(start.x, end.x),
+            y: min(start.y, end.y),
+            width: abs(end.x - start.x),
+            height: abs(end.y - start.y)
+        )
+
+        #expect(rect.width == rect.height)
+        #expect(rect == CGRect(x: 100, y: 100, width: 240, height: 240))
+    }
+
+    // MARK: - Angle snap
+
+    @Test("A near-horizontal drag snaps flat and keeps its length")
+    func angleSnapsToHorizontal() {
+        let end = AnnotationDragConstraint.angleSnappedEnd(from: start, to: CGPoint(x: 300, y: 112))
+        let length = hypot(300 - start.x, 112 - start.y)
+
+        #expect(abs(end.y - start.y) < 0.0001)
+        #expect(abs(end.x - (start.x + length)) < 0.0001)
+    }
+
+    @Test("A near-vertical drag snaps upright")
+    func angleSnapsToVertical() {
+        let end = AnnotationDragConstraint.angleSnappedEnd(from: start, to: CGPoint(x: 108, y: 320))
+
+        #expect(abs(end.x - start.x) < 0.0001)
+        #expect(end.y > start.y)
+    }
+
+    @Test("A drag near 45° snaps to an exact diagonal")
+    func angleSnapsToDiagonal() {
+        let end = AnnotationDragConstraint.angleSnappedEnd(from: start, to: CGPoint(x: 200, y: 190))
+        let dx = end.x - start.x
+        let dy = end.y - start.y
+
+        #expect(abs(dx - dy) < 0.0001)
+        #expect(dx > 0)
+    }
+
+    @Test("Angle snapping preserves the drag length on every increment")
+    func angleSnapPreservesLength() {
+        for degrees in stride(from: 0, to: 360, by: 7) {
+            let radians = CGFloat(degrees) * .pi / 180
+            let raw = CGPoint(x: start.x + cos(radians) * 150, y: start.y + sin(radians) * 150)
+            let snapped = AnnotationDragConstraint.angleSnappedEnd(from: start, to: raw)
+            let length = hypot(snapped.x - start.x, snapped.y - start.y)
+
+            #expect(abs(length - 150) < 0.0001, "length drifted at \(degrees)°")
+        }
+    }
+
+    @Test("Angle snapping never moves the endpoint more than 22.5°")
+    func angleSnapStaysWithinHalfIncrement() {
+        for degrees in stride(from: 0, to: 360, by: 3) {
+            let radians = CGFloat(degrees) * .pi / 180
+            let raw = CGPoint(x: start.x + cos(radians) * 150, y: start.y + sin(radians) * 150)
+            let snapped = AnnotationDragConstraint.angleSnappedEnd(from: start, to: raw)
+            let snappedAngle = atan2(snapped.y - start.y, snapped.x - start.x)
+
+            var delta = abs(snappedAngle - radians)
+            if delta > .pi { delta = 2 * .pi - delta }
+
+            #expect(delta <= .pi / 8 + 0.0001, "snapped too far at \(degrees)°")
+        }
+    }
+
+    @Test("A zero-length drag is left alone")
+    func angleSnapWithoutMovement() {
+        #expect(AnnotationDragConstraint.angleSnappedEnd(from: start, to: start) == start)
+    }
+}


### PR DESCRIPTION
## What changed

Hold Shift while drawing an annotation and the drag stays constrained, like it does in most design tools.

- Rectangle, ellipse and pixelate lock to 1:1 (square, circle)
- Line and arrow snap to 45° increments, keeping the length you dragged out
- Freehand, highlighter, text and counter are left alone
- Press or release Shift mid-drag and the preview updates right away

Works in the full editor and the inline all-in-one overlay, since both share `AnnotationCanvasNSView`.

## How it works

The geometry is a small pure helper in AnnotationKit, `AnnotationDragConstraint`, sitting next to `CropSnap` with its own unit tests. It holds the per-tool mapping plus the two transforms: a corner-anchored square where the bigger axis sets the side (same convention as the capture overlay's square lock), and a 45° rotation that preserves the drag length.

One gotcha worth calling out. The shape gets computed twice, once for the preview from `dragCurrent` and again on mouseUp from the event location. If only one of those applied the constraint you'd get a square preview committing as a plain rectangle, so both go through `constrainedCreationEnd` and `draw` now renders whatever `previewDragEnd` gives it.

`squareLock` is seeded in mouseDown from the event's modifier flags, so holding Shift before you start dragging works without waiting on a flagsChanged. The canvas is already first responder (it handles Delete), so no event monitor is needed here.

Shift-constrained resizing of existing objects via the selection handles isn't in this one. That felt like its own change.

## Related issue

Closes #213

## Screenshots / recordings

<p align="center">
  <img width="600" height="338" alt="Capso Recording 2026-07-24 at 12 38 13 - 600px" src="https://github.com/user-attachments/assets/bfc1207b-1358-4cde-b0ef-3ba448f4ec33" />
</p>

## Testing

- 13 unit tests on the constraint helper: tool mapping, square direction and anchoring, angle snapping keeps its length and never moves the endpoint more than 22.5°
- 7 interaction tests driving real mouse and flags events on the canvas, including the live mid-drag toggle and Shift held before mouse down
- `swift test --package-path Packages/AnnotationKit` 80 pass, `CapsoTests` 19 pass
- Ran a local Debug build and went through every tool by hand

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass (`swift test --package-path Packages/AnnotationKit`)
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per CONTRIBUTING.md

