### PR TITLE
fix: keep Launch at Login silent when menu bar icon is hidden

### DIFF
--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -23,7 +23,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private(set) var shareCoordinator: ShareCoordinator?
     private var preferencesWindow: PreferencesWindow?
     private var automationURLRequestBuffer = AutomationURLRequestBuffer()
-    private var receivedAutomationURLDuringLaunch = false
     private var imageFileOpenBuffer = ImageFileOpenBuffer()
     /// Sparkle update coordinator used by preferences and manual update checks.
     let updateManager = UpdateManager()
@@ -77,15 +76,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         performPendingAutomationURLAction()
         performPendingImageFileOpen()
         historyCoordinator?.runCleanup()
-
-        // Safety net: if the menu bar icon is hidden, the user has no obvious
-        // way to access settings, so surface Preferences on launch.
-        if !settings.showMenuBarIcon {
-            DispatchQueue.main.async { [weak self] in
-                guard let self, !receivedAutomationURLDuringLaunch else { return }
-                showPreferences()
-            }
-        }
 
         NotificationCenter.default.addObserver(
             forName: .openScreenshotSettings,
@@ -219,7 +209,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        receivedAutomationURLDuringLaunch = true
         automationURLRequestBuffer.enqueue(action)
         performPendingAutomationURLAction()
     }
@@ -258,9 +247,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DiagnosticLogger.append(message, category: "AutomationURL")
     }
 
-    /// Called when the user double-clicks the app while it's already running
-    /// (Spotlight, Launchpad, Finder). For an LSUIElement app with the menu
-    /// bar icon hidden, this is the user's only way back into Preferences.
+    /// Called when the user reopens the app while it's already running
+    /// (Spotlight, Launchpad, Finder). Launch — including Launch at Login —
+    /// stays silent. When the menu bar icon is hidden, reopen is the way back
+    /// into Preferences.
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         if !settings.showMenuBarIcon {
             showPreferences()


### PR DESCRIPTION
## Summary
- Stop auto-opening Capso Settings on launch when the menu bar icon is hidden.
- Launch at Login (and other cold starts) stay silent; reopening Capso from Spotlight/Launchpad/Finder still opens Settings as the recovery path.
- Fixes #226

## Test plan
- [ ] Enable Launch at Login, turn **off** Show Menu Bar Icon, restart/log out and back in — Capso should start with no Settings window
- [ ] With menu bar icon still hidden, open Capso again from Spotlight — Settings should appear
- [ ] With Show Menu Bar Icon **on**, Launch at Login and reopen both stay normal (no unexpected Settings window)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small AppDelegate launch/reopen behavior change with no auth, data, or security impact; regression risk is limited to menu-bar-hidden UX.
> 
> **Overview**
> **Launch no longer auto-opens Settings** when the menu bar icon is hidden. Cold starts—including Launch at Login—stay silent instead of surfacing Preferences as a “safety net.”
> 
> **Recovery path unchanged:** `applicationShouldHandleReopen` still opens Settings when the user reopens Capso from Spotlight, Launchpad, or Finder while the icon is hidden.
> 
> Removed the `receivedAutomationURLDuringLaunch` guard that skipped auto-open when an automation URL arrived during launch; that path is gone with the launch-time Preferences open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 674b5e3694bc31325dc04ff9c049388a73b2d729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->