### PR TITLE
feat: make automatic update checks optional

### DIFF
--- a/App/Sources/Preferences/Components/CheckForUpdatesView.swift
+++ b/App/Sources/Preferences/Components/CheckForUpdatesView.swift
@@ -18,6 +18,13 @@ final class UpdateManager: NSObject, ObservableObject {
 
     @Published private(set) var canCheckForUpdates = false
     @Published private(set) var status: Status?
+    @Published var automaticallyChecksForUpdates: Bool = true {
+        didSet {
+            guard oldValue != automaticallyChecksForUpdates else { return }
+            updater.automaticallyChecksForUpdates = automaticallyChecksForUpdates
+        }
+    }
+
     @Published var automaticallyDownloadsUpdates: Bool = false {
         didSet {
             guard oldValue != automaticallyDownloadsUpdates else { return }
@@ -33,6 +40,7 @@ final class UpdateManager: NSObject, ObservableObject {
     private var manualCheckState: ManualCheckState = .none
     private var probeFoundValidUpdate = false
     private var canCheckObservation: NSKeyValueObservation?
+    private var autoCheckObservation: NSKeyValueObservation?
     private var autoDownloadObservation: NSKeyValueObservation?
     private var clearStatusTask: Task<Void, Never>?
 
@@ -46,10 +54,16 @@ final class UpdateManager: NSObject, ObservableObject {
 
     override init() {
         super.init()
+        automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
         automaticallyDownloadsUpdates = updater.automaticallyDownloadsUpdates
         canCheckObservation = updater.observe(\.canCheckForUpdates, options: [.initial, .new]) { [weak self] updater, _ in
             Task { @MainActor in
                 self?.canCheckForUpdates = updater.canCheckForUpdates
+            }
+        }
+        autoCheckObservation = updater.observe(\.automaticallyChecksForUpdates, options: [.new]) { [weak self] updater, _ in
+            Task { @MainActor in
+                self?.automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
             }
         }
         autoDownloadObservation = updater.observe(\.automaticallyDownloadsUpdates, options: [.new]) { [weak self] updater, _ in

--- a/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
@@ -79,6 +79,14 @@ struct GeneralSettingsView: View {
             if let updateManager {
                 SettingGroup(title: "Updates") {
                     SettingCard {
+                        SettingRow(label: "Automatically Check for Updates", sublabel: "Check for new versions in the background daily") {
+                            Toggle("", isOn: Binding(
+                                get: { updateManager.automaticallyChecksForUpdates },
+                                set: { updateManager.automaticallyChecksForUpdates = $0 }
+                            ))
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                        }
                         SettingRow(label: "Automatically Install Updates", sublabel: "Install updates in the background when available") {
                             Toggle("", isOn: Binding(
                                 get: { updateManager.automaticallyDownloadsUpdates },
@@ -86,8 +94,9 @@ struct GeneralSettingsView: View {
                             ))
                             .toggleStyle(.switch)
                             .controlSize(.small)
+                            .disabled(!updateManager.automaticallyChecksForUpdates)
                         }
-                        SettingRow(label: "Check for Updates", sublabel: "Automatically checks daily", showDivider: true) {
+                        SettingRow(label: "Check for Updates", sublabel: "Manually check for a new version", showDivider: true) {
                             CheckForUpdatesView(updateManager: updateManager)
                         }
                     }


### PR DESCRIPTION
## Summary

Adds an **"Automatically Check for Updates"** toggle in Settings → General → Updates, so users can disable Sparkle's scheduled daily update checks (`SUEnableAutomaticChecks` was previously hardcoded to `true` in Info.plist with no way to opt out).

- New toggle binds to `SPUUpdater.automaticallyChecksForUpdates` (Sparkle persists it to UserDefaults; Info.plist default stays `true`, so behavior is unchanged for existing users)
- "Automatically Install Updates" is greyed out when automatic checks are off, since background downloads only trigger after scheduled checks
- Manual "Check for Updates" button remains fully functional when automatic checks are disabled
- Updated the manual-check row sublabel ("Automatically checks daily" → "Manually check for a new version") to avoid implying checks are always on

Closes #219

## Test plan

- [x] `xcodebuild -scheme Capso -configuration Debug build` succeeds
- [ ] Toggle off → relaunch → verify no scheduled check fires and manual check still works
- [ ] Toggle state persists across launches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized preferences and Sparkle binding changes; default behavior remains automatic checks via Info.plist.
> 
> **Overview**
> Users can now **turn off daily background update checks** from Settings → General → Updates via a new **"Automatically Check for Updates"** toggle, wired through `UpdateManager` to Sparkle’s `SPUUpdater.automaticallyChecksForUpdates` (with KVO so UI stays in sync when Sparkle changes the value).
> 
> **"Automatically Install Updates"** is disabled when automatic checks are off, since background installs depend on scheduled checks. The manual **Check for Updates** row copy is updated to describe on-demand checks instead of implying daily automatic checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf8f796c91c00dd4c4ee94e1780f61ddb435204d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->