### PR TITLE
fix: stream S3/R2 uploads to stop Capso quitting after recording

### DIFF
--- a/Packages/ShareKit/Package.swift
+++ b/Packages/ShareKit/Package.swift
@@ -9,14 +9,12 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../SharedKit"),
-        .package(url: "https://github.com/soto-project/soto.git", exact: "7.14.0"),
     ],
     targets: [
         .target(
             name: "ShareKit",
             dependencies: [
                 "SharedKit",
-                .product(name: "SotoS3", package: "soto"),
             ]
         ),
         .testTarget(

--- a/Packages/ShareKit/Sources/ShareKit/R2Destination.swift
+++ b/Packages/ShareKit/Sources/ShareKit/R2Destination.swift
@@ -1,7 +1,4 @@
-// Packages/ShareKit/Sources/ShareKit/R2Destination.swift
-
 import Foundation
-import SotoS3
 
 public actor R2Destination: ShareDestination {
     private let config: ShareConfig
@@ -14,77 +11,38 @@ public actor R2Destination: ShareDestination {
         self.secretKey = secretKey
     }
 
-    private func makeClient() -> AWSClient {
-        AWSClient(
-            credentialProvider: .static(accessKeyId: accessKey, secretAccessKey: secretKey)
-        )
-    }
-
-    private func makeS3(_ client: AWSClient) -> S3 {
-        S3(
-            client: client,
-            region: .useast1,  // R2 ignores region; placeholder required
-            endpoint: "https://\(config.accountID).r2.cloudflarestorage.com"
-        )
-    }
-
-    /// Run `body` with a fresh AWSClient + S3, awaiting client.shutdown()
-    /// before returning. Awaited shutdown avoids the AWSClient.deinit assertion
-    /// that fires when a deferred Task runs after the client goes out of scope.
-    private func withClient<T: Sendable>(_ body: @Sendable (S3) async throws -> T) async throws -> T {
-        let client = makeClient()
-        let s3 = makeS3(client)
-        do {
-            let result = try await body(s3)
-            try? await client.shutdown()
-            return result
-        } catch {
-            try? await client.shutdown()
-            throw error
-        }
-    }
-
     public func upload(file: URL, key: String, contentType: String) async throws -> URL {
         let objectKey = config.objectKey(for: key)
-        // TODO(v2): stream large files via AWSPayload.stream — current path loads the
-        // entire file into memory, which is fine for screenshots (~500KB) but pins
-        // RAM proportional to file size for screen recordings (10MB–1GB+).
-        let data = try Data(contentsOf: file)
-
-        return try await withClient { s3 in
-            do {
-                _ = try await s3.putObject(.init(
-                    body: .init(bytes: data),
-                    bucket: self.config.bucket,
-                    contentType: contentType,
-                    key: objectKey
-                ))
-            } catch let error as S3ErrorType {
-                throw self.map(error)
-            } catch let error as AWSResponseError {
-                throw self.mapResponse(error)
-            } catch {
-                throw ShareError.network(underlying: error.localizedDescription)
-            }
-
-            // The public URL is constructed from the user-configured prefix, not from S3 response.
-            return self.config.publicURL(forObjectKey: objectKey)
-        }
+        let target = S3CompatibleHTTP.r2Target(
+            accountID: config.accountID,
+            bucket: config.bucket,
+            objectKey: objectKey
+        )
+        // R2 ignores region for routing; SigV4 still requires a region string.
+        try await S3CompatibleHTTP.putObject(
+            file: file,
+            target: target,
+            region: "auto",
+            accessKeyId: accessKey,
+            secretAccessKey: secretKey,
+            contentType: contentType
+        )
+        return config.publicURL(forObjectKey: objectKey)
     }
 
     public func delete(key: String) async throws {
         let objectKey = config.objectKey(for: key)
-        try await withClient { s3 in
-            do {
-                _ = try await s3.deleteObject(.init(bucket: self.config.bucket, key: objectKey))
-            } catch let error as S3ErrorType {
-                throw self.map(error)
-            } catch let error as AWSResponseError {
-                throw self.mapResponse(error)
-            } catch {
-                throw ShareError.network(underlying: error.localizedDescription)
-            }
-        }
+        let target = S3CompatibleHTTP.r2Target(
+            accountID: config.accountID,
+            bucket: config.bucket,
+            objectKey: objectKey
+        )
+        try await S3CompatibleHTTP.deleteObject(
+            target: target,
+            region: "auto",
+            accessKeyId: accessKey,
+            secretAccessKey: secretKey
+        )
     }
 
     public func validateConfig() async throws {
@@ -110,27 +68,5 @@ public actor R2Destination: ShareDestination {
         }
 
         try await delete(key: testKey)
-    }
-
-    // MARK: - Error mapping
-
-    nonisolated private func map(_ error: S3ErrorType) -> ShareError {
-        // S3ErrorType only covers S3-specific typed errors (bucket/key not found, etc.)
-        .unknown("\(error.errorCode): \(error.message ?? "")")
-    }
-
-    nonisolated private func mapResponse(_ error: AWSResponseError) -> ShareError {
-        // Auth and quota errors arrive as untyped AWSResponseError from R2/S3.
-        let code = error.errorCode
-        switch code {
-        case "InvalidAccessKeyId", "SignatureDoesNotMatch", "AccessDenied":
-            return .invalidCredentials
-        case "QuotaExceeded", "EntityTooLarge":
-            return .quotaExceeded
-        case "NoSuchBucket":
-            return .unknown("Bucket not found — verify the bucket name in Cloud Share settings")
-        default:
-            return .unknown("\(code): \(error.message ?? "")")
-        }
     }
 }

--- a/Packages/ShareKit/Sources/ShareKit/S3CompatibleHTTP.swift
+++ b/Packages/ShareKit/Sources/ShareKit/S3CompatibleHTTP.swift
@@ -1,43 +1,51 @@
 import CryptoKit
 import Foundation
 
-/// S3 / R2 transport ported from the working capcap uploader:
-/// `AWSV4Signer` + `S3Common` + `R2Uploader` / `S3Uploader`.
+/// Shared SigV4 + URLSession transport for Amazon S3 and S3-compatible stores (R2).
 ///
-/// Wire format matches that stack:
+/// Wire format:
 /// - SigV4 with the real payload SHA-256 (not `UNSIGNED-PAYLOAD`)
 /// - signed headers: `content-type;host;x-amz-content-sha256;x-amz-date`
-/// - Amazon virtual-hosted vs custom path-style endpoints
+/// - Amazon virtual-hosted vs custom path-style endpoints (scheme preserved)
 /// - R2 path-style on `<accountId>.r2.cloudflarestorage.com` with region `auto`
 ///
-/// Capso only changes the body transport: hash the file in chunks, then
-/// `URLSession.upload(fromFile:)` so recordings are not held as one `Data`.
+/// Uploads hash the file in chunks, then use `URLSession.upload(fromFile:)` so
+/// recordings are not held as one `Data` buffer.
 enum S3CompatibleHTTP {
     static let emptyPayloadHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
-    struct Target: Sendable {
+    struct Target: Sendable, Equatable {
+        /// `http` or `https` — preserved from custom endpoints so LAN MinIO works.
+        let scheme: String
+        /// Host plus optional port only (no path).
         let host: String
         let canonicalURI: String
-    }
 
-    /// Mirrors capcap `S3Uploader` host / canonical URI selection.
-    static func amazonS3Target(bucket: String, objectKey: String, region: String, endpoint: String?) -> Target {
-        let encodedKey = encodePath(objectKey)
-        if let endpoint, let raw = nonEmpty(endpoint) {
-            // S3-compatible endpoint → path-style addressing (capcap `S3Common.stripScheme`).
-            let host = stripScheme(raw)
-            return Target(host: host, canonicalURI: "/\(bucket)/\(encodedKey)")
+        var requestURLString: String {
+            "\(scheme)://\(host)\(canonicalURI)"
         }
-        // Amazon S3 → virtual-hosted-style addressing.
-        let host = "\(bucket).s3.\(region).amazonaws.com"
-        return Target(host: host, canonicalURI: "/\(encodedKey)")
     }
 
-    /// Mirrors capcap `R2Uploader` host / canonical URI selection.
+    /// Amazon S3 virtual-hosted addressing, or path-style for a custom endpoint.
+    static func amazonS3Target(bucket: String, objectKey: String, region: String, endpoint: String?) -> Target {
+        let encodedKey = ShareConfig.encodeObjectKey(objectKey)
+        if let endpoint, let parsed = parseEndpoint(endpoint) {
+            let canonicalURI = "\(parsed.pathPrefix)/\(bucket)/\(encodedKey)"
+            return Target(scheme: parsed.scheme, host: parsed.host, canonicalURI: canonicalURI)
+        }
+        return Target(
+            scheme: "https",
+            host: "\(bucket).s3.\(region).amazonaws.com",
+            canonicalURI: "/\(encodedKey)"
+        )
+    }
+
+    /// Cloudflare R2 path-style addressing.
     static func r2Target(accountID: String, bucket: String, objectKey: String) -> Target {
-        let encodedKey = encodePath(objectKey)
+        let encodedKey = ShareConfig.encodeObjectKey(objectKey)
         let normalizedAccountID = normalizeAccountID(accountID)
         return Target(
+            scheme: "https",
             host: "\(normalizedAccountID).r2.cloudflarestorage.com",
             canonicalURI: "/\(bucket)/\(encodedKey)"
         )
@@ -51,10 +59,15 @@ enum S3CompatibleHTTP {
         secretAccessKey: String,
         contentType: String
     ) async throws {
-        let (payloadHash, contentLength) = try sha256File(file)
+        let (payloadHash, contentLength): (String, Int)
+        do {
+            (payloadHash, contentLength) = try sha256File(file)
+        } catch {
+            throw ShareError.unknown("Couldn't read file for upload: \(error.localizedDescription)")
+        }
+
         let request = try signedPutRequest(
-            host: target.host,
-            canonicalURI: target.canonicalURI,
+            target: target,
             region: region,
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -62,8 +75,15 @@ enum S3CompatibleHTTP {
             contentLength: contentLength,
             contentType: contentType
         )
-        let (body, response) = try await URLSession.shared.upload(for: request, fromFile: file)
-        try validate(response: response, body: body)
+
+        do {
+            let (body, response) = try await URLSession.shared.upload(for: request, fromFile: file)
+            try validate(response: response, body: body)
+        } catch let error as ShareError {
+            throw error
+        } catch {
+            throw ShareError.network(underlying: error.localizedDescription)
+        }
     }
 
     static func deleteObject(
@@ -73,20 +93,24 @@ enum S3CompatibleHTTP {
         secretAccessKey: String
     ) async throws {
         let request = try signedDeleteRequest(
-            host: target.host,
-            canonicalURI: target.canonicalURI,
+            target: target,
             region: region,
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey
         )
-        let (body, response) = try await URLSession.shared.data(for: request)
-        try validate(response: response, body: body)
+        do {
+            let (body, response) = try await URLSession.shared.data(for: request)
+            try validate(response: response, body: body)
+        } catch let error as ShareError {
+            throw error
+        } catch {
+            throw ShareError.network(underlying: error.localizedDescription)
+        }
     }
 
-    /// Empty-body DELETE SigV4 request (same empty payload hash as AWS docs).
+    /// Empty-body DELETE SigV4 request (AWS empty-payload hash).
     static func signedDeleteRequest(
-        host: String,
-        canonicalURI: String,
+        target: Target,
         region: String,
         accessKeyId: String,
         secretAccessKey: String,
@@ -94,8 +118,7 @@ enum S3CompatibleHTTP {
     ) throws -> URLRequest {
         try signedRequest(
             method: "DELETE",
-            host: host,
-            canonicalURI: canonicalURI,
+            target: target,
             region: region,
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -106,10 +129,8 @@ enum S3CompatibleHTTP {
         )
     }
 
-    /// capcap `AWSV4Signer.signedPutRequest` — same headers, same signature inputs.
     static func signedPutRequest(
-        host: String,
-        canonicalURI: String,
+        target: Target,
         region: String,
         accessKeyId: String,
         secretAccessKey: String,
@@ -120,8 +141,7 @@ enum S3CompatibleHTTP {
     ) throws -> URLRequest {
         var request = try signedRequest(
             method: "PUT",
-            host: host,
-            canonicalURI: canonicalURI,
+            target: target,
             region: region,
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -130,15 +150,13 @@ enum S3CompatibleHTTP {
             contentLength: contentLength,
             now: now
         )
-        // capcap sets Content-Length explicitly on the signed PUT.
         request.setValue("\(contentLength)", forHTTPHeaderField: "Content-Length")
         return request
     }
 
-    /// Deterministic helper for tests — same as hashing `payload` then calling `signedPutRequest`.
+    /// Convenience for tests — hash `payload` then sign.
     static func signedPutRequest(
-        host: String,
-        canonicalURI: String,
+        target: Target,
         region: String,
         accessKeyId: String,
         secretAccessKey: String,
@@ -147,8 +165,7 @@ enum S3CompatibleHTTP {
         now: Date = Date()
     ) throws -> URLRequest {
         try signedPutRequest(
-            host: host,
-            canonicalURI: canonicalURI,
+            target: target,
             region: region,
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
@@ -185,39 +202,72 @@ enum S3CompatibleHTTP {
         }
     }
 
-    // MARK: - Path / endpoint helpers (capcap)
+    // MARK: - Endpoint helpers
 
-    /// capcap `AWSV4Signer.encodePath`
-    static func encodePath(_ key: String) -> String {
-        key.split(separator: "/", omittingEmptySubsequences: false)
-            .map { String($0).sharePercentEncoded() }
-            .joined(separator: "/")
+    struct ParsedEndpoint: Equatable {
+        let scheme: String
+        let host: String
+        /// Empty or `"/" + encoded segments`, no trailing slash.
+        let pathPrefix: String
     }
 
-    /// capcap `S3Common.stripScheme`
-    static func stripScheme(_ raw: String) -> String {
+    /// Parses a user-supplied endpoint into scheme, host[:port], and optional path prefix.
+    static func parseEndpoint(_ raw: String) -> ParsedEndpoint? {
         var value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if value.hasPrefix("https://") { value.removeFirst(8) }
-        if value.hasPrefix("http://") { value.removeFirst(7) }
-        while value.hasSuffix("/") { value.removeLast() }
-        return value
+        guard !value.isEmpty else { return nil }
+
+        let scheme: String
+        if value.lowercased().hasPrefix("https://") {
+            scheme = "https"
+            value.removeFirst("https://".count)
+        } else if value.lowercased().hasPrefix("http://") {
+            scheme = "http"
+            value.removeFirst("http://".count)
+        } else {
+            scheme = "https"
+        }
+
+        while value.hasSuffix("/") {
+            value.removeLast()
+        }
+        guard !value.isEmpty else { return nil }
+
+        let parts = value.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+        let host = String(parts[0])
+        guard !host.isEmpty, !host.contains(" ") else { return nil }
+
+        let pathPrefix: String
+        if parts.count > 1 {
+            let encoded = ShareConfig.encodeObjectKey(String(parts[1]))
+            pathPrefix = encoded.isEmpty ? "" : "/\(encoded)"
+        } else {
+            pathPrefix = ""
+        }
+
+        return ParsedEndpoint(scheme: scheme, host: host, pathPrefix: pathPrefix)
     }
 
-    /// capcap `R2Uploader.normalizeAccountId`
     static func normalizeAccountID(_ raw: String) -> String {
-        var value = stripScheme(raw)
+        var value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.lowercased().hasPrefix("https://") {
+            value.removeFirst("https://".count)
+        } else if value.lowercased().hasPrefix("http://") {
+            value.removeFirst("http://".count)
+        }
+        while value.hasSuffix("/") {
+            value.removeLast()
+        }
         if let range = value.range(of: ".r2.cloudflarestorage.com") {
             value = String(value[value.startIndex..<range.lowerBound])
         }
         return value
     }
 
-    // MARK: - Private
+    // MARK: - Signing
 
     static func signedRequest(
         method: String,
-        host: String,
-        canonicalURI: String,
+        target: Target,
         region: String,
         accessKeyId: String,
         secretAccessKey: String,
@@ -226,14 +276,14 @@ enum S3CompatibleHTTP {
         contentLength: Int?,
         now: Date = Date()
     ) throws -> URLRequest {
-        guard let url = URL(string: "https://\(host)\(canonicalURI)") else {
-            throw ShareError.notConfigured
+        guard let url = URL(string: target.requestURLString) else {
+            throw ShareError.unknown("Invalid S3 endpoint URL")
         }
 
         let (amzDate, dateStamp) = timestamps(now)
         let service = "s3"
+        let host = target.host
 
-        // Canonical headers must be sorted by lowercased name (capcap PUT order).
         let canonicalHeaders: String
         let signedHeaders: String
         if let contentType {
@@ -253,7 +303,7 @@ enum S3CompatibleHTTP {
 
         let canonicalRequest = [
             method,
-            canonicalURI,
+            target.canonicalURI,
             "",
             canonicalHeaders,
             signedHeaders,
@@ -274,7 +324,6 @@ enum S3CompatibleHTTP {
         let kSigning = hmacSHA256(key: kService, message: Data("aws4_request".utf8))
         let signature = ShareSigning.hex(hmacSHA256(key: kSigning, message: Data(stringToSign.utf8)))
 
-        // Exact Authorization formatting from capcap `AWSV4Signer`.
         let authorization = "AWS4-HMAC-SHA256 " +
             "Credential=\(accessKeyId)/\(scope), " +
             "SignedHeaders=\(signedHeaders), " +
@@ -337,11 +386,6 @@ enum S3CompatibleHTTP {
 
     private static func sha256Hex(_ data: Data) -> String {
         ShareSigning.hex(Data(SHA256.hash(data: data)))
-    }
-
-    private static func nonEmpty(_ raw: String) -> String? {
-        let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.isEmpty ? nil : value
     }
 
     private static func xmlTag(_ xml: String, _ tag: String) -> String? {

--- a/Packages/ShareKit/Sources/ShareKit/S3CompatibleHTTP.swift
+++ b/Packages/ShareKit/Sources/ShareKit/S3CompatibleHTTP.swift
@@ -1,0 +1,357 @@
+import CryptoKit
+import Foundation
+
+/// S3 / R2 transport ported from the working capcap uploader:
+/// `AWSV4Signer` + `S3Common` + `R2Uploader` / `S3Uploader`.
+///
+/// Wire format matches that stack:
+/// - SigV4 with the real payload SHA-256 (not `UNSIGNED-PAYLOAD`)
+/// - signed headers: `content-type;host;x-amz-content-sha256;x-amz-date`
+/// - Amazon virtual-hosted vs custom path-style endpoints
+/// - R2 path-style on `<accountId>.r2.cloudflarestorage.com` with region `auto`
+///
+/// Capso only changes the body transport: hash the file in chunks, then
+/// `URLSession.upload(fromFile:)` so recordings are not held as one `Data`.
+enum S3CompatibleHTTP {
+    static let emptyPayloadHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+    struct Target: Sendable {
+        let host: String
+        let canonicalURI: String
+    }
+
+    /// Mirrors capcap `S3Uploader` host / canonical URI selection.
+    static func amazonS3Target(bucket: String, objectKey: String, region: String, endpoint: String?) -> Target {
+        let encodedKey = encodePath(objectKey)
+        if let endpoint, let raw = nonEmpty(endpoint) {
+            // S3-compatible endpoint → path-style addressing (capcap `S3Common.stripScheme`).
+            let host = stripScheme(raw)
+            return Target(host: host, canonicalURI: "/\(bucket)/\(encodedKey)")
+        }
+        // Amazon S3 → virtual-hosted-style addressing.
+        let host = "\(bucket).s3.\(region).amazonaws.com"
+        return Target(host: host, canonicalURI: "/\(encodedKey)")
+    }
+
+    /// Mirrors capcap `R2Uploader` host / canonical URI selection.
+    static func r2Target(accountID: String, bucket: String, objectKey: String) -> Target {
+        let encodedKey = encodePath(objectKey)
+        let normalizedAccountID = normalizeAccountID(accountID)
+        return Target(
+            host: "\(normalizedAccountID).r2.cloudflarestorage.com",
+            canonicalURI: "/\(bucket)/\(encodedKey)"
+        )
+    }
+
+    static func putObject(
+        file: URL,
+        target: Target,
+        region: String,
+        accessKeyId: String,
+        secretAccessKey: String,
+        contentType: String
+    ) async throws {
+        let (payloadHash, contentLength) = try sha256File(file)
+        let request = try signedPutRequest(
+            host: target.host,
+            canonicalURI: target.canonicalURI,
+            region: region,
+            accessKeyId: accessKeyId,
+            secretAccessKey: secretAccessKey,
+            payloadHash: payloadHash,
+            contentLength: contentLength,
+            contentType: contentType
+        )
+        let (body, response) = try await URLSession.shared.upload(for: request, fromFile: file)
+        try validate(response: response, body: body)
+    }
+
+    static func deleteObject(
+        target: Target,
+        region: String,
+        accessKeyId: String,
+        secretAccessKey: String
+    ) async throws {
+        let request = try signedDeleteRequest(
+            host: target.host,
+            canonicalURI: target.canonicalURI,
+            region: region,
+            accessKeyId: accessKeyId,
+            secretAccessKey: secretAccessKey
+        )
+        let (body, response) = try await URLSession.shared.data(for: request)
+        try validate(response: response, body: body)
+    }
+
+    /// Empty-body DELETE SigV4 request (same empty payload hash as AWS docs).
+    static func signedDeleteRequest(
+        host: String,
+        canonicalURI: String,
+        region: String,
+        accessKeyId: String,
+        secretAccessKey: String,
+        now: Date = Date()
+    ) throws -> URLRequest {
+        try signedRequest(
+            method: "DELETE",
+            host: host,
+            canonicalURI: canonicalURI,
+            region: region,
+            accessKeyId: accessKeyId,
+            secretAccessKey: secretAccessKey,
+            contentType: nil,
+            contentSHA256: emptyPayloadHash,
+            contentLength: nil,
+            now: now
+        )
+    }
+
+    /// capcap `AWSV4Signer.signedPutRequest` — same headers, same signature inputs.
+    static func signedPutRequest(
+        host: String,
+        canonicalURI: String,
+        region: String,
+        accessKeyId: String,
+        secretAccessKey: String,
+        payloadHash: String,
+        contentLength: Int,
+        contentType: String,
+        now: Date = Date()
+    ) throws -> URLRequest {
+        var request = try signedRequest(
+            method: "PUT",
+            host: host,
+            canonicalURI: canonicalURI,
+            region: region,
+            accessKeyId: accessKeyId,
+            secretAccessKey: secretAccessKey,
+            contentType: contentType,
+            contentSHA256: payloadHash,
+            contentLength: contentLength,
+            now: now
+        )
+        // capcap sets Content-Length explicitly on the signed PUT.
+        request.setValue("\(contentLength)", forHTTPHeaderField: "Content-Length")
+        return request
+    }
+
+    /// Deterministic helper for tests — same as hashing `payload` then calling `signedPutRequest`.
+    static func signedPutRequest(
+        host: String,
+        canonicalURI: String,
+        region: String,
+        accessKeyId: String,
+        secretAccessKey: String,
+        payload: Data,
+        contentType: String,
+        now: Date = Date()
+    ) throws -> URLRequest {
+        try signedPutRequest(
+            host: host,
+            canonicalURI: canonicalURI,
+            region: region,
+            accessKeyId: accessKeyId,
+            secretAccessKey: secretAccessKey,
+            payloadHash: sha256Hex(payload),
+            contentLength: payload.count,
+            contentType: contentType,
+            now: now
+        )
+    }
+
+    static func mapResponseError(statusCode: Int, body: Data) -> ShareError {
+        let text = String(data: body, encoding: .utf8) ?? ""
+        if let code = xmlTag(text, "Code") {
+            switch code {
+            case "InvalidAccessKeyId", "SignatureDoesNotMatch", "AccessDenied", "InvalidToken":
+                return .invalidCredentials
+            case "QuotaExceeded", "EntityTooLarge":
+                return .quotaExceeded
+            case "NoSuchBucket":
+                return .unknown("Bucket not found — verify the bucket name in Cloud Share settings")
+            default:
+                let message = xmlTag(text, "Message") ?? text
+                return .unknown("\(code): \(message)")
+            }
+        }
+
+        switch statusCode {
+        case 401, 403:
+            return .invalidCredentials
+        case 413, 507:
+            return .quotaExceeded
+        default:
+            return .unknown(text.isEmpty ? "HTTP \(statusCode)" : "HTTP \(statusCode): \(text)")
+        }
+    }
+
+    // MARK: - Path / endpoint helpers (capcap)
+
+    /// capcap `AWSV4Signer.encodePath`
+    static func encodePath(_ key: String) -> String {
+        key.split(separator: "/", omittingEmptySubsequences: false)
+            .map { String($0).sharePercentEncoded() }
+            .joined(separator: "/")
+    }
+
+    /// capcap `S3Common.stripScheme`
+    static func stripScheme(_ raw: String) -> String {
+        var value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.hasPrefix("https://") { value.removeFirst(8) }
+        if value.hasPrefix("http://") { value.removeFirst(7) }
+        while value.hasSuffix("/") { value.removeLast() }
+        return value
+    }
+
+    /// capcap `R2Uploader.normalizeAccountId`
+    static func normalizeAccountID(_ raw: String) -> String {
+        var value = stripScheme(raw)
+        if let range = value.range(of: ".r2.cloudflarestorage.com") {
+            value = String(value[value.startIndex..<range.lowerBound])
+        }
+        return value
+    }
+
+    // MARK: - Private
+
+    static func signedRequest(
+        method: String,
+        host: String,
+        canonicalURI: String,
+        region: String,
+        accessKeyId: String,
+        secretAccessKey: String,
+        contentType: String?,
+        contentSHA256: String,
+        contentLength: Int?,
+        now: Date = Date()
+    ) throws -> URLRequest {
+        guard let url = URL(string: "https://\(host)\(canonicalURI)") else {
+            throw ShareError.notConfigured
+        }
+
+        let (amzDate, dateStamp) = timestamps(now)
+        let service = "s3"
+
+        // Canonical headers must be sorted by lowercased name (capcap PUT order).
+        let canonicalHeaders: String
+        let signedHeaders: String
+        if let contentType {
+            canonicalHeaders =
+                "content-type:\(contentType)\n" +
+                "host:\(host)\n" +
+                "x-amz-content-sha256:\(contentSHA256)\n" +
+                "x-amz-date:\(amzDate)\n"
+            signedHeaders = "content-type;host;x-amz-content-sha256;x-amz-date"
+        } else {
+            canonicalHeaders =
+                "host:\(host)\n" +
+                "x-amz-content-sha256:\(contentSHA256)\n" +
+                "x-amz-date:\(amzDate)\n"
+            signedHeaders = "host;x-amz-content-sha256;x-amz-date"
+        }
+
+        let canonicalRequest = [
+            method,
+            canonicalURI,
+            "",
+            canonicalHeaders,
+            signedHeaders,
+            contentSHA256,
+        ].joined(separator: "\n")
+
+        let scope = "\(dateStamp)/\(region)/\(service)/aws4_request"
+        let stringToSign = [
+            "AWS4-HMAC-SHA256",
+            amzDate,
+            scope,
+            sha256Hex(Data(canonicalRequest.utf8)),
+        ].joined(separator: "\n")
+
+        let kDate = hmacSHA256(key: Data("AWS4\(secretAccessKey)".utf8), message: Data(dateStamp.utf8))
+        let kRegion = hmacSHA256(key: kDate, message: Data(region.utf8))
+        let kService = hmacSHA256(key: kRegion, message: Data(service.utf8))
+        let kSigning = hmacSHA256(key: kService, message: Data("aws4_request".utf8))
+        let signature = ShareSigning.hex(hmacSHA256(key: kSigning, message: Data(stringToSign.utf8)))
+
+        // Exact Authorization formatting from capcap `AWSV4Signer`.
+        let authorization = "AWS4-HMAC-SHA256 " +
+            "Credential=\(accessKeyId)/\(scope), " +
+            "SignedHeaders=\(signedHeaders), " +
+            "Signature=\(signature)"
+
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue(host, forHTTPHeaderField: "Host")
+        request.setValue(amzDate, forHTTPHeaderField: "X-Amz-Date")
+        request.setValue(contentSHA256, forHTTPHeaderField: "X-Amz-Content-Sha256")
+        request.setValue(authorization, forHTTPHeaderField: "Authorization")
+        if let contentType {
+            request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        }
+        if let contentLength {
+            request.setValue("\(contentLength)", forHTTPHeaderField: "Content-Length")
+        }
+        return request
+    }
+
+    private static func validate(response: URLResponse, body: Data) throws {
+        guard let http = response as? HTTPURLResponse else {
+            throw ShareError.network(underlying: "Missing HTTP response")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw mapResponseError(statusCode: http.statusCode, body: body)
+        }
+    }
+
+    /// Chunked file digest used by `putObject` — must match `SHA256(Data(contentsOf:))`.
+    static func sha256File(_ file: URL) throws -> (hash: String, size: Int) {
+        let handle = try FileHandle(forReadingFrom: file)
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
+        var size = 0
+        while true {
+            let chunk = try handle.read(upToCount: 1024 * 1024) ?? Data()
+            if chunk.isEmpty { break }
+            size += chunk.count
+            hasher.update(data: chunk)
+        }
+        return (ShareSigning.hex(Data(hasher.finalize())), size)
+    }
+
+    private static func timestamps(_ date: Date) -> (amz: String, stamp: String) {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "GMT")
+        formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
+        let amz = formatter.string(from: date)
+        formatter.dateFormat = "yyyyMMdd"
+        let stamp = formatter.string(from: date)
+        return (amz, stamp)
+    }
+
+    private static func hmacSHA256(key: Data, message: Data) -> Data {
+        Data(HMAC<SHA256>.authenticationCode(for: message, using: SymmetricKey(data: key)))
+    }
+
+    private static func sha256Hex(_ data: Data) -> String {
+        ShareSigning.hex(Data(SHA256.hash(data: data)))
+    }
+
+    private static func nonEmpty(_ raw: String) -> String? {
+        let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+
+    private static func xmlTag(_ xml: String, _ tag: String) -> String? {
+        guard let start = xml.range(of: "<\(tag)>"),
+              let end = xml.range(of: "</\(tag)>"),
+              start.upperBound <= end.lowerBound else {
+            return nil
+        }
+        let value = String(xml[start.upperBound..<end.lowerBound])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Packages/ShareKit/Sources/ShareKit/S3Destination.swift
+++ b/Packages/ShareKit/Sources/ShareKit/S3Destination.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SotoS3
 
 public actor S3Destination: ShareDestination {
     private let config: ShareConfig
@@ -12,86 +11,38 @@ public actor S3Destination: ShareDestination {
         self.secretKey = secretKey
     }
 
-    private func makeClient() -> AWSClient {
-        AWSClient(
-            credentialProvider: .static(accessKeyId: accessKey, secretAccessKey: secretKey)
-        )
-    }
-
-    private func makeS3(_ client: AWSClient) -> S3 {
-        S3(
-            client: client,
-            region: .init(rawValue: config.region),
-            endpoint: config.endpoint
-        )
-    }
-
-    private func withClient<T: Sendable>(_ body: @Sendable (S3) async throws -> T) async throws -> T {
-        let client = makeClient()
-        let s3 = makeS3(client)
-        do {
-            let result = try await body(s3)
-            try? await client.shutdown()
-            return result
-        } catch {
-            try? await client.shutdown()
-            throw error
-        }
-    }
-
     public func upload(file: URL, key: String, contentType: String) async throws -> URL {
         let objectKey = config.objectKey(for: key)
-        let data = try Data(contentsOf: file)
-
-        return try await withClient { s3 in
-            do {
-                _ = try await s3.putObject(.init(
-                    body: .init(bytes: data),
-                    bucket: self.config.bucket,
-                    contentType: contentType,
-                    key: objectKey
-                ))
-            } catch let error as S3ErrorType {
-                throw self.map(error)
-            } catch let error as AWSResponseError {
-                throw self.mapResponse(error)
-            } catch {
-                throw ShareError.network(underlying: error.localizedDescription)
-            }
-
-            return self.config.publicURL(forObjectKey: objectKey)
-        }
+        let target = S3CompatibleHTTP.amazonS3Target(
+            bucket: config.bucket,
+            objectKey: objectKey,
+            region: config.region,
+            endpoint: config.endpoint
+        )
+        try await S3CompatibleHTTP.putObject(
+            file: file,
+            target: target,
+            region: config.region,
+            accessKeyId: accessKey,
+            secretAccessKey: secretKey,
+            contentType: contentType
+        )
+        return config.publicURL(forObjectKey: objectKey)
     }
 
     public func delete(key: String) async throws {
         let objectKey = config.objectKey(for: key)
-        try await withClient { s3 in
-            do {
-                _ = try await s3.deleteObject(.init(bucket: self.config.bucket, key: objectKey))
-            } catch let error as S3ErrorType {
-                throw self.map(error)
-            } catch let error as AWSResponseError {
-                throw self.mapResponse(error)
-            } catch {
-                throw ShareError.network(underlying: error.localizedDescription)
-            }
-        }
-    }
-
-    nonisolated private func map(_ error: S3ErrorType) -> ShareError {
-        .unknown("\(error.errorCode): \(error.message ?? "")")
-    }
-
-    nonisolated private func mapResponse(_ error: AWSResponseError) -> ShareError {
-        switch error.errorCode {
-        case "InvalidAccessKeyId", "SignatureDoesNotMatch", "AccessDenied":
-            return .invalidCredentials
-        case "QuotaExceeded", "EntityTooLarge":
-            return .quotaExceeded
-        case "NoSuchBucket":
-            return .unknown("Bucket not found — verify the bucket name in Cloud Share settings")
-        default:
-            return .unknown("\(error.errorCode): \(error.message ?? "")")
-        }
+        let target = S3CompatibleHTTP.amazonS3Target(
+            bucket: config.bucket,
+            objectKey: objectKey,
+            region: config.region,
+            endpoint: config.endpoint
+        )
+        try await S3CompatibleHTTP.deleteObject(
+            target: target,
+            region: config.region,
+            accessKeyId: accessKey,
+            secretAccessKey: secretKey
+        )
     }
 }

--- a/Packages/ShareKit/Sources/ShareKit/ShareConfig.swift
+++ b/Packages/ShareKit/Sources/ShareKit/ShareConfig.swift
@@ -87,15 +87,22 @@ public struct ShareConfig: Sendable {
 
     public func publicURL(forObjectKey key: String) -> URL {
         let encoded = ShareConfig.encodeObjectKey(key)
-        return URL(string: "\(urlPrefix)/\(encoded)")!
+        if let url = URL(string: "\(urlPrefix)/\(encoded)") {
+            return url
+        }
+        // `urlPrefix` is validated via `validatePrefix`; this only guards against
+        // an unexpectedly unparseable encoded key.
+        return URL(string: urlPrefix) ?? URL(fileURLWithPath: "/")
     }
 
     /// Compose a public URL from a prefix, ID, and file extension.
-    /// - Precondition: `prefix` has passed `validatePrefix(_:)`. Calling this with an
-    ///   unvalidated user-supplied prefix can crash on the force-unwrap.
+    /// - Precondition: `prefix` has passed `validatePrefix(_:)`.
     public static func composePublicURL(prefix: String, id: String, ext: String) -> URL {
         let normalized = normalizePrefix(prefix)
-        return URL(string: "\(normalized)/\(id).\(ext)")!
+        if let url = URL(string: "\(normalized)/\(id).\(ext)") {
+            return url
+        }
+        return URL(string: normalized) ?? URL(fileURLWithPath: "/")
     }
 
     public static func normalizePrefix(_ prefix: String) -> String {

--- a/Packages/ShareKit/Tests/ShareKitTests/S3CompatibleHTTPTests.swift
+++ b/Packages/ShareKit/Tests/ShareKitTests/S3CompatibleHTTPTests.swift
@@ -1,0 +1,502 @@
+import CryptoKit
+import Foundation
+import Testing
+@testable import ShareKit
+
+@Suite("S3CompatibleHTTP")
+struct S3CompatibleHTTPTests {
+
+    // MARK: - Addressing (capcap S3Uploader / R2Uploader)
+
+    @Test("Amazon S3 uses virtual-hosted style when endpoint is empty")
+    func amazonVirtualHosted() {
+        let target = S3CompatibleHTTP.amazonS3Target(
+            bucket: "capso",
+            objectKey: "clips/demo.mp4",
+            region: "us-west-2",
+            endpoint: nil
+        )
+        #expect(target.host == "capso.s3.us-west-2.amazonaws.com")
+        #expect(target.canonicalURI == "/clips/demo.mp4")
+    }
+
+    @Test("Amazon S3 treats blank endpoint as virtual-hosted")
+    func amazonBlankEndpoint() {
+        let target = S3CompatibleHTTP.amazonS3Target(
+            bucket: "capso",
+            objectKey: "a.png",
+            region: "eu-central-1",
+            endpoint: "   "
+        )
+        #expect(target.host == "capso.s3.eu-central-1.amazonaws.com")
+        #expect(target.canonicalURI == "/a.png")
+    }
+
+    @Test("Amazon S3 uses path-style addressing for custom endpoints")
+    func amazonCustomEndpoint() {
+        let target = S3CompatibleHTTP.amazonS3Target(
+            bucket: "capso",
+            objectKey: "clips/demo one.mp4",
+            region: "us-east-1",
+            endpoint: "https://minio.example.com/"
+        )
+        #expect(target.host == "minio.example.com")
+        #expect(target.canonicalURI == "/capso/clips/demo%20one.mp4")
+    }
+
+    @Test("custom endpoint stripScheme keeps host:port like capcap")
+    func customEndpointWithPort() {
+        let target = S3CompatibleHTTP.amazonS3Target(
+            bucket: "shots",
+            objectKey: "x.png",
+            region: "us-east-1",
+            endpoint: "http://127.0.0.1:9000"
+        )
+        #expect(target.host == "127.0.0.1:9000")
+        #expect(target.canonicalURI == "/shots/x.png")
+    }
+
+    @Test("R2 target uses account endpoint and path-style bucket")
+    func r2Target() {
+        let target = S3CompatibleHTTP.r2Target(
+            accountID: "abc123",
+            bucket: "capso",
+            objectKey: "a/b.png"
+        )
+        #expect(target.host == "abc123.r2.cloudflarestorage.com")
+        #expect(target.canonicalURI == "/capso/a/b.png")
+    }
+
+    @Test("R2 account ID accepts a pasted full endpoint")
+    func r2NormalizesAccountID() {
+        let target = S3CompatibleHTTP.r2Target(
+            accountID: "https://abc123.r2.cloudflarestorage.com",
+            bucket: "capso",
+            objectKey: "x.png"
+        )
+        #expect(target.host == "abc123.r2.cloudflarestorage.com")
+    }
+
+    @Test("R2 account ID normalization strips scheme and trailing slash")
+    func r2NormalizeHelpers() {
+        #expect(S3CompatibleHTTP.normalizeAccountID("abc123") == "abc123")
+        #expect(S3CompatibleHTTP.normalizeAccountID("https://abc123.r2.cloudflarestorage.com/") == "abc123")
+        #expect(S3CompatibleHTTP.stripScheme("https://minio.example.com/") == "minio.example.com")
+        #expect(S3CompatibleHTTP.stripScheme("http://minio.example.com") == "minio.example.com")
+    }
+
+    // MARK: - Path encoding (capcap AWSV4Signer.encodePath)
+
+    @Test("encodePath percent-encodes segments and preserves slashes")
+    func encodePathRules() {
+        #expect(S3CompatibleHTTP.encodePath("a/b c.png") == "a/b%20c.png")
+        #expect(S3CompatibleHTTP.encodePath("已截图.png") == "%E5%B7%B2%E6%88%AA%E5%9B%BE.png")
+        #expect(S3CompatibleHTTP.encodePath("a+b~c_d-e.f") == "a%2Bb~c_d-e.f")
+        // Empty segments from leading / doubled slashes are preserved.
+        #expect(S3CompatibleHTTP.encodePath("/leading") == "/leading")
+        #expect(S3CompatibleHTTP.encodePath("a//b") == "a//b")
+    }
+
+    @Test("encodePath matches ShareConfig.encodeObjectKey")
+    func encodePathMatchesShareConfig() {
+        let keys = ["plain.png", "has space.mp4", "path/nested/file.gif", "emoji-🎬.mov"]
+        for key in keys {
+            #expect(S3CompatibleHTTP.encodePath(key) == ShareConfig.encodeObjectKey(key))
+        }
+    }
+
+    // MARK: - SigV4 PUT (capcap AWSV4Signer.signedPutRequest)
+
+    @Test("signed PUT matches capcap payload-hash SigV4 shape")
+    func signedPutMatchesCapcapShape() throws {
+        let payload = Data("hello-capso".utf8)
+        let payloadHash = Self.sha256Hex(payload)
+        let date = Self.fixedDate
+
+        let request = try S3CompatibleHTTP.signedPutRequest(
+            host: "capso.s3.us-east-1.amazonaws.com",
+            canonicalURI: "/demo.mp4",
+            region: "us-east-1",
+            accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+            secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            payload: payload,
+            contentType: "video/mp4",
+            now: date
+        )
+
+        #expect(request.httpMethod == "PUT")
+        #expect(request.value(forHTTPHeaderField: "X-Amz-Content-Sha256") == payloadHash)
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "video/mp4")
+        #expect(request.value(forHTTPHeaderField: "Content-Length") == "\(payload.count)")
+        #expect(request.value(forHTTPHeaderField: "X-Amz-Date") == "20260730T120000Z")
+        #expect(request.value(forHTTPHeaderField: "Host") == "capso.s3.us-east-1.amazonaws.com")
+        #expect(request.url?.absoluteString == "https://capso.s3.us-east-1.amazonaws.com/demo.mp4")
+
+        let authorization = try #require(request.value(forHTTPHeaderField: "Authorization"))
+        #expect(authorization.hasPrefix("AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20260730/us-east-1/s3/aws4_request, "))
+        #expect(authorization.contains("SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, "))
+        #expect(authorization.contains("Signature="))
+    }
+
+    @Test("signed PUT Authorization matches an independent capcap-style signer")
+    func signedPutMatchesIndependentCapcapSigner() throws {
+        let payload = Data("wire-compatible".utf8)
+        let date = Self.fixedDate
+        let host = "bucket.s3.us-west-2.amazonaws.com"
+        let uri = "/clips/demo.mp4"
+        let region = "us-west-2"
+        let accessKey = "AKIDEXAMPLE"
+        let secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        let contentType = "video/mp4"
+
+        let request = try S3CompatibleHTTP.signedPutRequest(
+            host: host,
+            canonicalURI: uri,
+            region: region,
+            accessKeyId: accessKey,
+            secretAccessKey: secret,
+            payload: payload,
+            contentType: contentType,
+            now: date
+        )
+
+        let expected = Self.capcapStyleAuthorization(
+            method: "PUT",
+            host: host,
+            canonicalURI: uri,
+            region: region,
+            accessKeyId: accessKey,
+            secretAccessKey: secret,
+            contentType: contentType,
+            payloadHash: Self.sha256Hex(payload),
+            now: date
+        )
+        #expect(request.value(forHTTPHeaderField: "Authorization") == expected)
+    }
+
+    @Test("R2 PUT signs with region auto like capcap R2Uploader")
+    func r2PutUsesAutoRegion() throws {
+        let payload = Data("r2".utf8)
+        let request = try S3CompatibleHTTP.signedPutRequest(
+            host: "abc123.r2.cloudflarestorage.com",
+            canonicalURI: "/capso/shot.png",
+            region: "auto",
+            accessKeyId: "AKID",
+            secretAccessKey: "SECRET",
+            payload: payload,
+            contentType: "image/png",
+            now: Self.fixedDate
+        )
+        let authorization = try #require(request.value(forHTTPHeaderField: "Authorization"))
+        #expect(authorization.contains("/20260730/auto/s3/aws4_request"))
+    }
+
+    @Test("payload-hash overload and explicit hash overload produce the same signature")
+    func payloadAndHashOverloadsMatch() throws {
+        let payload = Data("same-bytes".utf8)
+        let date = Self.fixedDate
+        let fromPayload = try S3CompatibleHTTP.signedPutRequest(
+            host: "bucket.s3.us-east-1.amazonaws.com",
+            canonicalURI: "/k",
+            region: "us-east-1",
+            accessKeyId: "AKID",
+            secretAccessKey: "SECRET",
+            payload: payload,
+            contentType: "text/plain",
+            now: date
+        )
+        let fromHash = try S3CompatibleHTTP.signedPutRequest(
+            host: "bucket.s3.us-east-1.amazonaws.com",
+            canonicalURI: "/k",
+            region: "us-east-1",
+            accessKeyId: "AKID",
+            secretAccessKey: "SECRET",
+            payloadHash: Self.sha256Hex(payload),
+            contentLength: payload.count,
+            contentType: "text/plain",
+            now: date
+        )
+        #expect(fromPayload.value(forHTTPHeaderField: "Authorization") == fromHash.value(forHTTPHeaderField: "Authorization"))
+        #expect(fromPayload.value(forHTTPHeaderField: "X-Amz-Content-Sha256") == fromHash.value(forHTTPHeaderField: "X-Amz-Content-Sha256"))
+        #expect(fromPayload.value(forHTTPHeaderField: "Content-Length") == fromHash.value(forHTTPHeaderField: "Content-Length"))
+    }
+
+    @Test("empty payload uses the AWS empty-body SHA-256")
+    func emptyPayloadHash() throws {
+        let request = try S3CompatibleHTTP.signedPutRequest(
+            host: "bucket.s3.us-east-1.amazonaws.com",
+            canonicalURI: "/empty.txt",
+            region: "us-east-1",
+            accessKeyId: "AKID",
+            secretAccessKey: "SECRET",
+            payload: Data(),
+            contentType: "text/plain",
+            now: Self.fixedDate
+        )
+        #expect(request.value(forHTTPHeaderField: "X-Amz-Content-Sha256") == S3CompatibleHTTP.emptyPayloadHash)
+        #expect(request.value(forHTTPHeaderField: "Content-Length") == "0")
+    }
+
+    // MARK: - SigV4 DELETE
+
+    @Test("signed DELETE uses empty payload hash and omits content-type")
+    func signedDeleteShape() throws {
+        let request = try S3CompatibleHTTP.signedDeleteRequest(
+            host: "capso.s3.us-east-1.amazonaws.com",
+            canonicalURI: "/old.mp4",
+            region: "us-east-1",
+            accessKeyId: "AKID",
+            secretAccessKey: "SECRET",
+            now: Self.fixedDate
+        )
+        #expect(request.httpMethod == "DELETE")
+        #expect(request.value(forHTTPHeaderField: "X-Amz-Content-Sha256") == S3CompatibleHTTP.emptyPayloadHash)
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == nil)
+        #expect(request.value(forHTTPHeaderField: "Content-Length") == nil)
+
+        let authorization = try #require(request.value(forHTTPHeaderField: "Authorization"))
+        #expect(authorization.contains("SignedHeaders=host;x-amz-content-sha256;x-amz-date, "))
+        #expect(authorization.contains("/us-east-1/s3/aws4_request"))
+    }
+
+    @Test("signed DELETE Authorization matches independent signer")
+    func signedDeleteMatchesIndependentSigner() throws {
+        let host = "abc123.r2.cloudflarestorage.com"
+        let uri = "/capso/old.png"
+        let request = try S3CompatibleHTTP.signedDeleteRequest(
+            host: host,
+            canonicalURI: uri,
+            region: "auto",
+            accessKeyId: "AKID",
+            secretAccessKey: "SECRET",
+            now: Self.fixedDate
+        )
+        let expected = Self.capcapStyleAuthorization(
+            method: "DELETE",
+            host: host,
+            canonicalURI: uri,
+            region: "auto",
+            accessKeyId: "AKID",
+            secretAccessKey: "SECRET",
+            contentType: nil,
+            payloadHash: S3CompatibleHTTP.emptyPayloadHash,
+            now: Self.fixedDate
+        )
+        #expect(request.value(forHTTPHeaderField: "Authorization") == expected)
+    }
+
+    // MARK: - Chunked file hashing
+
+    @Test("chunked sha256File matches Data(contentsOf:) for small files")
+    func sha256FileMatchesDataSmall() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-sha-small-\(UUID().uuidString).bin")
+        let data = Data("small-recording-bytes".utf8)
+        try data.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let hashed = try S3CompatibleHTTP.sha256File(url)
+        #expect(hashed.size == data.count)
+        #expect(hashed.hash == Self.sha256Hex(data))
+    }
+
+    @Test("chunked sha256File matches Data(contentsOf:) across 1MB boundaries")
+    func sha256FileMatchesDataLarge() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-sha-large-\(UUID().uuidString).bin")
+        // 1.5 MiB forces more than one 1 MiB read chunk in sha256File.
+        var data = Data(count: 1_500_000)
+        for i in data.indices {
+            data[i] = UInt8(i % 251)
+        }
+        try data.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let hashed = try S3CompatibleHTTP.sha256File(url)
+        #expect(hashed.size == data.count)
+        #expect(hashed.hash == Self.sha256Hex(data))
+    }
+
+    @Test("chunked file hash produces the same PUT signature as in-memory payload")
+    func fileHashSignatureMatchesPayloadSignature() throws {
+        let payload = Data(repeating: 0x5A, count: 4096)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("capso-sig-\(UUID().uuidString).bin")
+        try payload.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let fileDigest = try S3CompatibleHTTP.sha256File(url)
+        let fromFile = try S3CompatibleHTTP.signedPutRequest(
+            host: "bucket.s3.us-east-1.amazonaws.com",
+            canonicalURI: "/clip.mp4",
+            region: "us-east-1",
+            accessKeyId: "AKID",
+            secretAccessKey: "SECRET",
+            payloadHash: fileDigest.hash,
+            contentLength: fileDigest.size,
+            contentType: "video/mp4",
+            now: Self.fixedDate
+        )
+        let fromMemory = try S3CompatibleHTTP.signedPutRequest(
+            host: "bucket.s3.us-east-1.amazonaws.com",
+            canonicalURI: "/clip.mp4",
+            region: "us-east-1",
+            accessKeyId: "AKID",
+            secretAccessKey: "SECRET",
+            payload: payload,
+            contentType: "video/mp4",
+            now: Self.fixedDate
+        )
+        #expect(fromFile.value(forHTTPHeaderField: "Authorization") == fromMemory.value(forHTTPHeaderField: "Authorization"))
+        #expect(fromFile.value(forHTTPHeaderField: "X-Amz-Content-Sha256") == fromMemory.value(forHTTPHeaderField: "X-Amz-Content-Sha256"))
+        #expect(fromFile.value(forHTTPHeaderField: "Content-Length") == fromMemory.value(forHTTPHeaderField: "Content-Length"))
+    }
+
+    // MARK: - Error mapping
+
+    @Test("maps S3 XML auth failures to invalidCredentials", arguments: [
+        "SignatureDoesNotMatch",
+        "InvalidAccessKeyId",
+        "AccessDenied",
+        "InvalidToken",
+    ])
+    func mapsAuthFailures(code: String) {
+        let body = Data("<Error><Code>\(code)</Code><Message>nope</Message></Error>".utf8)
+        #expect(S3CompatibleHTTP.mapResponseError(statusCode: 403, body: body) == .invalidCredentials)
+    }
+
+    @Test("maps quota XML codes to quotaExceeded", arguments: ["QuotaExceeded", "EntityTooLarge"])
+    func mapsQuotaFailures(code: String) {
+        let body = Data("<Error><Code>\(code)</Code><Message>too big</Message></Error>".utf8)
+        #expect(S3CompatibleHTTP.mapResponseError(statusCode: 400, body: body) == .quotaExceeded)
+    }
+
+    @Test("maps missing bucket XML to a helpful unknown error")
+    func mapsMissingBucket() {
+        let body = Data("""
+        <Error><Code>NoSuchBucket</Code><Message>gone</Message></Error>
+        """.utf8)
+        #expect(
+            S3CompatibleHTTP.mapResponseError(statusCode: 404, body: body)
+                == .unknown("Bucket not found — verify the bucket name in Cloud Share settings")
+        )
+    }
+
+    @Test("maps unknown XML code with message")
+    func mapsUnknownXMLCode() {
+        let body = Data("<Error><Code>SlowDown</Code><Message>wait</Message></Error>".utf8)
+        #expect(S3CompatibleHTTP.mapResponseError(statusCode: 503, body: body) == .unknown("SlowDown: wait"))
+    }
+
+    @Test("maps HTTP status fallbacks without XML")
+    func mapsHTTPStatusFallbacks() {
+        #expect(S3CompatibleHTTP.mapResponseError(statusCode: 401, body: Data()) == .invalidCredentials)
+        #expect(S3CompatibleHTTP.mapResponseError(statusCode: 403, body: Data()) == .invalidCredentials)
+        #expect(S3CompatibleHTTP.mapResponseError(statusCode: 413, body: Data()) == .quotaExceeded)
+        #expect(S3CompatibleHTTP.mapResponseError(statusCode: 507, body: Data()) == .quotaExceeded)
+        #expect(S3CompatibleHTTP.mapResponseError(statusCode: 500, body: Data()) == .unknown("HTTP 500"))
+        #expect(
+            S3CompatibleHTTP.mapResponseError(statusCode: 500, body: Data("boom".utf8))
+                == .unknown("HTTP 500: boom")
+        )
+    }
+
+    // MARK: - Destinations still construct
+
+    @Test("S3 and R2 destinations still construct through the factory")
+    func destinationsConstruct() throws {
+        let s3 = ShareConfig(
+            provider: .s3,
+            urlPrefix: "https://cdn.example.com",
+            bucket: "capso",
+            fields: ["region": "us-east-1", "endpoint": "https://minio.example.com"]
+        )
+        let r2 = ShareConfig(
+            provider: .r2,
+            urlPrefix: "https://cdn.example.com",
+            bucket: "capso",
+            fields: ["accountID": "abc123"]
+        )
+        #expect(try ShareDestinationFactory.make(config: s3, accessKey: "id", secretKey: "secret") is S3Destination)
+        #expect(try ShareDestinationFactory.make(config: r2, accessKey: "id", secretKey: "secret") is R2Destination)
+    }
+
+    // MARK: - Helpers
+
+    private static let fixedDate = ISO8601DateFormatter().date(from: "2026-07-30T12:00:00Z")!
+
+    private static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Independent reimplementation of capcap `AWSV4Signer` Authorization formatting.
+    private static func capcapStyleAuthorization(
+        method: String,
+        host: String,
+        canonicalURI: String,
+        region: String,
+        accessKeyId: String,
+        secretAccessKey: String,
+        contentType: String?,
+        payloadHash: String,
+        now: Date
+    ) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "GMT")
+        formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
+        let amzDate = formatter.string(from: now)
+        formatter.dateFormat = "yyyyMMdd"
+        let dateStamp = formatter.string(from: now)
+
+        let canonicalHeaders: String
+        let signedHeaders: String
+        if let contentType {
+            canonicalHeaders =
+                "content-type:\(contentType)\n" +
+                "host:\(host)\n" +
+                "x-amz-content-sha256:\(payloadHash)\n" +
+                "x-amz-date:\(amzDate)\n"
+            signedHeaders = "content-type;host;x-amz-content-sha256;x-amz-date"
+        } else {
+            canonicalHeaders =
+                "host:\(host)\n" +
+                "x-amz-content-sha256:\(payloadHash)\n" +
+                "x-amz-date:\(amzDate)\n"
+            signedHeaders = "host;x-amz-content-sha256;x-amz-date"
+        }
+
+        let canonicalRequest = [
+            method,
+            canonicalURI,
+            "",
+            canonicalHeaders,
+            signedHeaders,
+            payloadHash,
+        ].joined(separator: "\n")
+
+        let scope = "\(dateStamp)/\(region)/s3/aws4_request"
+        let stringToSign = [
+            "AWS4-HMAC-SHA256",
+            amzDate,
+            scope,
+            sha256Hex(Data(canonicalRequest.utf8)),
+        ].joined(separator: "\n")
+
+        func hmac(_ key: Data, _ message: Data) -> Data {
+            Data(HMAC<SHA256>.authenticationCode(for: message, using: SymmetricKey(data: key)))
+        }
+        let kDate = hmac(Data("AWS4\(secretAccessKey)".utf8), Data(dateStamp.utf8))
+        let kRegion = hmac(kDate, Data(region.utf8))
+        let kService = hmac(kRegion, Data("s3".utf8))
+        let kSigning = hmac(kService, Data("aws4_request".utf8))
+        let signature = hmac(kSigning, Data(stringToSign.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+
+        return "AWS4-HMAC-SHA256 " +
+            "Credential=\(accessKeyId)/\(scope), " +
+            "SignedHeaders=\(signedHeaders), " +
+            "Signature=\(signature)"
+    }
+}

--- a/Packages/ShareKit/Tests/ShareKitTests/S3CompatibleHTTPTests.swift
+++ b/Packages/ShareKit/Tests/ShareKitTests/S3CompatibleHTTPTests.swift
@@ -6,9 +6,9 @@ import Testing
 @Suite("S3CompatibleHTTP")
 struct S3CompatibleHTTPTests {
 
-    // MARK: - Addressing (capcap S3Uploader / R2Uploader)
+    // MARK: - Addressing
 
-    @Test("Amazon S3 uses virtual-hosted style when endpoint is empty")
+    @Test("Amazon S3 uses virtual-hosted HTTPS when endpoint is empty")
     func amazonVirtualHosted() {
         let target = S3CompatibleHTTP.amazonS3Target(
             bucket: "capso",
@@ -16,8 +16,10 @@ struct S3CompatibleHTTPTests {
             region: "us-west-2",
             endpoint: nil
         )
+        #expect(target.scheme == "https")
         #expect(target.host == "capso.s3.us-west-2.amazonaws.com")
         #expect(target.canonicalURI == "/clips/demo.mp4")
+        #expect(target.requestURLString == "https://capso.s3.us-west-2.amazonaws.com/clips/demo.mp4")
     }
 
     @Test("Amazon S3 treats blank endpoint as virtual-hosted")
@@ -28,32 +30,81 @@ struct S3CompatibleHTTPTests {
             region: "eu-central-1",
             endpoint: "   "
         )
+        #expect(target.scheme == "https")
         #expect(target.host == "capso.s3.eu-central-1.amazonaws.com")
-        #expect(target.canonicalURI == "/a.png")
     }
 
-    @Test("Amazon S3 uses path-style addressing for custom endpoints")
-    func amazonCustomEndpoint() {
+    @Test("custom HTTPS endpoint uses path-style addressing")
+    func amazonCustomHTTPSEndpoint() {
         let target = S3CompatibleHTTP.amazonS3Target(
             bucket: "capso",
             objectKey: "clips/demo one.mp4",
             region: "us-east-1",
             endpoint: "https://minio.example.com/"
         )
+        #expect(target.scheme == "https")
         #expect(target.host == "minio.example.com")
         #expect(target.canonicalURI == "/capso/clips/demo%20one.mp4")
+        #expect(target.requestURLString == "https://minio.example.com/capso/clips/demo%20one.mp4")
     }
 
-    @Test("custom endpoint stripScheme keeps host:port like capcap")
-    func customEndpointWithPort() {
+    @Test("custom HTTP endpoint preserves http scheme and port")
+    func amazonCustomHTTPEndpointPreservesScheme() throws {
         let target = S3CompatibleHTTP.amazonS3Target(
             bucket: "shots",
             objectKey: "x.png",
             region: "us-east-1",
             endpoint: "http://127.0.0.1:9000"
         )
+        #expect(target.scheme == "http")
         #expect(target.host == "127.0.0.1:9000")
         #expect(target.canonicalURI == "/shots/x.png")
+        #expect(target.requestURLString == "http://127.0.0.1:9000/shots/x.png")
+
+        let request = try S3CompatibleHTTP.signedPutRequest(
+            target: target,
+            region: "us-east-1",
+            accessKeyId: "AKID",
+            secretAccessKey: "SECRET",
+            payload: Data("x".utf8),
+            contentType: "image/png",
+            now: Self.fixedDate
+        )
+        #expect(request.url?.scheme == "http")
+        #expect(request.url?.absoluteString == "http://127.0.0.1:9000/shots/x.png")
+        #expect(request.value(forHTTPHeaderField: "Host") == "127.0.0.1:9000")
+    }
+
+    @Test("endpoint path is folded into the canonical URI, not the Host header")
+    func endpointPathGoesIntoCanonicalURI() throws {
+        let target = S3CompatibleHTTP.amazonS3Target(
+            bucket: "capso",
+            objectKey: "a.png",
+            region: "us-east-1",
+            endpoint: "https://minio.example.com/base"
+        )
+        #expect(target.scheme == "https")
+        #expect(target.host == "minio.example.com")
+        #expect(target.canonicalURI == "/base/capso/a.png")
+        #expect(target.requestURLString == "https://minio.example.com/base/capso/a.png")
+
+        let request = try S3CompatibleHTTP.signedPutRequest(
+            target: target,
+            region: "us-east-1",
+            accessKeyId: "AKID",
+            secretAccessKey: "SECRET",
+            payload: Data("x".utf8),
+            contentType: "image/png",
+            now: Self.fixedDate
+        )
+        #expect(request.value(forHTTPHeaderField: "Host") == "minio.example.com")
+        #expect(request.url?.path == "/base/capso/a.png")
+    }
+
+    @Test("bare host endpoint defaults to https")
+    func bareHostDefaultsToHTTPS() {
+        let parsed = S3CompatibleHTTP.parseEndpoint("minio.lan:9000")
+        #expect(parsed == .init(scheme: "https", host: "minio.lan:9000", pathPrefix: ""))
     }
 
     @Test("R2 target uses account endpoint and path-style bucket")
@@ -63,6 +114,7 @@ struct S3CompatibleHTTPTests {
             bucket: "capso",
             objectKey: "a/b.png"
         )
+        #expect(target.scheme == "https")
         #expect(target.host == "abc123.r2.cloudflarestorage.com")
         #expect(target.canonicalURI == "/capso/a/b.png")
     }
@@ -75,53 +127,30 @@ struct S3CompatibleHTTPTests {
             objectKey: "x.png"
         )
         #expect(target.host == "abc123.r2.cloudflarestorage.com")
-    }
-
-    @Test("R2 account ID normalization strips scheme and trailing slash")
-    func r2NormalizeHelpers() {
-        #expect(S3CompatibleHTTP.normalizeAccountID("abc123") == "abc123")
         #expect(S3CompatibleHTTP.normalizeAccountID("https://abc123.r2.cloudflarestorage.com/") == "abc123")
-        #expect(S3CompatibleHTTP.stripScheme("https://minio.example.com/") == "minio.example.com")
-        #expect(S3CompatibleHTTP.stripScheme("http://minio.example.com") == "minio.example.com")
+        #expect(S3CompatibleHTTP.normalizeAccountID("abc123") == "abc123")
     }
 
-    // MARK: - Path encoding (capcap AWSV4Signer.encodePath)
+    // MARK: - SigV4 PUT
 
-    @Test("encodePath percent-encodes segments and preserves slashes")
-    func encodePathRules() {
-        #expect(S3CompatibleHTTP.encodePath("a/b c.png") == "a/b%20c.png")
-        #expect(S3CompatibleHTTP.encodePath("已截图.png") == "%E5%B7%B2%E6%88%AA%E5%9B%BE.png")
-        #expect(S3CompatibleHTTP.encodePath("a+b~c_d-e.f") == "a%2Bb~c_d-e.f")
-        // Empty segments from leading / doubled slashes are preserved.
-        #expect(S3CompatibleHTTP.encodePath("/leading") == "/leading")
-        #expect(S3CompatibleHTTP.encodePath("a//b") == "a//b")
-    }
-
-    @Test("encodePath matches ShareConfig.encodeObjectKey")
-    func encodePathMatchesShareConfig() {
-        let keys = ["plain.png", "has space.mp4", "path/nested/file.gif", "emoji-🎬.mov"]
-        for key in keys {
-            #expect(S3CompatibleHTTP.encodePath(key) == ShareConfig.encodeObjectKey(key))
-        }
-    }
-
-    // MARK: - SigV4 PUT (capcap AWSV4Signer.signedPutRequest)
-
-    @Test("signed PUT matches capcap payload-hash SigV4 shape")
-    func signedPutMatchesCapcapShape() throws {
+    @Test("signed PUT uses payload-hash SigV4 shape")
+    func signedPutShape() throws {
         let payload = Data("hello-capso".utf8)
         let payloadHash = Self.sha256Hex(payload)
-        let date = Self.fixedDate
+        let target = S3CompatibleHTTP.Target(
+            scheme: "https",
+            host: "capso.s3.us-east-1.amazonaws.com",
+            canonicalURI: "/demo.mp4"
+        )
 
         let request = try S3CompatibleHTTP.signedPutRequest(
-            host: "capso.s3.us-east-1.amazonaws.com",
-            canonicalURI: "/demo.mp4",
+            target: target,
             region: "us-east-1",
             accessKeyId: "AKIAIOSFODNN7EXAMPLE",
             secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
             payload: payload,
             contentType: "video/mp4",
-            now: date
+            now: Self.fixedDate
         )
 
         #expect(request.httpMethod == "PUT")
@@ -138,52 +167,47 @@ struct S3CompatibleHTTPTests {
         #expect(authorization.contains("Signature="))
     }
 
-    @Test("signed PUT Authorization matches an independent capcap-style signer")
-    func signedPutMatchesIndependentCapcapSigner() throws {
+    @Test("signed PUT Authorization matches an independent SigV4 implementation")
+    func signedPutMatchesIndependentSigner() throws {
         let payload = Data("wire-compatible".utf8)
-        let date = Self.fixedDate
-        let host = "bucket.s3.us-west-2.amazonaws.com"
-        let uri = "/clips/demo.mp4"
-        let region = "us-west-2"
-        let accessKey = "AKIDEXAMPLE"
-        let secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-        let contentType = "video/mp4"
-
+        let target = S3CompatibleHTTP.Target(
+            scheme: "https",
+            host: "bucket.s3.us-west-2.amazonaws.com",
+            canonicalURI: "/clips/demo.mp4"
+        )
         let request = try S3CompatibleHTTP.signedPutRequest(
-            host: host,
-            canonicalURI: uri,
-            region: region,
-            accessKeyId: accessKey,
-            secretAccessKey: secret,
+            target: target,
+            region: "us-west-2",
+            accessKeyId: "AKIDEXAMPLE",
+            secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
             payload: payload,
-            contentType: contentType,
-            now: date
+            contentType: "video/mp4",
+            now: Self.fixedDate
         )
 
-        let expected = Self.capcapStyleAuthorization(
+        let expected = Self.independentAuthorization(
             method: "PUT",
-            host: host,
-            canonicalURI: uri,
-            region: region,
-            accessKeyId: accessKey,
-            secretAccessKey: secret,
-            contentType: contentType,
+            host: target.host,
+            canonicalURI: target.canonicalURI,
+            region: "us-west-2",
+            accessKeyId: "AKIDEXAMPLE",
+            secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            contentType: "video/mp4",
             payloadHash: Self.sha256Hex(payload),
-            now: date
+            now: Self.fixedDate
         )
         #expect(request.value(forHTTPHeaderField: "Authorization") == expected)
     }
 
-    @Test("R2 PUT signs with region auto like capcap R2Uploader")
+    @Test("R2 PUT signs with region auto")
     func r2PutUsesAutoRegion() throws {
-        let payload = Data("r2".utf8)
+        let target = S3CompatibleHTTP.r2Target(accountID: "abc123", bucket: "capso", objectKey: "shot.png")
         let request = try S3CompatibleHTTP.signedPutRequest(
-            host: "abc123.r2.cloudflarestorage.com",
-            canonicalURI: "/capso/shot.png",
+            target: target,
             region: "auto",
             accessKeyId: "AKID",
             secretAccessKey: "SECRET",
-            payload: payload,
+            payload: Data("r2".utf8),
             contentType: "image/png",
             now: Self.fixedDate
         )
@@ -194,27 +218,29 @@ struct S3CompatibleHTTPTests {
     @Test("payload-hash overload and explicit hash overload produce the same signature")
     func payloadAndHashOverloadsMatch() throws {
         let payload = Data("same-bytes".utf8)
-        let date = Self.fixedDate
-        let fromPayload = try S3CompatibleHTTP.signedPutRequest(
+        let target = S3CompatibleHTTP.Target(
+            scheme: "https",
             host: "bucket.s3.us-east-1.amazonaws.com",
-            canonicalURI: "/k",
+            canonicalURI: "/k"
+        )
+        let fromPayload = try S3CompatibleHTTP.signedPutRequest(
+            target: target,
             region: "us-east-1",
             accessKeyId: "AKID",
             secretAccessKey: "SECRET",
             payload: payload,
             contentType: "text/plain",
-            now: date
+            now: Self.fixedDate
         )
         let fromHash = try S3CompatibleHTTP.signedPutRequest(
-            host: "bucket.s3.us-east-1.amazonaws.com",
-            canonicalURI: "/k",
+            target: target,
             region: "us-east-1",
             accessKeyId: "AKID",
             secretAccessKey: "SECRET",
             payloadHash: Self.sha256Hex(payload),
             contentLength: payload.count,
             contentType: "text/plain",
-            now: date
+            now: Self.fixedDate
         )
         #expect(fromPayload.value(forHTTPHeaderField: "Authorization") == fromHash.value(forHTTPHeaderField: "Authorization"))
         #expect(fromPayload.value(forHTTPHeaderField: "X-Amz-Content-Sha256") == fromHash.value(forHTTPHeaderField: "X-Amz-Content-Sha256"))
@@ -223,9 +249,13 @@ struct S3CompatibleHTTPTests {
 
     @Test("empty payload uses the AWS empty-body SHA-256")
     func emptyPayloadHash() throws {
-        let request = try S3CompatibleHTTP.signedPutRequest(
+        let target = S3CompatibleHTTP.Target(
+            scheme: "https",
             host: "bucket.s3.us-east-1.amazonaws.com",
-            canonicalURI: "/empty.txt",
+            canonicalURI: "/empty.txt"
+        )
+        let request = try S3CompatibleHTTP.signedPutRequest(
+            target: target,
             region: "us-east-1",
             accessKeyId: "AKID",
             secretAccessKey: "SECRET",
@@ -237,13 +267,53 @@ struct S3CompatibleHTTPTests {
         #expect(request.value(forHTTPHeaderField: "Content-Length") == "0")
     }
 
+    @Test("invalid request URL maps to unknown, not notConfigured")
+    func invalidURLMapsToUnknown() {
+        let target = S3CompatibleHTTP.Target(
+            scheme: "https",
+            host: "host with spaces",
+            canonicalURI: "/k"
+        )
+        #expect(throws: ShareError.self) {
+            _ = try S3CompatibleHTTP.signedPutRequest(
+                target: target,
+                region: "us-east-1",
+                accessKeyId: "AKID",
+                secretAccessKey: "SECRET",
+                payload: Data("x".utf8),
+                contentType: "text/plain",
+                now: Self.fixedDate
+            )
+        }
+        do {
+            _ = try S3CompatibleHTTP.signedPutRequest(
+                target: target,
+                region: "us-east-1",
+                accessKeyId: "AKID",
+                secretAccessKey: "SECRET",
+                payload: Data("x".utf8),
+                contentType: "text/plain",
+                now: Self.fixedDate
+            )
+            Issue.record("expected throw")
+        } catch let error as ShareError {
+            #expect(error == .unknown("Invalid S3 endpoint URL"))
+        } catch {
+            Issue.record("unexpected error \(error)")
+        }
+    }
+
     // MARK: - SigV4 DELETE
 
     @Test("signed DELETE uses empty payload hash and omits content-type")
     func signedDeleteShape() throws {
-        let request = try S3CompatibleHTTP.signedDeleteRequest(
+        let target = S3CompatibleHTTP.Target(
+            scheme: "https",
             host: "capso.s3.us-east-1.amazonaws.com",
-            canonicalURI: "/old.mp4",
+            canonicalURI: "/old.mp4"
+        )
+        let request = try S3CompatibleHTTP.signedDeleteRequest(
+            target: target,
             region: "us-east-1",
             accessKeyId: "AKID",
             secretAccessKey: "SECRET",
@@ -261,20 +331,18 @@ struct S3CompatibleHTTPTests {
 
     @Test("signed DELETE Authorization matches independent signer")
     func signedDeleteMatchesIndependentSigner() throws {
-        let host = "abc123.r2.cloudflarestorage.com"
-        let uri = "/capso/old.png"
+        let target = S3CompatibleHTTP.r2Target(accountID: "abc123", bucket: "capso", objectKey: "old.png")
         let request = try S3CompatibleHTTP.signedDeleteRequest(
-            host: host,
-            canonicalURI: uri,
+            target: target,
             region: "auto",
             accessKeyId: "AKID",
             secretAccessKey: "SECRET",
             now: Self.fixedDate
         )
-        let expected = Self.capcapStyleAuthorization(
+        let expected = Self.independentAuthorization(
             method: "DELETE",
-            host: host,
-            canonicalURI: uri,
+            host: target.host,
+            canonicalURI: target.canonicalURI,
             region: "auto",
             accessKeyId: "AKID",
             secretAccessKey: "SECRET",
@@ -304,7 +372,6 @@ struct S3CompatibleHTTPTests {
     func sha256FileMatchesDataLarge() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("capso-sha-large-\(UUID().uuidString).bin")
-        // 1.5 MiB forces more than one 1 MiB read chunk in sha256File.
         var data = Data(count: 1_500_000)
         for i in data.indices {
             data[i] = UInt8(i % 251)
@@ -325,10 +392,14 @@ struct S3CompatibleHTTPTests {
         try payload.write(to: url)
         defer { try? FileManager.default.removeItem(at: url) }
 
+        let target = S3CompatibleHTTP.Target(
+            scheme: "https",
+            host: "bucket.s3.us-east-1.amazonaws.com",
+            canonicalURI: "/clip.mp4"
+        )
         let fileDigest = try S3CompatibleHTTP.sha256File(url)
         let fromFile = try S3CompatibleHTTP.signedPutRequest(
-            host: "bucket.s3.us-east-1.amazonaws.com",
-            canonicalURI: "/clip.mp4",
+            target: target,
             region: "us-east-1",
             accessKeyId: "AKID",
             secretAccessKey: "SECRET",
@@ -338,8 +409,7 @@ struct S3CompatibleHTTPTests {
             now: Self.fixedDate
         )
         let fromMemory = try S3CompatibleHTTP.signedPutRequest(
-            host: "bucket.s3.us-east-1.amazonaws.com",
-            canonicalURI: "/clip.mp4",
+            target: target,
             region: "us-east-1",
             accessKeyId: "AKID",
             secretAccessKey: "SECRET",
@@ -373,9 +443,7 @@ struct S3CompatibleHTTPTests {
 
     @Test("maps missing bucket XML to a helpful unknown error")
     func mapsMissingBucket() {
-        let body = Data("""
-        <Error><Code>NoSuchBucket</Code><Message>gone</Message></Error>
-        """.utf8)
+        let body = Data("<Error><Code>NoSuchBucket</Code><Message>gone</Message></Error>".utf8)
         #expect(
             S3CompatibleHTTP.mapResponseError(statusCode: 404, body: body)
                 == .unknown("Bucket not found — verify the bucket name in Cloud Share settings")
@@ -401,7 +469,7 @@ struct S3CompatibleHTTPTests {
         )
     }
 
-    // MARK: - Destinations still construct
+    // MARK: - Destinations / public URL
 
     @Test("S3 and R2 destinations still construct through the factory")
     func destinationsConstruct() throws {
@@ -409,7 +477,7 @@ struct S3CompatibleHTTPTests {
             provider: .s3,
             urlPrefix: "https://cdn.example.com",
             bucket: "capso",
-            fields: ["region": "us-east-1", "endpoint": "https://minio.example.com"]
+            fields: ["region": "us-east-1", "endpoint": "http://minio.example.com"]
         )
         let r2 = ShareConfig(
             provider: .r2,
@@ -421,6 +489,18 @@ struct S3CompatibleHTTPTests {
         #expect(try ShareDestinationFactory.make(config: r2, accessKey: "id", secretKey: "secret") is R2Destination)
     }
 
+    @Test("publicURL does not trap on unusual encoded keys")
+    func publicURLIsNonTrapping() {
+        let config = ShareConfig(
+            provider: .s3,
+            urlPrefix: "https://cdn.example.com",
+            bucket: "capso",
+            fields: ["region": "us-east-1"]
+        )
+        let url = config.publicURL(forObjectKey: "a/b c.png")
+        #expect(url.absoluteString == "https://cdn.example.com/a/b%20c.png")
+    }
+
     // MARK: - Helpers
 
     private static let fixedDate = ISO8601DateFormatter().date(from: "2026-07-30T12:00:00Z")!
@@ -429,8 +509,9 @@ struct S3CompatibleHTTPTests {
         SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 
-    /// Independent reimplementation of capcap `AWSV4Signer` Authorization formatting.
-    private static func capcapStyleAuthorization(
+    /// Second implementation of the same SigV4 Authorization string — catches accidental
+    /// drift in the production signer, not a shared helper call.
+    private static func independentAuthorization(
         method: String,
         host: String,
         canonicalURI: String,


### PR DESCRIPTION
## Summary
- Fixes [#222](https://github.com/lzhgus/Capso/issues/222): after screen recording with Amazon S3 auto-upload, Capso could disappear because `S3Destination` / `R2Destination` loaded the whole file via Soto `putObject(Data)`.
- Replaces Soto with an in-house SigV4 + `URLSession.upload(fromFile:)` transport (payload-hash signing, virtual-hosted / path-style endpoints, R2 `auto` region).
- Preserves `http://` custom endpoints (LAN MinIO), folds endpoint path prefixes into the signed canonical URI, and maps transport failures to `ShareError.network`.
- Drops the Soto dependency from ShareKit; share links still come from the user-configured URL prefix.

## Test plan
- [x] `swift test --package-path Packages/ShareKit` (50 tests)
- [ ] Reproduce #222: enable S3 cloud share + auto-upload, record a longer clip, stop, confirm share link copies and Capso stays in the menu bar
- [ ] Smoke: screenshot auto-upload to S3 and R2 still returns a working public URL
- [ ] Cloud Share wizard “Test connection” still succeeds for S3 / R2
- [ ] Custom `http://host:port` S3-compatible endpoint still uploads

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New custom SigV4 signing and upload path for all S3/R2 cloud share traffic; well-tested but any signing or endpoint edge-case bug could break uploads or credentials handling.
> 
> **Overview**
> **Replaces Soto with an in-house S3/R2 transport** so large recordings are not loaded entirely into memory before upload (addresses app quit after recording with S3 auto-upload).
> 
> `S3Destination` and `R2Destination` now delegate PUT/DELETE to new **`S3CompatibleHTTP`**: AWS SigV4 with real payload SHA-256, chunked file hashing, and **`URLSession.upload(fromFile:)`** for uploads. The Soto dependency is removed from ShareKit. Custom endpoints keep **`http://`** and path prefixes in the signed canonical URI; R2 uses region **`auto`**. S3 XML/HTTP errors are mapped to existing **`ShareError`** cases (including **`InvalidToken`**).
> 
> **`ShareConfig`** public URL helpers no longer force-unwrap invalid URLs. A large **`S3CompatibleHTTPTests`** suite covers addressing, signing, hashing, and error mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad16167edc06eaabf1985a06f3b5814615947b96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->