### PR TITLE
feat: add screenshot file path clipboard option

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -1938,6 +1938,62 @@
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "剪贴板" } }
       }
     },
+    "Clipboard Content" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "クリップボードの内容" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "클립보드 내용" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "剪贴板内容" } }
+      }
+    },
+    "Clipboard Format" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "クリップボード形式" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "클립보드 형식" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "剪贴板格式" } }
+      }
+    },
+    "Copy image data to the clipboard" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "画像データをクリップボードにコピー" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "이미지 데이터를 클립보드에 복사" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "将图像数据复制到剪贴板" } }
+      }
+    },
+    "Copy the saved path, or keep a temporary file for 24 hours" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "保存先のパスをコピーします。自動保存しない場合、一時ファイルを24時間保持します" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "저장된 경로를 복사합니다. 자동 저장하지 않으면 임시 파일을 24시간 보관합니다" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "复制已保存文件的路径；未自动保存时，临时文件保留 24 小时" } }
+      }
+    },
+    "File Path" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ファイルパス" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "파일 경로" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "文件路径" } }
+      }
+    },
+    "Image" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "画像" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "이미지" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "图像" } }
+      }
+    },
+    "TIFF" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "TIFF" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "TIFF" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "TIFF" } }
+      }
+    },
+    "Used whenever a screenshot is copied" : {
+      "localizations" : {
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "スクリーンショットをコピーするときに使用" } },
+        "ko" : { "stringUnit" : { "state" : "translated", "value" : "스크린샷을 복사할 때 사용" } },
+        "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "每次复制截图时使用" } }
+      }
+    },
     "Copy" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -1511,12 +1511,13 @@ final class CaptureCoordinator {
             return  // history already saved above; skip the call below
         case .default:
             let shouldAutoUpload = settings.cloudShareAutoUploadEnabled && shareCoordinator != nil
-            applyDefaultPostCaptureActions(outputResult, entryID: entryID)
+            let savedFileURL = applyDefaultPostCaptureActions(outputResult, entryID: entryID)
             if settings.screenshotShowPreview {
                 showQuickAccess(
                     for: outputResult,
                     entryID: entryID,
-                    autoUpload: shouldAutoUpload
+                    autoUpload: shouldAutoUpload,
+                    preferredFileURL: savedFileURL
                 )
             } else if shouldAutoUpload, let coord = shareCoordinator {
                 Task {
@@ -1548,7 +1549,14 @@ final class CaptureCoordinator {
         return NSSound(named: "Pop")
     }()
 
-    private func showQuickAccess(for result: CaptureResult, entryID: UUID, autoUpload: Bool) {
+    @discardableResult
+    func showQuickAccess(
+        for result: CaptureResult,
+        entryID: UUID,
+        autoUpload: Bool,
+        preferredFileURL: URL? = nil,
+        pasteboard: NSPasteboard = .general
+    ) -> QuickAccessWindow {
         // If the stack is full, evict the oldest (the one anchored at the
         // bottom slot) with a slide-off-left animation. The remaining
         // previews will slide down one slot as part of the restack below.
@@ -1575,7 +1583,12 @@ final class CaptureCoordinator {
         // stack slot gets dismissed — not whichever one happens to be newest.
         window.onCopy = { [weak self, weak window] in
             guard let self, let window else { return }
-            self.copyScreenshotToClipboard(result, entryID: entryID)
+            self.copyScreenshotToClipboard(
+                result,
+                entryID: entryID,
+                preferredFileURL: preferredFileURL,
+                pasteboard: pasteboard
+            )
             self.dismissQuickAccessWindow(window)
         }
         window.onSave = { [weak self, weak window] in
@@ -1619,6 +1632,7 @@ final class CaptureCoordinator {
         quickAccessWindows.append(window)
         restackQuickAccessWindows(excluding: window)
         window.show()
+        return window
     }
 
     private func openQuickAccessPreview(_ result: CaptureResult, anchorScreen: NSScreen?) {
@@ -1861,7 +1875,7 @@ final class CaptureCoordinator {
             image: image,
             anchorRect: anchor,
             onCopy: { [weak self] in
-                self?.copyImageToClipboard(image)
+                self?.copyRenderedScreenshotToClipboard(image)
             },
             onSave: { [weak self] in
                 self?.saveImageToFile(
@@ -1879,7 +1893,7 @@ final class CaptureCoordinator {
         controller.show()
     }
 
-    private func copyImageToClipboard(_ image: CGImage) {
+    private func copyRenderedScreenshotToClipboard(_ image: CGImage) {
         let temporaryFileStore = QuickAccessDragFileStore()
         ScreenshotClipboard.copy(
             image,
@@ -1925,11 +1939,12 @@ final class CaptureCoordinator {
         }
     }
 
+    @discardableResult
     func applyDefaultPostCaptureActions(
         _ result: CaptureResult,
         entryID: UUID,
         pasteboard: NSPasteboard = .general
-    ) {
+    ) -> URL? {
         if settings.screenshotAutoCopy,
            settings.screenshotClipboardContent == .image {
             copyScreenshotToClipboard(
@@ -1950,6 +1965,7 @@ final class CaptureCoordinator {
                 pasteboard: pasteboard
             )
         }
+        return savedFileURL
     }
 
     @discardableResult
@@ -2020,7 +2036,7 @@ final class CaptureCoordinator {
     }
 
     private func copyRenderedImage(_ image: CGImage) {
-        copyImageToClipboard(image)
+        copyRenderedScreenshotToClipboard(image)
     }
 
     private func showToast(

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -1593,7 +1593,17 @@ final class CaptureCoordinator {
         }
         window.onSave = { [weak self, weak window] in
             guard let self, let window else { return }
-            self.saveImageToFile(result)
+            let savedFileURL = self.saveImageToFile(result)
+            if self.settings.screenshotAutoCopy,
+               self.settings.screenshotClipboardContent == .filePath,
+               let savedFileURL {
+                self.copyScreenshotToClipboard(
+                    result,
+                    entryID: entryID,
+                    preferredFileURL: savedFileURL,
+                    pasteboard: pasteboard
+                )
+            }
             self.dismissQuickAccessWindow(window)
         }
         window.onAnnotate = { [weak self, weak window] in

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -1483,7 +1483,7 @@ final class CaptureCoordinator {
 
         switch action {
         case .clipboard:
-            copyImageToClipboard(outputResult.image)
+            copyScreenshotToClipboard(outputResult, entryID: entryID)
         case .annotate:
             // Open the editor on the same screen the capture came from.
             openAnnotationEditor(outputResult, anchorScreen: screenFor(result: result))
@@ -1511,12 +1511,7 @@ final class CaptureCoordinator {
             return  // history already saved above; skip the call below
         case .default:
             let shouldAutoUpload = settings.cloudShareAutoUploadEnabled && shareCoordinator != nil
-            if settings.screenshotAutoCopy {
-                copyImageToClipboard(outputResult.image)
-            }
-            if settings.screenshotAutoSave {
-                saveImageToFile(outputResult)
-            }
+            applyDefaultPostCaptureActions(outputResult, entryID: entryID)
             if settings.screenshotShowPreview {
                 showQuickAccess(
                     for: outputResult,
@@ -1580,7 +1575,7 @@ final class CaptureCoordinator {
         // stack slot gets dismissed — not whichever one happens to be newest.
         window.onCopy = { [weak self, weak window] in
             guard let self, let window else { return }
-            self.copyImageToClipboard(result.image)
+            self.copyScreenshotToClipboard(result, entryID: entryID)
             self.dismissQuickAccessWindow(window)
         }
         window.onSave = { [weak self, weak window] in
@@ -1885,13 +1880,80 @@ final class CaptureCoordinator {
     }
 
     private func copyImageToClipboard(_ image: CGImage) {
-        ImageUtilities.copyToPasteboard(
+        let temporaryFileStore = QuickAccessDragFileStore()
+        ScreenshotClipboard.copy(
             image,
-            format: settings.screenshotClipboardFormat
-        )
+            content: settings.screenshotClipboardContent,
+            imageFormat: settings.screenshotClipboardFormat
+        ) {
+            try temporaryFileStore.fileURL(
+                for: image,
+                id: UUID(),
+                preset: self.settings.screenshotOutputPreset,
+                template: self.settings.screenshotFilenameTemplate
+            )
+        }
     }
 
-    private func saveImageToFile(_ result: CaptureResult) {
+    @discardableResult
+    func copyScreenshotToClipboard(
+        _ result: CaptureResult,
+        entryID: UUID,
+        preferredFileURL: URL? = nil,
+        pasteboard: NSPasteboard = .general
+    ) -> Bool {
+        let temporaryFileStore = QuickAccessDragFileStore()
+        return ScreenshotClipboard.copy(
+            result.image,
+            content: settings.screenshotClipboardContent,
+            imageFormat: settings.screenshotClipboardFormat,
+            pasteboard: pasteboard
+        ) {
+            if let preferredFileURL,
+               FileManager.default.isReadableFile(atPath: preferredFileURL.path) {
+                return preferredFileURL
+            }
+            return try temporaryFileStore.fileURL(
+                for: result.image,
+                id: entryID,
+                preset: self.settings.screenshotOutputPreset,
+                date: result.timestamp,
+                sourceAppName: result.appName,
+                sourceWindowTitle: result.windowName,
+                template: self.settings.screenshotFilenameTemplate
+            )
+        }
+    }
+
+    func applyDefaultPostCaptureActions(
+        _ result: CaptureResult,
+        entryID: UUID,
+        pasteboard: NSPasteboard = .general
+    ) {
+        if settings.screenshotAutoCopy,
+           settings.screenshotClipboardContent == .image {
+            copyScreenshotToClipboard(
+                result,
+                entryID: entryID,
+                pasteboard: pasteboard
+            )
+        }
+        let savedFileURL = settings.screenshotAutoSave
+            ? saveImageToFile(result)
+            : nil
+        if settings.screenshotAutoCopy,
+           settings.screenshotClipboardContent == .filePath {
+            copyScreenshotToClipboard(
+                result,
+                entryID: entryID,
+                preferredFileURL: savedFileURL,
+                pasteboard: pasteboard
+            )
+        }
+    }
+
+    @discardableResult
+    private func saveImageToFile(_ result: CaptureResult) -> URL? {
         saveImageToFile(
             result.image,
             sourceAppName: result.appName,
@@ -1900,13 +1962,14 @@ final class CaptureCoordinator {
         )
     }
 
+    @discardableResult
     private func saveImageToFile(
         _ image: CGImage,
         sourceAppName: String? = nil,
         sourceWindowTitle: String? = nil,
         date: Date = Date()
-    ) {
-        guard let encoded = screenshotData(from: image) else { return }
+    ) -> URL? {
+        guard let encoded = screenshotData(from: image) else { return nil }
         let directory = settings.screenshotMonthlyFolders
             ? FileNaming.monthlyDirectory(in: settings.exportLocation)
             : settings.exportLocation
@@ -1919,8 +1982,13 @@ final class CaptureCoordinator {
             sourceWindowTitle: sourceWindowTitle,
             template: settings.screenshotFilenameTemplate
         )
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        try? encoded.data.write(to: url)
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try encoded.data.write(to: url)
+            return url
+        } catch {
+            return nil
+        }
     }
 
     private func screenshotData(from image: CGImage) -> (data: Data, format: FileFormat)? {

--- a/App/Sources/History/HistoryCoordinator.swift
+++ b/App/Sources/History/HistoryCoordinator.swift
@@ -500,7 +500,7 @@ final class HistoryCoordinator {
                 return true
             },
             onCopy: { [weak self] rendered in
-                self?.copyImageToClipboard(rendered)
+                self?.copyScreenshotToClipboard(rendered)
                 self?.annotationWindow = nil
             },
             onPin: { [weak self] rendered, frame in
@@ -600,11 +600,30 @@ final class HistoryCoordinator {
         dragFileURLs.removeAll()
     }
 
-    private func copyImageToClipboard(_ image: CGImage) {
-        ImageUtilities.copyToPasteboard(
+    @discardableResult
+    func copyScreenshotToClipboard(
+        _ image: CGImage,
+        preferredFileURL: URL? = nil,
+        pasteboard: NSPasteboard = .general
+    ) -> Bool {
+        let temporaryFileStore = QuickAccessDragFileStore()
+        return ScreenshotClipboard.copy(
             image,
-            format: settings.screenshotClipboardFormat
-        )
+            content: settings.screenshotClipboardContent,
+            imageFormat: settings.screenshotClipboardFormat,
+            pasteboard: pasteboard
+        ) {
+            if let preferredFileURL,
+               FileManager.default.isReadableFile(atPath: preferredFileURL.path) {
+                return preferredFileURL
+            }
+            return try temporaryFileStore.fileURL(
+                for: image,
+                id: UUID(),
+                preset: self.settings.screenshotOutputPreset,
+                template: self.settings.screenshotFilenameTemplate
+            )
+        }
     }
 
     private func pinImage(
@@ -618,7 +637,7 @@ final class HistoryCoordinator {
             image: image,
             anchorRect: anchor,
             onCopy: { [weak self] in
-                self?.copyImageToClipboard(image)
+                self?.copyScreenshotToClipboard(image)
             },
             onSave: { [weak self] in
                 self?.saveImageToExportLocation(
@@ -680,7 +699,7 @@ final class HistoryCoordinator {
 
         case .area, .fullscreen, .window:
             guard let image = Self.loadCGImage(from: sourceURL) else { return }
-            copyImageToClipboard(image)
+            copyScreenshotToClipboard(image, preferredFileURL: sourceURL)
         }
     }
 

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -115,6 +115,17 @@ final class PreferencesViewModel {
             }
         }
     }
+    var screenshotClipboardContent: ScreenshotClipboardContent {
+        get {
+            access(keyPath: \.screenshotClipboardContent)
+            return settings.screenshotClipboardContent
+        }
+        set {
+            withMutation(keyPath: \.screenshotClipboardContent) {
+                settings.screenshotClipboardContent = newValue
+            }
+        }
+    }
     var screenshotAutoSave: Bool {
         get {
             access(keyPath: \.screenshotAutoSave)

--- a/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ScreenshotSettingsView.swift
@@ -29,18 +29,33 @@ struct ScreenshotSettingsView: View {
                             .controlSize(.small)
                     }
                     SettingRow(
-                        label: "Clipboard Format",
-                        sublabel: "Used whenever a screenshot is copied",
+                        label: "Clipboard Content",
+                        sublabel: clipboardContentDescription,
                         showDivider: true
                     ) {
-                        Picker("", selection: $viewModel.screenshotClipboardFormat) {
-                            Text("PNG").tag(ScreenshotClipboardFormat.png)
-                            Text("JPEG").tag(ScreenshotClipboardFormat.jpeg)
-                            Text("TIFF").tag(ScreenshotClipboardFormat.tiff)
+                        Picker("", selection: $viewModel.screenshotClipboardContent) {
+                            Text("Image").tag(ScreenshotClipboardContent.image)
+                            Text("File Path").tag(ScreenshotClipboardContent.filePath)
                         }
                         .labelsHidden()
                         .pickerStyle(.menu)
                         .fixedSize(horizontal: true, vertical: false)
+                    }
+                    if viewModel.screenshotClipboardContent == .image {
+                        SettingRow(
+                            label: "Clipboard Format",
+                            sublabel: "Used whenever a screenshot is copied",
+                            showDivider: true
+                        ) {
+                            Picker("", selection: $viewModel.screenshotClipboardFormat) {
+                                Text("PNG").tag(ScreenshotClipboardFormat.png)
+                                Text("JPEG").tag(ScreenshotClipboardFormat.jpeg)
+                                Text("TIFF").tag(ScreenshotClipboardFormat.tiff)
+                            }
+                            .labelsHidden()
+                            .pickerStyle(.menu)
+                            .fixedSize(horizontal: true, vertical: false)
+                        }
                     }
                     SettingRow(label: "Auto Save", sublabel: "Save to file automatically", showDivider: true) {
                         Toggle("", isOn: $viewModel.screenshotAutoSave)
@@ -258,6 +273,15 @@ struct ScreenshotSettingsView: View {
         }
         .sheet(isPresented: $showingAddPreset) {
             addPresetSheet
+        }
+    }
+
+    private var clipboardContentDescription: LocalizedStringKey {
+        switch viewModel.screenshotClipboardContent {
+        case .image:
+            "Copy image data to the clipboard"
+        case .filePath:
+            "Copy the saved path, or keep a temporary file for 24 hours"
         }
     }
 

--- a/App/Tests/ScreenshotClipboardContentTests.swift
+++ b/App/Tests/ScreenshotClipboardContentTests.swift
@@ -143,6 +143,55 @@ final class ScreenshotClipboardContentTests: XCTestCase {
         )
     }
 
+    func testQuickAccessSaveReplacesManagedTemporaryPathWithSavedPath() throws {
+        let settings = makeSettings()
+        let exportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ScreenshotClipboardQuickAccessSaveTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: exportDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: exportDirectory) }
+        settings.setExportLocation(exportDirectory)
+        settings.screenshotAutoCopy = true
+        settings.screenshotAutoSave = false
+        settings.screenshotClipboardContent = .filePath
+        let coordinator = CaptureCoordinator(settings: settings)
+        let pasteboard = makePasteboard()
+        let result = try makeCaptureResult()
+        let entryID = UUID()
+
+        coordinator.applyDefaultPostCaptureActions(
+            result,
+            entryID: entryID,
+            pasteboard: pasteboard
+        )
+        let temporaryPath = try XCTUnwrap(pasteboard.string(forType: .string))
+        defer { try? FileManager.default.removeItem(atPath: temporaryPath) }
+
+        let window = coordinator.showQuickAccess(
+            for: result,
+            entryID: entryID,
+            autoUpload: false,
+            pasteboard: pasteboard
+        )
+        window.onSave?()
+
+        let savedPath = try XCTUnwrap(pasteboard.string(forType: .string))
+        let savedFiles = try FileManager.default.contentsOfDirectory(
+            at: exportDirectory,
+            includingPropertiesForKeys: nil
+        )
+        XCTAssertNotEqual(
+            URL(fileURLWithPath: savedPath).resolvingSymlinksInPath(),
+            URL(fileURLWithPath: temporaryPath).resolvingSymlinksInPath()
+        )
+        XCTAssertEqual(savedFiles.count, 1)
+        XCTAssertEqual(
+            URL(fileURLWithPath: savedPath).resolvingSymlinksInPath(),
+            savedFiles[0].resolvingSymlinksInPath()
+        )
+        XCTAssertTrue(FileManager.default.isReadableFile(atPath: savedPath))
+    }
+
     func testHistoryScreenshotCopyUsesExistingReadableFilePath() throws {
         let settings = makeSettings()
         settings.screenshotClipboardContent = .filePath

--- a/App/Tests/ScreenshotClipboardContentTests.swift
+++ b/App/Tests/ScreenshotClipboardContentTests.swift
@@ -1,0 +1,166 @@
+import AppKit
+import CaptureKit
+import SharedKit
+import XCTest
+@testable import Capso
+
+@MainActor
+final class ScreenshotClipboardContentTests: XCTestCase {
+    func testFilePathContentCopiesReadableManagedFileWithoutPreview() throws {
+        let settings = makeSettings()
+        settings.screenshotClipboardContent = .filePath
+        settings.screenshotOutputPreset = .losslessPNG
+        let coordinator = CaptureCoordinator(settings: settings)
+        let pasteboard = makePasteboard()
+
+        XCTAssertTrue(coordinator.copyScreenshotToClipboard(
+            try makeCaptureResult(),
+            entryID: UUID(),
+            pasteboard: pasteboard
+        ))
+
+        let path = try XCTUnwrap(pasteboard.string(forType: .string))
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        XCTAssertTrue(path.hasPrefix("/"))
+        XCTAssertEqual((path as NSString).pathExtension, "png")
+        XCTAssertTrue(FileManager.default.isReadableFile(atPath: path))
+    }
+
+    func testFilePathContentPrefersSuccessfulAutoSaveOutput() throws {
+        let settings = makeSettings()
+        settings.screenshotClipboardContent = .filePath
+        let coordinator = CaptureCoordinator(settings: settings)
+        let pasteboard = makePasteboard()
+        let savedURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-autosave-\(UUID().uuidString)")
+            .appendingPathExtension("png")
+        try Data([0x89, 0x50, 0x4E, 0x47]).write(to: savedURL)
+        defer { try? FileManager.default.removeItem(at: savedURL) }
+
+        XCTAssertTrue(coordinator.copyScreenshotToClipboard(
+            try makeCaptureResult(),
+            entryID: UUID(),
+            preferredFileURL: savedURL,
+            pasteboard: pasteboard
+        ))
+
+        XCTAssertEqual(pasteboard.string(forType: .string), savedURL.path)
+    }
+
+    func testDefaultPostCaptureCopiesFilePathWhenPreviewIsDisabled() throws {
+        let settings = makeSettings()
+        settings.screenshotShowPreview = false
+        settings.screenshotAutoCopy = true
+        settings.screenshotAutoSave = false
+        settings.screenshotClipboardContent = .filePath
+        let coordinator = CaptureCoordinator(settings: settings)
+        let pasteboard = makePasteboard()
+
+        coordinator.applyDefaultPostCaptureActions(
+            try makeCaptureResult(),
+            entryID: UUID(),
+            pasteboard: pasteboard
+        )
+
+        let path = try XCTUnwrap(pasteboard.string(forType: .string))
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        XCTAssertTrue(FileManager.default.isReadableFile(atPath: path))
+    }
+
+    func testDefaultPostCaptureCopiesAutoSaveOutputPathWithoutDuplicateTemporaryFile() throws {
+        let settings = makeSettings()
+        let exportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ScreenshotClipboardAutoSaveTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: exportDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: exportDirectory) }
+        settings.setExportLocation(exportDirectory)
+        settings.screenshotShowPreview = false
+        settings.screenshotAutoCopy = true
+        settings.screenshotAutoSave = true
+        settings.screenshotClipboardContent = .filePath
+        let coordinator = CaptureCoordinator(settings: settings)
+        let pasteboard = makePasteboard()
+
+        coordinator.applyDefaultPostCaptureActions(
+            try makeCaptureResult(),
+            entryID: UUID(),
+            pasteboard: pasteboard
+        )
+
+        let copiedPath = try XCTUnwrap(pasteboard.string(forType: .string))
+        defer {
+            if !copiedPath.hasPrefix(exportDirectory.path) {
+                try? FileManager.default.removeItem(atPath: copiedPath)
+            }
+        }
+        let savedFiles = try FileManager.default.contentsOfDirectory(
+            at: exportDirectory,
+            includingPropertiesForKeys: nil
+        )
+        XCTAssertEqual(savedFiles.count, 1)
+        XCTAssertEqual(
+            URL(fileURLWithPath: copiedPath).resolvingSymlinksInPath(),
+            savedFiles[0].resolvingSymlinksInPath()
+        )
+        XCTAssertTrue(FileManager.default.isReadableFile(atPath: copiedPath))
+    }
+
+    func testHistoryScreenshotCopyUsesExistingReadableFilePath() throws {
+        let settings = makeSettings()
+        settings.screenshotClipboardContent = .filePath
+        let coordinator = HistoryCoordinator(settings: settings)
+        let pasteboard = makePasteboard()
+        let sourceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-history-\(UUID().uuidString)")
+            .appendingPathExtension("png")
+        try Data([0x89, 0x50, 0x4E, 0x47]).write(to: sourceURL)
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+
+        XCTAssertTrue(coordinator.copyScreenshotToClipboard(
+            try makeCaptureResult().image,
+            preferredFileURL: sourceURL,
+            pasteboard: pasteboard
+        ))
+
+        XCTAssertEqual(pasteboard.string(forType: .string), sourceURL.path)
+    }
+
+    private func makeSettings() -> AppSettings {
+        let suite = "ScreenshotClipboardContentTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return AppSettings(defaults: defaults)
+    }
+
+    private func makePasteboard() -> NSPasteboard {
+        let pasteboard = NSPasteboard(
+            name: NSPasteboard.Name("ScreenshotClipboardContentTests.\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+        return pasteboard
+    }
+
+    private func makeCaptureResult() throws -> CaptureResult {
+        let context = try XCTUnwrap(CGContext(
+            data: nil,
+            width: 8,
+            height: 6,
+            bitsPerComponent: 8,
+            bytesPerRow: 32,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(CGColor(red: 0.1, green: 0.5, blue: 0.8, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: 8, height: 6))
+        return CaptureResult(
+            image: try XCTUnwrap(context.makeImage()),
+            mode: .area,
+            captureRect: CGRect(x: 0, y: 0, width: 8, height: 6),
+            windowName: "Terminal",
+            appName: "Agent",
+            timestamp: Date(timeIntervalSince1970: 1_800),
+            displayID: 1
+        )
+    }
+}

--- a/App/Tests/ScreenshotClipboardContentTests.swift
+++ b/App/Tests/ScreenshotClipboardContentTests.swift
@@ -106,6 +106,43 @@ final class ScreenshotClipboardContentTests: XCTestCase {
         XCTAssertTrue(FileManager.default.isReadableFile(atPath: copiedPath))
     }
 
+    func testQuickAccessCopyReusesAutoSaveOutputPath() throws {
+        let settings = makeSettings()
+        let exportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ScreenshotClipboardQuickAccessTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: exportDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: exportDirectory) }
+        settings.setExportLocation(exportDirectory)
+        settings.screenshotAutoCopy = false
+        settings.screenshotAutoSave = true
+        settings.screenshotClipboardContent = .filePath
+        let coordinator = CaptureCoordinator(settings: settings)
+        let pasteboard = makePasteboard()
+        let result = try makeCaptureResult()
+        let entryID = UUID()
+
+        let savedFileURL = try XCTUnwrap(coordinator.applyDefaultPostCaptureActions(
+            result,
+            entryID: entryID,
+            pasteboard: pasteboard
+        ))
+        let window = coordinator.showQuickAccess(
+            for: result,
+            entryID: entryID,
+            autoUpload: false,
+            preferredFileURL: savedFileURL,
+            pasteboard: pasteboard
+        )
+        window.onCopy?()
+
+        XCTAssertEqual(
+            URL(fileURLWithPath: try XCTUnwrap(pasteboard.string(forType: .string)))
+                .resolvingSymlinksInPath(),
+            savedFileURL.resolvingSymlinksInPath()
+        )
+    }
+
     func testHistoryScreenshotCopyUsesExistingReadableFilePath() throws {
         let settings = makeSettings()
         settings.screenshotClipboardContent = .filePath

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -14,6 +14,11 @@ public enum ScreenshotClipboardFormat: String, CaseIterable, Sendable {
     case tiff
 }
 
+public enum ScreenshotClipboardContent: String, CaseIterable, Sendable {
+    case image
+    case filePath
+}
+
 public enum ScreenshotOutputPreset: String, CaseIterable, Sendable {
     case losslessPNG
     case standardJPEG
@@ -459,6 +464,15 @@ public final class AppSettings: @unchecked Sendable {
             return value
         }
         set { defaults.set(newValue.rawValue, forKey: "screenshotClipboardFormat") }
+    }
+
+    public var screenshotClipboardContent: ScreenshotClipboardContent {
+        get {
+            guard let raw = defaults.string(forKey: "screenshotClipboardContent"),
+                  let value = ScreenshotClipboardContent(rawValue: raw) else { return .image }
+            return value
+        }
+        set { defaults.set(newValue.rawValue, forKey: "screenshotClipboardContent") }
     }
 
     public var screenshotAutoSave: Bool {

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ScreenshotClipboard.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ScreenshotClipboard.swift
@@ -1,0 +1,31 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+public enum ScreenshotClipboard {
+    @discardableResult
+    public static func copy(
+        _ image: CGImage,
+        content: ScreenshotClipboardContent,
+        imageFormat: ScreenshotClipboardFormat,
+        pasteboard: NSPasteboard = .general,
+        fileURLProvider: () throws -> URL
+    ) -> Bool {
+        switch content {
+        case .image:
+            return ImageUtilities.copyToPasteboard(
+                image,
+                format: imageFormat,
+                pasteboard: pasteboard
+            )
+        case .filePath:
+            guard let fileURL = try? fileURLProvider(),
+                  fileURL.isFileURL,
+                  FileManager.default.isReadableFile(atPath: fileURL.path) else {
+                return false
+            }
+            pasteboard.clearContents()
+            return pasteboard.setString(fileURL.path, forType: .string)
+        }
+    }
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -52,6 +52,21 @@ struct AppSettingsTests {
         #expect(second.screenshotClipboardFormat == .jpeg)
     }
 
+    @Test("Screenshot clipboard content defaults to image and persists file path")
+    func screenshotClipboardContentDefaultsAndPersists() {
+        let suite = "test.screenshotClipboardContent"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let first = AppSettings(defaults: defaults)
+        #expect(first.screenshotClipboardContent == .image)
+
+        first.screenshotClipboardContent = .filePath
+
+        let second = AppSettings(defaults: defaults)
+        #expect(second.screenshotClipboardContent == .filePath)
+    }
+
     @Test("Screenshot output preset falls back to legacy JPEG format")
     func screenshotOutputPresetLegacyFormatFallback() {
         let suite = "test.screenshotOutputPreset.legacy"

--- a/Packages/SharedKit/Tests/SharedKitTests/ScreenshotClipboardTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ScreenshotClipboardTests.swift
@@ -1,0 +1,102 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import Testing
+@testable import SharedKit
+
+@Suite("ScreenshotClipboard")
+struct ScreenshotClipboardTests {
+    @Test("Image content copies image data without materializing a file")
+    func imageContentCopiesImageWithoutMaterializingFile() throws {
+        let pasteboard = makePasteboard()
+        var requestedFileURL = false
+
+        let copied = ScreenshotClipboard.copy(
+            try makeImage(),
+            content: .image,
+            imageFormat: .png,
+            pasteboard: pasteboard
+        ) {
+            requestedFileURL = true
+            return URL(fileURLWithPath: "/tmp/unused.png")
+        }
+
+        #expect(copied)
+        #expect(!requestedFileURL)
+        #expect(pasteboard.data(forType: .png) != nil)
+        #expect(pasteboard.string(forType: .string) == nil)
+    }
+
+    @Test("File path content copies a readable absolute path as text")
+    func filePathContentCopiesReadableAbsolutePath() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ScreenshotClipboardTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("Screenshot.png")
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data([0x89, 0x50, 0x4E, 0x47]).write(to: fileURL)
+        let pasteboard = makePasteboard()
+
+        let copied = ScreenshotClipboard.copy(
+            try makeImage(),
+            content: .filePath,
+            imageFormat: .png,
+            pasteboard: pasteboard
+        ) {
+            fileURL
+        }
+
+        #expect(copied)
+        #expect(pasteboard.string(forType: .string) == fileURL.path)
+        #expect(FileManager.default.isReadableFile(atPath: fileURL.path))
+        #expect(pasteboard.data(forType: .png) == nil)
+    }
+
+    @Test("Unreadable file path leaves existing clipboard content unchanged")
+    func unreadableFilePathLeavesClipboardUnchanged() throws {
+        let pasteboard = makePasteboard()
+        pasteboard.setString("keep me", forType: .string)
+        let missingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("Missing.png")
+
+        let copied = ScreenshotClipboard.copy(
+            try makeImage(),
+            content: .filePath,
+            imageFormat: .png,
+            pasteboard: pasteboard
+        ) {
+            missingURL
+        }
+
+        #expect(!copied)
+        #expect(pasteboard.string(forType: .string) == "keep me")
+    }
+
+    private func makePasteboard() -> NSPasteboard {
+        let pasteboard = NSPasteboard(
+            name: NSPasteboard.Name("ScreenshotClipboardTests.\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+        return pasteboard
+    }
+
+    private func makeImage() throws -> CGImage {
+        let context = try #require(CGContext(
+            data: nil,
+            width: 4,
+            height: 3,
+            bitsPerComponent: 8,
+            bytesPerRow: 16,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(CGColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: 4, height: 3))
+        return try #require(context.makeImage())
+    }
+}


### PR DESCRIPTION
## Summary

- add a **Clipboard Content** setting for screenshots with **Image** as the default and **File Path** as the new option
- copy a readable file path immediately after capture even when Quick Access preview is disabled
- reuse a successful Auto Save URL, otherwise materialize a managed temporary file retained for 24 hours
- apply the screenshot clipboard policy to Quick Access and History while leaving recording and GIF behavior unchanged
- localize the new setting and descriptions in Japanese, Korean, and Simplified Chinese

## Why

Some users intentionally disable Quick Access but still need the screenshot file path immediately after capture. Previously Capso only copied image data, so that workflow required opening another UI or locating the file manually.

## User impact

Users can enable **Copy to Clipboard** and choose **File Path** under Screenshot settings. When Auto Save succeeds, Capso copies that durable path. When Auto Save is disabled or fails, Capso copies a readable managed temporary path instead.

## Validation

- `swift test --package-path Packages/SharedKit` — 168 tests passed
- `xcodebuild test -project Capso.xcodeproj -scheme Capso CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build CODE_SIGNING_ALLOWED=NO`
- localization catalog completeness check for Japanese, Korean, and Simplified Chinese
- `git diff --check origin/main...HEAD`

Closes #205

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core post-capture clipboard and save ordering across CaptureCoordinator and HistoryCoordinator; file-path mode depends on temp file lifecycle and readable paths, though behavior is covered by new tests.
> 
> **Overview**
> Adds a **Clipboard Content** screenshot setting: **Image** (unchanged default with PNG/JPEG/TIFF) or **File Path**, which puts a readable absolute path on the pasteboard instead of bitmap data.
> 
> Post-capture and Quick Access/History copy paths now go through `ScreenshotClipboard` and `copyScreenshotToClipboard`, with **`applyDefaultPostCaptureActions`** ordering auto-save before file-path copy when both are enabled. File-path mode prefers an auto-saved URL, otherwise a managed temporary file (24h); Quick Access passes **`preferredFileURL`** so copy/save does not duplicate temp files. Pinned/annotation “rendered image” copy still uses image mode via **`copyRenderedScreenshotToClipboard`**.
> 
> New **`screenshotClipboardContent`** persists in `AppSettings`; screenshot settings UI and ja/ko/zh-Hans strings were added. Unit/integration tests cover clipboard behavior and settings persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46e4dd8b28769014ee1affae76e9d77ca5b2eafe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->