### PR TITLE
feat: add capso://grab/all-in-one automation URL

### DIFF
--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -247,6 +247,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             captureCoordinator.captureFullscreen()
         case .captureWindow:
             captureCoordinator.captureWindow()
+        case .captureAllInOne:
+            captureCoordinator.captureAllInOne()
         }
         logAutomationURL("Performed action \(String(describing: action))")
     }

--- a/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/GeneralSettingsView.swift
@@ -58,6 +58,7 @@ struct GeneralSettingsView: View {
                             Text(verbatim: "capso://grab/area")
                             Text(verbatim: "capso://grab/fullscreen")
                             Text(verbatim: "capso://grab/window")
+                            Text(verbatim: "capso://grab/all-in-one")
                         }
                         .font(.system(size: 11, design: .monospaced))
                         .foregroundStyle(.secondary)

--- a/Packages/SharedKit/Sources/SharedKit/AutomationURLAction.swift
+++ b/Packages/SharedKit/Sources/SharedKit/AutomationURLAction.swift
@@ -4,6 +4,7 @@ public enum AutomationURLAction: Equatable, Sendable {
     case captureArea
     case captureFullscreen
     case captureWindow
+    case captureAllInOne
 
     public init?(url: URL) {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
@@ -21,6 +22,7 @@ public enum AutomationURLAction: Equatable, Sendable {
         case "/area": self = .captureArea
         case "/fullscreen": self = .captureFullscreen
         case "/window": self = .captureWindow
+        case "/all-in-one": self = .captureAllInOne
         default: return nil
         }
     }

--- a/Packages/SharedKit/Tests/SharedKitTests/AutomationURLActionTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AutomationURLActionTests.swift
@@ -10,6 +10,7 @@ struct AutomationURLActionTests {
             ("capso://grab/area", .captureArea),
             ("capso://grab/fullscreen", .captureFullscreen),
             ("capso://grab/window", .captureWindow),
+            ("capso://grab/all-in-one", .captureAllInOne),
             ("CAPSO://GRAB/area", .captureArea),
         ]
 


### PR DESCRIPTION
## What changed

Adds `capso://grab/all-in-one` to the automation URL scheme, routing it to the existing `CaptureCoordinator.captureAllInOne()` — the same action already available via global hotkey and the menu bar.

Previously only `area`, `fullscreen`, and `window` were exposed to the automation URL scheme (added in #186), so external launchers (Raycast, Alfred, Shortcuts) had no way to start an **All-in-One** capture. This closes that gap with a one-line route and a documented URL.

- Add `captureAllInOne` case to `AutomationURLAction` and parse `/all-in-one`
- Dispatch the action in `AppDelegate.performPendingAutomationURLAction()`
- Document the URL in the Automation settings list (Settings → General)
- Cover the new path in `AutomationURLActionTests`

## Related issue

None.

## Screenshots / recordings

No behavioral UI change beyond the Settings → Automation "Supported URLs" list gaining one more row (`capso://grab/all-in-one`).

## Checklist

- [x] `xcodegen generate` not needed — no source files added/removed, `project.yml` untouched
- [x] `SharedKit` library builds; new parser test case added. Full `xcodebuild` / swift-testing run left to CI (no full Xcode in my dev env, only Command Line Tools)
- [x] No new `TODO` / `FIXME` / debug prints
- [x] Follows Swift 6 strict concurrency (pure `Sendable` value type + existing `@MainActor` dispatch context)
- [x] I agree that my contribution is licensed under BSL 1.1 per CONTRIBUTING.md