### PR TITLE
feat: let users turn off or reschedule the update check

### DIFF
--- a/App/Resources/Info.plist
+++ b/App/Resources/Info.plist
@@ -67,6 +67,6 @@
     <key>SUEnableAutomaticChecks</key>
     <true/>
     <key>SUScheduledCheckInterval</key>
-    <integer>604800</integer>
+    <integer>86400</integer>
 </dict>
 </plist>

--- a/App/Resources/Info.plist
+++ b/App/Resources/Info.plist
@@ -67,6 +67,6 @@
     <key>SUEnableAutomaticChecks</key>
     <true/>
     <key>SUScheduledCheckInterval</key>
-    <integer>86400</integer>
+    <integer>604800</integer>
 </dict>
 </plist>

--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -8295,6 +8295,160 @@
           }
         }
       }
+    },
+    "Automatically Check for Updates" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アップデートを自動確認"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "업데이트 자동 확인"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动检查更新"
+          }
+        }
+      }
+    },
+    "Look for new versions in the background" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "バックグラウンドで新しいバージョンを確認します"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "백그라운드에서 새 버전을 확인합니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在后台查找新版本"
+          }
+        }
+      }
+    },
+    "Check Frequency" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "確認の頻度"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "확인 주기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检查频率"
+          }
+        }
+      }
+    },
+    "Daily" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "毎日"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "매일"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每天"
+          }
+        }
+      }
+    },
+    "Weekly" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "毎週"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "매주"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每周"
+          }
+        }
+      }
+    },
+    "Monthly" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "毎月"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "매월"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "每月"
+          }
+        }
+      }
+    },
+    "Look for a new version now" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今すぐ新しいバージョンを確認します"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "지금 새 버전을 확인합니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即查找新版本"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/App/Sources/Preferences/Components/CheckForUpdatesView.swift
+++ b/App/Sources/Preferences/Components/CheckForUpdatesView.swift
@@ -18,9 +18,6 @@ final class UpdateManager: NSObject, ObservableObject {
     }
 
     @Published private(set) var canCheckForUpdates = false
-    /// Whether the automatic-install option can be offered at all. Sparkle turns
-    /// this off while background checks are disabled.
-    @Published private(set) var canConfigureAutomaticInstall = true
     @Published private(set) var status: Status?
     @Published var automaticallyChecksForUpdates: Bool = true {
         didSet {
@@ -34,10 +31,12 @@ final class UpdateManager: NSObject, ObservableObject {
             updater.updateCheckInterval = updateCheckFrequency.timeInterval
         }
     }
+    /// Independent of `automaticallyChecksForUpdates`: switching background
+    /// checks off must not disturb what the user chose here.
     @Published var automaticallyDownloadsUpdates: Bool = false {
         didSet {
             guard oldValue != automaticallyDownloadsUpdates else { return }
-            updater.automaticallyDownloadsUpdates = automaticallyDownloadsUpdates
+            updater.storedAutomaticallyDownloadsUpdates = automaticallyDownloadsUpdates
         }
     }
 
@@ -49,7 +48,6 @@ final class UpdateManager: NSObject, ObservableObject {
     private var manualCheckState: ManualCheckState = .none
     private var probeFoundValidUpdate = false
     private var canCheckObservation: NSKeyValueObservation?
-    private var allowsAutomaticObservation: NSKeyValueObservation?
     private var autoCheckObservation: NSKeyValueObservation?
     private var autoDownloadObservation: NSKeyValueObservation?
     private var clearStatusTask: Task<Void, Never>?
@@ -72,10 +70,9 @@ final class UpdateManager: NSObject, ObservableObject {
         // Property observers don't run inside an initializer, so seeding these
         // never writes back to the updater.
         canCheckForUpdates = self.updater.canCheckForUpdates
-        canConfigureAutomaticInstall = self.updater.allowsAutomaticUpdates
         automaticallyChecksForUpdates = self.updater.automaticallyChecksForUpdates
         updateCheckFrequency = UpdateCheckFrequency(closestTo: self.updater.updateCheckInterval)
-        automaticallyDownloadsUpdates = self.updater.automaticallyDownloadsUpdates
+        automaticallyDownloadsUpdates = self.updater.storedAutomaticallyDownloadsUpdates
         startObservingSparkleUpdater()
     }
 
@@ -89,19 +86,17 @@ final class UpdateManager: NSObject, ObservableObject {
                 self?.canCheckForUpdates = updater.canCheckForUpdates
             }
         }
-        allowsAutomaticObservation = sparkleUpdater.observe(\.allowsAutomaticUpdates, options: [.initial, .new]) { [weak self] updater, _ in
-            Task { @MainActor in
-                self?.canConfigureAutomaticInstall = updater.allowsAutomaticUpdates
-            }
-        }
         autoCheckObservation = sparkleUpdater.observe(\.automaticallyChecksForUpdates, options: [.new]) { [weak self] updater, _ in
             Task { @MainActor in
                 self?.automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
             }
         }
+        // Sparkle's own update dialog can flip the auto-install preference, so
+        // stay in sync with it — but re-read the stored value rather than the
+        // masked one this notification carries.
         autoDownloadObservation = sparkleUpdater.observe(\.automaticallyDownloadsUpdates, options: [.new]) { [weak self] updater, _ in
             Task { @MainActor in
-                self?.automaticallyDownloadsUpdates = updater.automaticallyDownloadsUpdates
+                self?.automaticallyDownloadsUpdates = updater.storedAutomaticallyDownloadsUpdates
             }
         }
     }
@@ -131,38 +126,69 @@ final class UpdateManager: NSObject, ObservableObject {
         manualCheckState = .none
         probeFoundValidUpdate = false
     }
-}
 
-extension UpdateManager: SPUUpdaterDelegate {
-    func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+    // MARK: Manual probe outcomes
+    //
+    // Split out from the `SPUUpdaterDelegate` callbacks, whose signatures require
+    // a live `SPUUpdater`, so the manual-check flow stays testable.
+
+    /// The silent probe found an update, so the interactive flow can take over.
+    func handleProbeFoundUpdate() {
         guard manualCheckState == .probing else { return }
         probeFoundValidUpdate = true
         status = nil
     }
 
-    func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: Error) {
+    /// The silent probe found nothing.
+    func handleProbeFoundNoUpdate(error: any Error) {
         guard manualCheckState == .probing else { return }
         let message = error.localizedDescription.isEmpty ? String(localized: "You’re up to date!") : error.localizedDescription
         showStatus(message, kind: .success)
     }
 
-    func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
+    /// The silent probe was aborted. Sparkle reports "no update found" this way
+    /// too (error 1001), which `handleProbeFoundNoUpdate` has already covered.
+    func handleProbeAborted(error: any Error) {
         guard manualCheckState == .probing else { return }
         let nsError = error as NSError
         guard !(nsError.domain == SUSparkleErrorDomain && nsError.code == 1001) else { return }
         showStatus(error.localizedDescription, kind: .error, autoDismissAfter: .seconds(6))
     }
 
-    func updater(_ updater: SPUUpdater, didFinishUpdateCycleFor updateCheck: SPUUpdateCheck, error: (any Error)?) {
-        guard manualCheckState == .probing, updateCheck == .updateInformation else { return }
+    /// The silent probe finished. Hand over to Sparkle's interactive flow when
+    /// there is something to install.
+    ///
+    /// This is user-initiated, so Sparkle always presents the update rather than
+    /// installing it silently, whatever the automatic check and install settings
+    /// happen to be.
+    func handleProbeFinished(error: (any Error)?) {
+        guard manualCheckState == .probing else { return }
 
         let shouldLaunchInteractiveFlow = probeFoundValidUpdate && error == nil
         clearManualProbeState()
 
-        if shouldLaunchInteractiveFlow {
-            status = nil
-            updater.checkForUpdates()
-        }
+        guard shouldLaunchInteractiveFlow else { return }
+        status = nil
+        updater.checkForUpdates()
+    }
+}
+
+extension UpdateManager: SPUUpdaterDelegate {
+    func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        handleProbeFoundUpdate()
+    }
+
+    func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: Error) {
+        handleProbeFoundNoUpdate(error: error)
+    }
+
+    func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
+        handleProbeAborted(error: error)
+    }
+
+    func updater(_ updater: SPUUpdater, didFinishUpdateCycleFor updateCheck: SPUUpdateCheck, error: (any Error)?) {
+        guard updateCheck == .updateInformation else { return }
+        handleProbeFinished(error: error)
     }
 }
 

--- a/App/Sources/Preferences/Components/CheckForUpdatesView.swift
+++ b/App/Sources/Preferences/Components/CheckForUpdatesView.swift
@@ -1,6 +1,7 @@
 // App/Sources/Preferences/Components/CheckForUpdatesView.swift
 import AppKit
 import SwiftUI
+import SharedKit
 import Sparkle
 
 @MainActor
@@ -17,7 +18,22 @@ final class UpdateManager: NSObject, ObservableObject {
     }
 
     @Published private(set) var canCheckForUpdates = false
+    /// Whether the automatic-install option can be offered at all. Sparkle turns
+    /// this off while background checks are disabled.
+    @Published private(set) var canConfigureAutomaticInstall = true
     @Published private(set) var status: Status?
+    @Published var automaticallyChecksForUpdates: Bool = true {
+        didSet {
+            guard oldValue != automaticallyChecksForUpdates else { return }
+            updater.automaticallyChecksForUpdates = automaticallyChecksForUpdates
+        }
+    }
+    @Published var updateCheckFrequency: UpdateCheckFrequency = .daily {
+        didSet {
+            guard oldValue != updateCheckFrequency else { return }
+            updater.updateCheckInterval = updateCheckFrequency.timeInterval
+        }
+    }
     @Published var automaticallyDownloadsUpdates: Bool = false {
         didSet {
             guard oldValue != automaticallyDownloadsUpdates else { return }
@@ -33,6 +49,8 @@ final class UpdateManager: NSObject, ObservableObject {
     private var manualCheckState: ManualCheckState = .none
     private var probeFoundValidUpdate = false
     private var canCheckObservation: NSKeyValueObservation?
+    private var allowsAutomaticObservation: NSKeyValueObservation?
+    private var autoCheckObservation: NSKeyValueObservation?
     private var autoDownloadObservation: NSKeyValueObservation?
     private var clearStatusTask: Task<Void, Never>?
 
@@ -42,17 +60,46 @@ final class UpdateManager: NSObject, ObservableObject {
         userDriverDelegate: nil
     )
 
-    var updater: SPUUpdater { updaterController.updater }
+    private let injectedUpdater: (any SoftwareUpdating)?
 
-    override init() {
+    var updater: any SoftwareUpdating { injectedUpdater ?? updaterController.updater }
+
+    /// - Parameter updater: Overrides Sparkle's updater. Tests pass a stand-in;
+    ///   the app passes nothing so the real `SPUStandardUpdaterController` is used.
+    init(updater: (any SoftwareUpdating)? = nil) {
+        injectedUpdater = updater
         super.init()
-        automaticallyDownloadsUpdates = updater.automaticallyDownloadsUpdates
-        canCheckObservation = updater.observe(\.canCheckForUpdates, options: [.initial, .new]) { [weak self] updater, _ in
+        // Property observers don't run inside an initializer, so seeding these
+        // never writes back to the updater.
+        canCheckForUpdates = self.updater.canCheckForUpdates
+        canConfigureAutomaticInstall = self.updater.allowsAutomaticUpdates
+        automaticallyChecksForUpdates = self.updater.automaticallyChecksForUpdates
+        updateCheckFrequency = UpdateCheckFrequency(closestTo: self.updater.updateCheckInterval)
+        automaticallyDownloadsUpdates = self.updater.automaticallyDownloadsUpdates
+        startObservingSparkleUpdater()
+    }
+
+    /// Sparkle's properties are KVO-compliant; a stand-in updater is not, and
+    /// keeps whatever state the test sets on it.
+    private func startObservingSparkleUpdater() {
+        guard let sparkleUpdater = updater as? SPUUpdater else { return }
+
+        canCheckObservation = sparkleUpdater.observe(\.canCheckForUpdates, options: [.initial, .new]) { [weak self] updater, _ in
             Task { @MainActor in
                 self?.canCheckForUpdates = updater.canCheckForUpdates
             }
         }
-        autoDownloadObservation = updater.observe(\.automaticallyDownloadsUpdates, options: [.new]) { [weak self] updater, _ in
+        allowsAutomaticObservation = sparkleUpdater.observe(\.allowsAutomaticUpdates, options: [.initial, .new]) { [weak self] updater, _ in
+            Task { @MainActor in
+                self?.canConfigureAutomaticInstall = updater.allowsAutomaticUpdates
+            }
+        }
+        autoCheckObservation = sparkleUpdater.observe(\.automaticallyChecksForUpdates, options: [.new]) { [weak self] updater, _ in
+            Task { @MainActor in
+                self?.automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
+            }
+        }
+        autoDownloadObservation = sparkleUpdater.observe(\.automaticallyDownloadsUpdates, options: [.new]) { [weak self] updater, _ in
             Task { @MainActor in
                 self?.automaticallyDownloadsUpdates = updater.automaticallyDownloadsUpdates
             }

--- a/App/Sources/Preferences/Components/SoftwareUpdating.swift
+++ b/App/Sources/Preferences/Components/SoftwareUpdating.swift
@@ -1,0 +1,29 @@
+// App/Sources/Preferences/Components/SoftwareUpdating.swift
+import Foundation
+import Sparkle
+
+/// The slice of Sparkle's updater that Capso drives.
+///
+/// `UpdateManager` talks to this instead of `SPUUpdater` directly so its behaviour
+/// can be unit tested without starting a real updater. `SPUUpdater` is already
+/// main-actor isolated (`NS_SWIFT_UI_ACTOR`), matching this protocol's isolation.
+@MainActor
+protocol SoftwareUpdating: AnyObject {
+    /// Whether the user can start an update check right now.
+    var canCheckForUpdates: Bool { get }
+    /// Whether Sparkle checks for updates in the background.
+    var automaticallyChecksForUpdates: Bool { get set }
+    /// Whether found updates are downloaded and installed without asking.
+    var automaticallyDownloadsUpdates: Bool { get set }
+    /// Whether the automatic-install option can be turned on at all.
+    var allowsAutomaticUpdates: Bool { get }
+    /// How often background checks run, in seconds.
+    var updateCheckInterval: TimeInterval { get set }
+
+    /// Silently fetches update information without showing Sparkle's UI.
+    func checkForUpdateInformation()
+    /// Runs a user-initiated check, showing Sparkle's UI.
+    func checkForUpdates()
+}
+
+extension SPUUpdater: SoftwareUpdating {}

--- a/App/Sources/Preferences/Components/SoftwareUpdating.swift
+++ b/App/Sources/Preferences/Components/SoftwareUpdating.swift
@@ -13,10 +13,12 @@ protocol SoftwareUpdating: AnyObject {
     var canCheckForUpdates: Bool { get }
     /// Whether Sparkle checks for updates in the background.
     var automaticallyChecksForUpdates: Bool { get set }
-    /// Whether found updates are downloaded and installed without asking.
-    var automaticallyDownloadsUpdates: Bool { get set }
-    /// Whether the automatic-install option can be turned on at all.
-    var allowsAutomaticUpdates: Bool { get }
+    /// The stored "install updates automatically" preference.
+    ///
+    /// Deliberately not `SPUUpdater.automaticallyDownloadsUpdates`: that getter
+    /// reports `false` whenever automatic checks are off, which would drag the
+    /// two settings around together.
+    var storedAutomaticallyDownloadsUpdates: Bool { get set }
     /// How often background checks run, in seconds.
     var updateCheckInterval: TimeInterval { get set }
 
@@ -26,4 +28,37 @@ protocol SoftwareUpdating: AnyObject {
     func checkForUpdates()
 }
 
-extension SPUUpdater: SoftwareUpdating {}
+/// Reads and writes Sparkle's persisted "install updates automatically"
+/// preference, bypassing `SPUUpdater`'s accessors for it.
+///
+/// Both of Sparkle's accessors are gated on `allowsAutomaticUpdates`, which is
+/// itself tied to `automaticallyChecksForUpdates`: the getter reports `false`
+/// and the setter silently drops the write while background checks are off
+/// (`SPUUpdaterSettings.setAutomaticallyDownloadsUpdates:`). Capso keeps the two
+/// settings independent, so it goes to the stored value directly. Sparkle
+/// observes this key and picks the change up on its own.
+enum AutomaticInstallPreference {
+    static let key = "SUAutomaticallyUpdate"
+
+    /// - Parameter fallback: The bundle's `SUAutomaticallyUpdate` value, used
+    ///   until the user has made a choice.
+    static func value(in defaults: UserDefaults, fallback: Bool?) -> Bool {
+        defaults.object(forKey: key) as? Bool ?? fallback ?? false
+    }
+
+    static func setValue(_ newValue: Bool, in defaults: UserDefaults) {
+        defaults.set(newValue, forKey: key)
+    }
+}
+
+extension SPUUpdater: SoftwareUpdating {
+    var storedAutomaticallyDownloadsUpdates: Bool {
+        get {
+            AutomaticInstallPreference.value(
+                in: .standard,
+                fallback: Bundle.main.object(forInfoDictionaryKey: AutomaticInstallPreference.key) as? Bool
+            )
+        }
+        set { AutomaticInstallPreference.setValue(newValue, in: .standard) }
+    }
+}

--- a/App/Sources/Preferences/Components/UpdatesSettingsSection.swift
+++ b/App/Sources/Preferences/Components/UpdatesSettingsSection.swift
@@ -6,7 +6,8 @@ import SharedKit
 ///
 /// Lives in its own view so it can observe `UpdateManager` directly: the
 /// frequency and auto-install rows have to grey out as soon as automatic
-/// checks are switched off.
+/// checks are switched off. Greying them leaves both stored values alone, so
+/// switching checks back on restores what the user had.
 struct UpdatesSettingsSection: View {
     @ObservedObject var updateManager: UpdateManager
 
@@ -38,6 +39,7 @@ struct UpdatesSettingsSection: View {
                     Toggle("", isOn: $updateManager.automaticallyDownloadsUpdates)
                         .toggleStyle(.switch)
                         .controlSize(.small)
+                        .disabled(!updateManager.automaticallyChecksForUpdates)
                 }
                 SettingRow(label: "Check for Updates", sublabel: "Look for a new version now", showDivider: true) {
                     CheckForUpdatesView(updateManager: updateManager)

--- a/App/Sources/Preferences/Components/UpdatesSettingsSection.swift
+++ b/App/Sources/Preferences/Components/UpdatesSettingsSection.swift
@@ -38,7 +38,6 @@ struct UpdatesSettingsSection: View {
                     Toggle("", isOn: $updateManager.automaticallyDownloadsUpdates)
                         .toggleStyle(.switch)
                         .controlSize(.small)
-                        .disabled(!updateManager.canConfigureAutomaticInstall)
                 }
                 SettingRow(label: "Check for Updates", sublabel: "Look for a new version now", showDivider: true) {
                     CheckForUpdatesView(updateManager: updateManager)

--- a/App/Sources/Preferences/Components/UpdatesSettingsSection.swift
+++ b/App/Sources/Preferences/Components/UpdatesSettingsSection.swift
@@ -1,0 +1,49 @@
+// App/Sources/Preferences/Components/UpdatesSettingsSection.swift
+import SwiftUI
+import SharedKit
+
+/// The Updates group in Preferences → General.
+///
+/// Lives in its own view so it can observe `UpdateManager` directly: the
+/// frequency and auto-install rows have to grey out as soon as automatic
+/// checks are switched off.
+struct UpdatesSettingsSection: View {
+    @ObservedObject var updateManager: UpdateManager
+
+    var body: some View {
+        SettingGroup(title: "Updates") {
+            SettingCard {
+                SettingRow(
+                    label: "Automatically Check for Updates",
+                    sublabel: "Look for new versions in the background"
+                ) {
+                    Toggle("", isOn: $updateManager.automaticallyChecksForUpdates)
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                }
+                SettingRow(label: "Check Frequency", showDivider: true) {
+                    Picker("", selection: $updateManager.updateCheckFrequency) {
+                        Text("Daily").tag(UpdateCheckFrequency.daily)
+                        Text("Weekly").tag(UpdateCheckFrequency.weekly)
+                        Text("Monthly").tag(UpdateCheckFrequency.monthly)
+                    }
+                    .frame(width: 130)
+                    .disabled(!updateManager.automaticallyChecksForUpdates)
+                }
+                SettingRow(
+                    label: "Automatically Install Updates",
+                    sublabel: "Install updates in the background when available",
+                    showDivider: true
+                ) {
+                    Toggle("", isOn: $updateManager.automaticallyDownloadsUpdates)
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                        .disabled(!updateManager.canConfigureAutomaticInstall)
+                }
+                SettingRow(label: "Check for Updates", sublabel: "Look for a new version now", showDivider: true) {
+                    CheckForUpdatesView(updateManager: updateManager)
+                }
+            }
+        }
+    }
+}

--- a/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
@@ -43,6 +43,10 @@ struct GeneralSettingsView: View {
                 }
             }
 
+            if let updateManager {
+                UpdatesSettingsSection(updateManager: updateManager)
+            }
+
             SettingGroup(title: "Automation") {
                 SettingCard {
                     SettingRow(
@@ -72,24 +76,6 @@ struct GeneralSettingsView: View {
                         Toggle("", isOn: $viewModel.playShutterSound)
                             .toggleStyle(.switch)
                             .controlSize(.small)
-                    }
-                }
-            }
-
-            if let updateManager {
-                SettingGroup(title: "Updates") {
-                    SettingCard {
-                        SettingRow(label: "Automatically Install Updates", sublabel: "Install updates in the background when available") {
-                            Toggle("", isOn: Binding(
-                                get: { updateManager.automaticallyDownloadsUpdates },
-                                set: { updateManager.automaticallyDownloadsUpdates = $0 }
-                            ))
-                            .toggleStyle(.switch)
-                            .controlSize(.small)
-                        }
-                        SettingRow(label: "Check for Updates", sublabel: "Automatically checks daily", showDivider: true) {
-                            CheckForUpdatesView(updateManager: updateManager)
-                        }
                     }
                 }
             }

--- a/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
@@ -43,10 +43,6 @@ struct GeneralSettingsView: View {
                 }
             }
 
-            if let updateManager {
-                UpdatesSettingsSection(updateManager: updateManager)
-            }
-
             SettingGroup(title: "Automation") {
                 SettingCard {
                     SettingRow(
@@ -78,6 +74,10 @@ struct GeneralSettingsView: View {
                             .controlSize(.small)
                     }
                 }
+            }
+
+            if let updateManager {
+                UpdatesSettingsSection(updateManager: updateManager)
             }
 
             SettingGroup(title: "History") {

--- a/App/Tests/UpdateManagerTests.swift
+++ b/App/Tests/UpdateManagerTests.swift
@@ -215,7 +215,9 @@ final class UpdateManagerTests: XCTestCase {
         XCTAssertEqual(updater.automaticallyDownloadsUpdatesWriteCount, writes)
     }
 
-    func testAutomaticInstallCanStillBeChangedWhileAutomaticChecksAreOff() {
+    /// The row is greyed out in this state, but Sparkle's own update dialog can
+    /// still change the preference, and the write has to survive.
+    func testAutomaticInstallWritesStillPersistWhileAutomaticChecksAreOff() {
         let updater = FakeSoftwareUpdater()
         updater.automaticallyChecksForUpdates = false
         let manager = UpdateManager(updater: updater)

--- a/App/Tests/UpdateManagerTests.swift
+++ b/App/Tests/UpdateManagerTests.swift
@@ -32,6 +32,10 @@ final class FakeSoftwareUpdater: SoftwareUpdating {
 
 /// The values Sparkle starts from before the user picks anything, which live in
 /// the app's Info.plist rather than in code.
+///
+/// These are deliberately unchanged by this feature: an existing install has
+/// nothing stored for them, so editing the plist would silently move everyone
+/// who upgrades. Anyone who wants a different interval can pick one.
 final class ShippedUpdateDefaultsTests: XCTestCase {
     func testAutomaticChecksAreOnByDefault() {
         XCTAssertEqual(Bundle.main.object(forInfoDictionaryKey: "SUEnableAutomaticChecks") as? Bool, true)
@@ -41,11 +45,11 @@ final class ShippedUpdateDefaultsTests: XCTestCase {
         XCTAssertNil(Bundle.main.object(forInfoDictionaryKey: AutomaticInstallPreference.key))
     }
 
-    func testDefaultCheckFrequencyIsWeekly() {
+    func testDefaultCheckFrequencyIsDaily() {
         let interval = Bundle.main.object(forInfoDictionaryKey: "SUScheduledCheckInterval") as? TimeInterval
 
-        XCTAssertEqual(interval, UpdateCheckFrequency.weekly.timeInterval)
-        XCTAssertEqual(UpdateCheckFrequency(closestTo: interval ?? 0), .weekly)
+        XCTAssertEqual(interval, UpdateCheckFrequency.daily.timeInterval)
+        XCTAssertEqual(UpdateCheckFrequency(closestTo: interval ?? 0), .daily)
     }
 }
 

--- a/App/Tests/UpdateManagerTests.swift
+++ b/App/Tests/UpdateManagerTests.swift
@@ -215,8 +215,6 @@ final class UpdateManagerTests: XCTestCase {
         XCTAssertEqual(updater.automaticallyDownloadsUpdatesWriteCount, writes)
     }
 
-    /// The row is greyed out in this state, but Sparkle's own update dialog can
-    /// still change the preference, and the write has to survive.
     func testAutomaticInstallWritesStillPersistWhileAutomaticChecksAreOff() {
         let updater = FakeSoftwareUpdater()
         updater.automaticallyChecksForUpdates = false

--- a/App/Tests/UpdateManagerTests.swift
+++ b/App/Tests/UpdateManagerTests.swift
@@ -7,7 +7,6 @@ import SharedKit
 @MainActor
 final class FakeSoftwareUpdater: SoftwareUpdating {
     var canCheckForUpdates = true
-    var allowsAutomaticUpdates = true
     var updateCheckInterval: TimeInterval = 86_400
     var checkForUpdateInformationCount = 0
     var checkForUpdatesCount = 0
@@ -17,7 +16,7 @@ final class FakeSoftwareUpdater: SoftwareUpdating {
     }
     private(set) var automaticallyChecksForUpdatesWriteCount = 0
 
-    var automaticallyDownloadsUpdates = false {
+    var storedAutomaticallyDownloadsUpdates = false {
         didSet { automaticallyDownloadsUpdatesWriteCount += 1 }
     }
     private(set) var automaticallyDownloadsUpdatesWriteCount = 0
@@ -31,12 +30,53 @@ final class FakeSoftwareUpdater: SoftwareUpdating {
     }
 }
 
+/// Sparkle drops `setAutomaticallyDownloadsUpdates:` while automatic checks are
+/// off, so Capso persists the preference by writing Sparkle's own key. These
+/// cover that storage directly, since no stand-in updater can catch it.
+final class AutomaticInstallPreferenceTests: XCTestCase {
+    private func makeDefaults(_ name: String) -> UserDefaults {
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        return defaults
+    }
+
+    func testDefaultsToFalseWhenNothingIsStored() {
+        let defaults = makeDefaults("test.automaticInstall.unset")
+
+        XCTAssertFalse(AutomaticInstallPreference.value(in: defaults, fallback: nil))
+    }
+
+    func testFallsBackToTheInfoPlistValue() {
+        let defaults = makeDefaults("test.automaticInstall.fallback")
+
+        XCTAssertTrue(AutomaticInstallPreference.value(in: defaults, fallback: true))
+        XCTAssertFalse(AutomaticInstallPreference.value(in: defaults, fallback: false))
+    }
+
+    func testStoredValueWinsOverTheInfoPlistValue() {
+        let defaults = makeDefaults("test.automaticInstall.override")
+
+        AutomaticInstallPreference.setValue(false, in: defaults)
+
+        XCTAssertFalse(AutomaticInstallPreference.value(in: defaults, fallback: true))
+    }
+
+    func testWritingPersistsUnderSparklesOwnKey() {
+        let defaults = makeDefaults("test.automaticInstall.persist")
+
+        AutomaticInstallPreference.setValue(true, in: defaults)
+
+        XCTAssertTrue(AutomaticInstallPreference.value(in: defaults, fallback: nil))
+        XCTAssertEqual(defaults.object(forKey: "SUAutomaticallyUpdate") as? Bool, true)
+    }
+}
+
 @MainActor
 final class UpdateManagerTests: XCTestCase {
     func testInitReadsCurrentUpdaterState() {
         let updater = FakeSoftwareUpdater()
         updater.canCheckForUpdates = false
-        updater.automaticallyDownloadsUpdates = true
+        updater.storedAutomaticallyDownloadsUpdates = true
 
         let manager = UpdateManager(updater: updater)
 
@@ -130,33 +170,58 @@ final class UpdateManagerTests: XCTestCase {
         XCTAssertEqual(updater.updateCheckInterval, UpdateCheckFrequency.weekly.timeInterval)
     }
 
-    func testAutomaticInstallIsConfigurableWhenSparkleAllowsIt() {
+    func testDisablingAutomaticChecksLeavesTheAutomaticInstallToggleOn() {
         let updater = FakeSoftwareUpdater()
-        updater.allowsAutomaticUpdates = true
-
-        let manager = UpdateManager(updater: updater)
-
-        XCTAssertTrue(manager.canConfigureAutomaticInstall)
-    }
-
-    func testAutomaticInstallIsNotConfigurableWhenSparkleDisallowsIt() {
-        let updater = FakeSoftwareUpdater()
-        updater.allowsAutomaticUpdates = false
-
-        let manager = UpdateManager(updater: updater)
-
-        XCTAssertFalse(manager.canConfigureAutomaticInstall)
-    }
-
-    func testDisablingAutomaticChecksKeepsTheAutomaticInstallPreference() {
-        let updater = FakeSoftwareUpdater()
-        updater.automaticallyDownloadsUpdates = true
+        updater.storedAutomaticallyDownloadsUpdates = true
         let manager = UpdateManager(updater: updater)
 
         manager.automaticallyChecksForUpdates = false
 
-        XCTAssertTrue(updater.automaticallyDownloadsUpdates)
         XCTAssertTrue(manager.automaticallyDownloadsUpdates)
+        XCTAssertTrue(updater.storedAutomaticallyDownloadsUpdates)
+    }
+
+    func testDisablingAutomaticChecksNeverWritesTheAutomaticInstallPreference() {
+        let updater = FakeSoftwareUpdater()
+        updater.storedAutomaticallyDownloadsUpdates = true
+        let manager = UpdateManager(updater: updater)
+        let writes = updater.automaticallyDownloadsUpdatesWriteCount
+
+        manager.automaticallyChecksForUpdates = false
+
+        XCTAssertEqual(updater.automaticallyDownloadsUpdatesWriteCount, writes)
+    }
+
+    func testAutomaticInstallCanStillBeChangedWhileAutomaticChecksAreOff() {
+        let updater = FakeSoftwareUpdater()
+        updater.automaticallyChecksForUpdates = false
+        let manager = UpdateManager(updater: updater)
+
+        manager.automaticallyDownloadsUpdates = true
+
+        XCTAssertTrue(updater.storedAutomaticallyDownloadsUpdates)
+    }
+
+    func testInitReadsTheStoredAutomaticInstallPreferenceWhileChecksAreOff() {
+        let updater = FakeSoftwareUpdater()
+        updater.automaticallyChecksForUpdates = false
+        updater.storedAutomaticallyDownloadsUpdates = true
+
+        let manager = UpdateManager(updater: updater)
+
+        XCTAssertTrue(manager.automaticallyDownloadsUpdates)
+    }
+
+    func testEnablingAutomaticChecksLeavesTheAutomaticInstallToggleOff() {
+        let updater = FakeSoftwareUpdater()
+        updater.automaticallyChecksForUpdates = false
+        updater.storedAutomaticallyDownloadsUpdates = false
+        let manager = UpdateManager(updater: updater)
+
+        manager.automaticallyChecksForUpdates = true
+
+        XCTAssertFalse(manager.automaticallyDownloadsUpdates)
+        XCTAssertFalse(updater.storedAutomaticallyDownloadsUpdates)
     }
 
     func testManualCheckStillRunsWhileAutomaticChecksAreOff() {
@@ -178,6 +243,86 @@ final class UpdateManagerTests: XCTestCase {
         manager.checkForUpdates()
 
         XCTAssertEqual(updater.checkForUpdateInformationCount, 0)
+        XCTAssertNil(manager.status)
+    }
+
+    // MARK: Manual check with automatic checks off
+
+    func testManualCheckWithAutomaticChecksOffAndAutomaticInstallOnTouchesNoPreference() {
+        let updater = FakeSoftwareUpdater()
+        updater.automaticallyChecksForUpdates = false
+        updater.storedAutomaticallyDownloadsUpdates = true
+        let manager = UpdateManager(updater: updater)
+        let checkWrites = updater.automaticallyChecksForUpdatesWriteCount
+        let installWrites = updater.automaticallyDownloadsUpdatesWriteCount
+
+        manager.checkForUpdates()
+
+        XCTAssertEqual(updater.checkForUpdateInformationCount, 1)
+        XCTAssertEqual(updater.automaticallyChecksForUpdatesWriteCount, checkWrites)
+        XCTAssertEqual(updater.automaticallyDownloadsUpdatesWriteCount, installWrites)
+        XCTAssertFalse(manager.automaticallyChecksForUpdates)
+        XCTAssertTrue(manager.automaticallyDownloadsUpdates)
+    }
+
+    func testManualProbeThatFindsAnUpdateEscalatesToTheInteractiveFlow() {
+        let updater = FakeSoftwareUpdater()
+        updater.automaticallyChecksForUpdates = false
+        updater.storedAutomaticallyDownloadsUpdates = true
+        let manager = UpdateManager(updater: updater)
+
+        manager.checkForUpdates()
+        manager.handleProbeFoundUpdate()
+        manager.handleProbeFinished(error: nil)
+
+        XCTAssertEqual(updater.checkForUpdatesCount, 1)
+        XCTAssertNil(manager.status)
+    }
+
+    func testEscalatingAManualCheckLeavesBothPreferencesAlone() {
+        let updater = FakeSoftwareUpdater()
+        updater.automaticallyChecksForUpdates = false
+        updater.storedAutomaticallyDownloadsUpdates = true
+        let manager = UpdateManager(updater: updater)
+
+        manager.checkForUpdates()
+        manager.handleProbeFoundUpdate()
+        manager.handleProbeFinished(error: nil)
+
+        XCTAssertFalse(updater.automaticallyChecksForUpdates)
+        XCTAssertTrue(updater.storedAutomaticallyDownloadsUpdates)
+    }
+
+    func testManualProbeThatFindsNothingDoesNotEscalate() {
+        let updater = FakeSoftwareUpdater()
+        let manager = UpdateManager(updater: updater)
+
+        manager.checkForUpdates()
+        manager.handleProbeFinished(error: nil)
+
+        XCTAssertEqual(updater.checkForUpdatesCount, 0)
+    }
+
+    func testFailedManualProbeDoesNotEscalate() {
+        let updater = FakeSoftwareUpdater()
+        let manager = UpdateManager(updater: updater)
+        let failure = NSError(domain: "test.appcast", code: 42)
+
+        manager.checkForUpdates()
+        manager.handleProbeFoundUpdate()
+        manager.handleProbeFinished(error: failure)
+
+        XCTAssertEqual(updater.checkForUpdatesCount, 0)
+    }
+
+    func testProbeCallbacksArrivingOutsideAManualCheckAreIgnored() {
+        let updater = FakeSoftwareUpdater()
+        let manager = UpdateManager(updater: updater)
+
+        manager.handleProbeFoundUpdate()
+        manager.handleProbeFinished(error: nil)
+
+        XCTAssertEqual(updater.checkForUpdatesCount, 0)
         XCTAssertNil(manager.status)
     }
 

--- a/App/Tests/UpdateManagerTests.swift
+++ b/App/Tests/UpdateManagerTests.swift
@@ -30,6 +30,25 @@ final class FakeSoftwareUpdater: SoftwareUpdating {
     }
 }
 
+/// The values Sparkle starts from before the user picks anything, which live in
+/// the app's Info.plist rather than in code.
+final class ShippedUpdateDefaultsTests: XCTestCase {
+    func testAutomaticChecksAreOnByDefault() {
+        XCTAssertEqual(Bundle.main.object(forInfoDictionaryKey: "SUEnableAutomaticChecks") as? Bool, true)
+    }
+
+    func testAutomaticInstallIsOffByDefault() {
+        XCTAssertNil(Bundle.main.object(forInfoDictionaryKey: AutomaticInstallPreference.key))
+    }
+
+    func testDefaultCheckFrequencyIsWeekly() {
+        let interval = Bundle.main.object(forInfoDictionaryKey: "SUScheduledCheckInterval") as? TimeInterval
+
+        XCTAssertEqual(interval, UpdateCheckFrequency.weekly.timeInterval)
+        XCTAssertEqual(UpdateCheckFrequency(closestTo: interval ?? 0), .weekly)
+    }
+}
+
 /// Sparkle drops `setAutomaticallyDownloadsUpdates:` while automatic checks are
 /// off, so Capso persists the preference by writing Sparkle's own key. These
 /// cover that storage directly, since no stand-in updater can catch it.

--- a/App/Tests/UpdateManagerTests.swift
+++ b/App/Tests/UpdateManagerTests.swift
@@ -1,0 +1,194 @@
+import XCTest
+@testable import Capso
+import SharedKit
+
+/// Stand-in for Sparkle's `SPUUpdater` so `UpdateManager` can be exercised
+/// without starting a real updater inside the test host.
+@MainActor
+final class FakeSoftwareUpdater: SoftwareUpdating {
+    var canCheckForUpdates = true
+    var allowsAutomaticUpdates = true
+    var updateCheckInterval: TimeInterval = 86_400
+    var checkForUpdateInformationCount = 0
+    var checkForUpdatesCount = 0
+
+    var automaticallyChecksForUpdates = true {
+        didSet { automaticallyChecksForUpdatesWriteCount += 1 }
+    }
+    private(set) var automaticallyChecksForUpdatesWriteCount = 0
+
+    var automaticallyDownloadsUpdates = false {
+        didSet { automaticallyDownloadsUpdatesWriteCount += 1 }
+    }
+    private(set) var automaticallyDownloadsUpdatesWriteCount = 0
+
+    func checkForUpdateInformation() {
+        checkForUpdateInformationCount += 1
+    }
+
+    func checkForUpdates() {
+        checkForUpdatesCount += 1
+    }
+}
+
+@MainActor
+final class UpdateManagerTests: XCTestCase {
+    func testInitReadsCurrentUpdaterState() {
+        let updater = FakeSoftwareUpdater()
+        updater.canCheckForUpdates = false
+        updater.automaticallyDownloadsUpdates = true
+
+        let manager = UpdateManager(updater: updater)
+
+        XCTAssertFalse(manager.canCheckForUpdates)
+        XCTAssertTrue(manager.automaticallyDownloadsUpdates)
+    }
+
+    func testInitReadsAutomaticCheckSetting() {
+        let updater = FakeSoftwareUpdater()
+        updater.automaticallyChecksForUpdates = false
+
+        let manager = UpdateManager(updater: updater)
+
+        XCTAssertFalse(manager.automaticallyChecksForUpdates)
+    }
+
+    func testDisablingAutomaticChecksWritesThroughToTheUpdater() {
+        let updater = FakeSoftwareUpdater()
+        let manager = UpdateManager(updater: updater)
+
+        manager.automaticallyChecksForUpdates = false
+
+        XCTAssertFalse(updater.automaticallyChecksForUpdates)
+    }
+
+    func testEnablingAutomaticChecksWritesThroughToTheUpdater() {
+        let updater = FakeSoftwareUpdater()
+        updater.automaticallyChecksForUpdates = false
+        let manager = UpdateManager(updater: updater)
+
+        manager.automaticallyChecksForUpdates = true
+
+        XCTAssertTrue(updater.automaticallyChecksForUpdates)
+    }
+
+    func testSettingTheSameAutomaticCheckValueDoesNotRewrite() {
+        let updater = FakeSoftwareUpdater()
+        let manager = UpdateManager(updater: updater)
+        let writes = updater.automaticallyChecksForUpdatesWriteCount
+
+        manager.automaticallyChecksForUpdates = true
+
+        XCTAssertEqual(updater.automaticallyChecksForUpdatesWriteCount, writes)
+    }
+
+    func testInitDerivesFrequencyFromTheUpdaterInterval() {
+        let updater = FakeSoftwareUpdater()
+        updater.updateCheckInterval = UpdateCheckFrequency.weekly.timeInterval
+
+        let manager = UpdateManager(updater: updater)
+
+        XCTAssertEqual(manager.updateCheckFrequency, .weekly)
+    }
+
+    func testInitSnapsAnUnknownIntervalToTheClosestFrequency() {
+        let updater = FakeSoftwareUpdater()
+        updater.updateCheckInterval = 3_600
+
+        let manager = UpdateManager(updater: updater)
+
+        XCTAssertEqual(manager.updateCheckFrequency, .daily)
+    }
+
+    func testChangingFrequencyWritesTheIntervalToTheUpdater() {
+        let updater = FakeSoftwareUpdater()
+        let manager = UpdateManager(updater: updater)
+
+        manager.updateCheckFrequency = .monthly
+
+        XCTAssertEqual(updater.updateCheckInterval, UpdateCheckFrequency.monthly.timeInterval)
+    }
+
+    func testChangingFrequencyLeavesTheAutomaticCheckSettingAlone() {
+        let updater = FakeSoftwareUpdater()
+        let manager = UpdateManager(updater: updater)
+        let writes = updater.automaticallyChecksForUpdatesWriteCount
+
+        manager.updateCheckFrequency = .weekly
+
+        XCTAssertTrue(updater.automaticallyChecksForUpdates)
+        XCTAssertEqual(updater.automaticallyChecksForUpdatesWriteCount, writes)
+    }
+
+    func testFrequencyStillPersistsWhileAutomaticChecksAreOff() {
+        let updater = FakeSoftwareUpdater()
+        updater.automaticallyChecksForUpdates = false
+        let manager = UpdateManager(updater: updater)
+
+        manager.updateCheckFrequency = .weekly
+
+        XCTAssertEqual(updater.updateCheckInterval, UpdateCheckFrequency.weekly.timeInterval)
+    }
+
+    func testAutomaticInstallIsConfigurableWhenSparkleAllowsIt() {
+        let updater = FakeSoftwareUpdater()
+        updater.allowsAutomaticUpdates = true
+
+        let manager = UpdateManager(updater: updater)
+
+        XCTAssertTrue(manager.canConfigureAutomaticInstall)
+    }
+
+    func testAutomaticInstallIsNotConfigurableWhenSparkleDisallowsIt() {
+        let updater = FakeSoftwareUpdater()
+        updater.allowsAutomaticUpdates = false
+
+        let manager = UpdateManager(updater: updater)
+
+        XCTAssertFalse(manager.canConfigureAutomaticInstall)
+    }
+
+    func testDisablingAutomaticChecksKeepsTheAutomaticInstallPreference() {
+        let updater = FakeSoftwareUpdater()
+        updater.automaticallyDownloadsUpdates = true
+        let manager = UpdateManager(updater: updater)
+
+        manager.automaticallyChecksForUpdates = false
+
+        XCTAssertTrue(updater.automaticallyDownloadsUpdates)
+        XCTAssertTrue(manager.automaticallyDownloadsUpdates)
+    }
+
+    func testManualCheckStillRunsWhileAutomaticChecksAreOff() {
+        let updater = FakeSoftwareUpdater()
+        updater.automaticallyChecksForUpdates = false
+        let manager = UpdateManager(updater: updater)
+
+        manager.checkForUpdates()
+
+        XCTAssertEqual(updater.checkForUpdateInformationCount, 1)
+        XCTAssertEqual(manager.status?.kind, .checking)
+    }
+
+    func testManualCheckIsIgnoredWhenTheUpdaterCannotCheck() {
+        let updater = FakeSoftwareUpdater()
+        updater.canCheckForUpdates = false
+        let manager = UpdateManager(updater: updater)
+
+        manager.checkForUpdates()
+
+        XCTAssertEqual(updater.checkForUpdateInformationCount, 0)
+        XCTAssertNil(manager.status)
+    }
+
+    func testInitDoesNotWriteBackToTheUpdater() {
+        let updater = FakeSoftwareUpdater()
+        let checksWrites = updater.automaticallyChecksForUpdatesWriteCount
+        let downloadsWrites = updater.automaticallyDownloadsUpdatesWriteCount
+
+        _ = UpdateManager(updater: updater)
+
+        XCTAssertEqual(updater.automaticallyChecksForUpdatesWriteCount, checksWrites)
+        XCTAssertEqual(updater.automaticallyDownloadsUpdatesWriteCount, downloadsWrites)
+    }
+}

--- a/Packages/SharedKit/Sources/SharedKit/Settings/UpdateCheckFrequency.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/UpdateCheckFrequency.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// How often the app checks for updates in the background.
+///
+/// The selected interval is stored by Sparkle itself (`SPUUpdater.updateCheckInterval`,
+/// persisted as `SUScheduledCheckInterval`), so this type only maps between the
+/// user-facing choices and the raw interval Sparkle expects.
+public enum UpdateCheckFrequency: String, CaseIterable, Sendable {
+    case daily
+    case weekly
+    case monthly
+
+    /// The background check interval, in seconds.
+    public var timeInterval: TimeInterval {
+        switch self {
+        case .daily: return 86_400
+        case .weekly: return 604_800
+        case .monthly: return 2_592_000
+        }
+    }
+
+    /// The frequency whose interval sits closest to `interval`.
+    ///
+    /// Sparkle stores an arbitrary `TimeInterval`, which may have been written by an
+    /// older build or by the Info.plist default, so an exact match is not guaranteed.
+    /// Non-positive intervals resolve to `.daily`.
+    public init(closestTo interval: TimeInterval) {
+        guard interval > 0 else {
+            self = .daily
+            return
+        }
+
+        self = Self.allCases.min { lhs, rhs in
+            abs(lhs.timeInterval - interval) < abs(rhs.timeInterval - interval)
+        } ?? .daily
+    }
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/UpdateCheckFrequencyTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/UpdateCheckFrequencyTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import SharedKit
+
+@Suite("UpdateCheckFrequency")
+struct UpdateCheckFrequencyTests {
+    @Test("Cases are ordered from most to least frequent")
+    func caseOrder() {
+        #expect(UpdateCheckFrequency.allCases == [.daily, .weekly, .monthly])
+    }
+
+    @Test("Raw values are stable identifiers")
+    func rawValues() {
+        #expect(UpdateCheckFrequency.daily.rawValue == "daily")
+        #expect(UpdateCheckFrequency.weekly.rawValue == "weekly")
+        #expect(UpdateCheckFrequency.monthly.rawValue == "monthly")
+    }
+
+    @Test("Each frequency maps to its Sparkle check interval")
+    func timeIntervals() {
+        #expect(UpdateCheckFrequency.daily.timeInterval == 86_400)
+        #expect(UpdateCheckFrequency.weekly.timeInterval == 604_800)
+        #expect(UpdateCheckFrequency.monthly.timeInterval == 2_592_000)
+    }
+
+    @Test("Exact intervals round-trip")
+    func exactIntervalsRoundTrip() {
+        for frequency in UpdateCheckFrequency.allCases {
+            #expect(UpdateCheckFrequency(closestTo: frequency.timeInterval) == frequency)
+        }
+    }
+
+    @Test("Unknown intervals snap to the closest frequency")
+    func unknownIntervalsSnap() {
+        #expect(UpdateCheckFrequency(closestTo: 3_600) == .daily)
+        #expect(UpdateCheckFrequency(closestTo: 200_000) == .daily)
+        #expect(UpdateCheckFrequency(closestTo: 500_000) == .weekly)
+        #expect(UpdateCheckFrequency(closestTo: 1_500_000) == .weekly)
+        #expect(UpdateCheckFrequency(closestTo: 2_000_000) == .monthly)
+        #expect(UpdateCheckFrequency(closestTo: 10_000_000) == .monthly)
+    }
+
+    @Test("Non-positive intervals fall back to daily")
+    func nonPositiveIntervalsFallBackToDaily() {
+        #expect(UpdateCheckFrequency(closestTo: 0) == .daily)
+        #expect(UpdateCheckFrequency(closestTo: -1) == .daily)
+    }
+}


### PR DESCRIPTION
Closes #219

Adds a way to turn off the daily update check, plus a frequency picker for people who want the check but not every day.

### What's new in Preferences > General

* **Automatically Check for Updates** switch
* **Check Frequency** picker: Daily, Weekly, Monthly
* Both the frequency picker and **Automatically Install Updates** grey out while checks are off, since neither can do anything without a scheduled check

<img width="1602" height="1258" alt="Capso Screenshot - Capso 2026-07-26 at 18 09 12" src="https://github.com/user-attachments/assets/a9684e30-3704-462f-a4cb-7d3878383884" />

<img width="1602" height="1258" alt="image" src="https://github.com/user-attachments/assets/030bae0f-f66e-4846-97b6-7ad6f5af0907" />

### Greying the install row doesn't cost you the setting

Switching checks off greys out "Automatically Install Updates" but leaves the stored preference exactly where you left it, so switching checks back on restores what you had.

That needed a workaround. Sparkle gates both accessors for the install preference on `allowsAutomaticUpdates`, which just follows `automaticallyChecksForUpdates`:

* the getter reports `false` while background checks are off
* `SPUUpdaterSettings.setAutomaticallyDownloadsUpdates:` drops the write entirely

So going through `SPUUpdater` meant the install switch flipped itself off when you switched checks off, and the KVO handler wrote that masked `false` straight back, wiping the real preference. Capso now reads and writes `SUAutomaticallyUpdate` directly. Sparkle observes that key, so it stays in sync.

A manual check still works with automatic checks off. Sparkle routes user-initiated checks through `SPUUserInitiatedUpdateDriver`, which never consults the install preference, so a found update is always presented rather than installed silently.

### Notes

Sparkle already persists all of this in user defaults and its header says not to keep a second copy, so there are no new `AppSettings` keys. Info.plist still supplies the starting values, unchanged: checks on, install off, daily interval. I did try defaulting to weekly, but existing installs have nothing stored for the interval and read straight from the plist, so it would have moved everyone who upgrades rather than just new installs. Weekly is two clicks away for anyone who wants it.

The Updates section stays where it was, after Sound.

### Tests

Built test first, 37 new tests.

* `UpdateCheckFrequency`, a new pure enum in SharedKit, maps picker choices to Sparkle intervals and snaps unknown values to the closest one (6 tests)
* `UpdateManager` talks to a small `SoftwareUpdating` protocol, so it runs against a stand-in instead of a live Sparkle updater (24 tests): write-through, no writes during init, the install preference surviving a checks toggle in both directions, frequency persisting while checks are off, and the manual check escalating to the interactive flow without touching either preference
* The manual-probe outcomes moved out of the `SPUUpdaterDelegate` callbacks, whose signatures need a live `SPUUpdater`, which is what makes that last group testable
* `AutomaticInstallPreference` storage is covered directly against a scratch defaults suite, since no stand-in updater can catch Sparkle silently dropping a write
* The shipped Info.plist defaults are pinned by tests so they can't drift unnoticed

`swift test --package-path Packages/SharedKit` (174 tests) and `xcodebuild test -scheme Capso` (109 tests) both pass.

New strings are localized for ja, ko, and zh-Hans.
