### PR TITLE
fix: stop near-edge annotation drags from resizing the all-in-one selection

### DIFF
--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -1161,7 +1161,9 @@ final class AllInOneSelectionOverlayView: NSView {
     var onSelectionPreviewChanged: ((CGRect) -> Void)?
     var onSelectionChanged: ((CGRect) -> Void)?
     var onCancel: (() -> Void)?
-    var passesThroughSelectionBody = false
+    var passesThroughSelectionBody = false {
+        didSet { window?.invalidateCursorRects(for: self) }
+    }
 
     private enum DragOperation {
         case none
@@ -1180,6 +1182,12 @@ final class AllInOneSelectionOverlayView: NSView {
     private let minSelectionSize: CGSize
     private var activePreset: CapturePreset
     private let hitSlop: CGFloat = 26
+    /// Resize hot-zone reach while annotating (`passesThroughSelectionBody`).
+    /// The inner reach stays thin so a drag starting near—but inside—the edge
+    /// begins an annotation instead of a resize; the outer reach stays generous
+    /// because nothing outside the selection competes for those points.
+    private let annotationInnerHitSlop: CGFloat = 3
+    private let annotationOuterHitSlop: CGFloat = 12
     private var dragOperation: DragOperation = .none
     private var trackingArea: NSTrackingArea?
     /// Whether Shift is currently held, locking the drag to a 1:1 square.
@@ -1266,52 +1274,55 @@ final class AllInOneSelectionOverlayView: NSView {
             return
         }
 
-        let slop = hitSlop
-        let handleSize = slop * 2
-        let horizontalEdgeWidth = max(0, rect.width - handleSize)
-        let verticalEdgeHeight = max(0, rect.height - handleSize)
+        // Match `hitTarget(at:)`: while annotating, the resize zones stay thin
+        // inside the selection so they don't overlap the annotation area.
+        let innerSlop = passesThroughSelectionBody ? annotationInnerHitSlop : hitSlop
+        let outerSlop = passesThroughSelectionBody ? annotationOuterHitSlop : hitSlop
+        let bandWidth = innerSlop + outerSlop
+        let horizontalEdgeWidth = max(0, rect.width - innerSlop * 2)
+        let verticalEdgeHeight = max(0, rect.height - innerSlop * 2)
 
         addCursorRect(
-            CGRect(x: rect.minX - slop, y: rect.maxY - slop, width: handleSize, height: handleSize),
+            CGRect(x: rect.minX - outerSlop, y: rect.maxY - innerSlop, width: bandWidth, height: bandWidth),
             cursor: AllInOneResizeCursor.topLeft
         )
         addCursorRect(
-            CGRect(x: rect.maxX - slop, y: rect.maxY - slop, width: handleSize, height: handleSize),
+            CGRect(x: rect.maxX - innerSlop, y: rect.maxY - innerSlop, width: bandWidth, height: bandWidth),
             cursor: AllInOneResizeCursor.topRight
         )
         addCursorRect(
-            CGRect(x: rect.maxX - slop, y: rect.minY - slop, width: handleSize, height: handleSize),
+            CGRect(x: rect.maxX - innerSlop, y: rect.minY - outerSlop, width: bandWidth, height: bandWidth),
             cursor: AllInOneResizeCursor.bottomRight
         )
         addCursorRect(
-            CGRect(x: rect.minX - slop, y: rect.minY - slop, width: handleSize, height: handleSize),
+            CGRect(x: rect.minX - outerSlop, y: rect.minY - outerSlop, width: bandWidth, height: bandWidth),
             cursor: AllInOneResizeCursor.bottomLeft
         )
 
         if horizontalEdgeWidth > 0 {
             addCursorRect(
-                CGRect(x: rect.minX + slop, y: rect.maxY - slop, width: horizontalEdgeWidth, height: handleSize),
+                CGRect(x: rect.minX + innerSlop, y: rect.maxY - innerSlop, width: horizontalEdgeWidth, height: bandWidth),
                 cursor: AllInOneResizeCursor.vertical
             )
             addCursorRect(
-                CGRect(x: rect.minX + slop, y: rect.minY - slop, width: horizontalEdgeWidth, height: handleSize),
+                CGRect(x: rect.minX + innerSlop, y: rect.minY - outerSlop, width: horizontalEdgeWidth, height: bandWidth),
                 cursor: AllInOneResizeCursor.vertical
             )
         }
 
         if verticalEdgeHeight > 0 {
             addCursorRect(
-                CGRect(x: rect.minX - slop, y: rect.minY + slop, width: handleSize, height: verticalEdgeHeight),
+                CGRect(x: rect.minX - outerSlop, y: rect.minY + innerSlop, width: bandWidth, height: verticalEdgeHeight),
                 cursor: AllInOneResizeCursor.horizontal
             )
             addCursorRect(
-                CGRect(x: rect.maxX - slop, y: rect.minY + slop, width: handleSize, height: verticalEdgeHeight),
+                CGRect(x: rect.maxX - innerSlop, y: rect.minY + innerSlop, width: bandWidth, height: verticalEdgeHeight),
                 cursor: AllInOneResizeCursor.horizontal
             )
         }
 
         if !passesThroughSelectionBody {
-            let bodyRect = rect.insetBy(dx: slop, dy: slop)
+            let bodyRect = rect.insetBy(dx: innerSlop, dy: innerSlop)
             if bodyRect.width > 0, bodyRect.height > 0 {
                 addCursorRect(bodyRect, cursor: .openHand)
             }
@@ -1330,11 +1341,7 @@ final class AllInOneSelectionOverlayView: NSView {
         squareLock = event.modifierFlags.contains(.shift)
 
         if let fixedSize = activePreset.fixedPixelSize {
-            if CaptureSelectionGeometry.hitTarget(
-                at: point,
-                selectionRect: selectionRect,
-                hitSlop: hitSlop
-            ) != nil {
+            if hitTarget(at: point) != nil {
                 dragOperation = .move(startRect: selectionRect, startPoint: point)
                 NSCursor.closedHand.set()
                 return
@@ -1352,11 +1359,7 @@ final class AllInOneSelectionOverlayView: NSView {
             return
         }
 
-        switch CaptureSelectionGeometry.hitTarget(
-            at: point,
-            selectionRect: selectionRect,
-            hitSlop: hitSlop
-        ) {
+        switch hitTarget(at: point) {
         case .resize(let handle):
             dragOperation = .resize(handle: handle, startRect: selectionRect)
             cursor(for: .resize(handle), at: point).set()
@@ -1506,23 +1509,35 @@ final class AllInOneSelectionOverlayView: NSView {
         }
 
         cursor(
-            for: CaptureSelectionGeometry.hitTarget(
-                at: point,
-                selectionRect: selectionRect,
-                hitSlop: hitSlop
-            ),
+            for: hitTarget(at: point),
             at: point,
         ).set()
+    }
+
+    /// Hit test used by mouse handling, cursor feedback, and event pass-through.
+    /// While annotating (`passesThroughSelectionBody`), the resize hot zone
+    /// reaches only a few points inside the selection so near-edge drags can
+    /// start an annotation; during initial selection the full `hitSlop` applies.
+    private func hitTarget(at point: CGPoint) -> CaptureSelectionHitTarget? {
+        if passesThroughSelectionBody {
+            return CaptureSelectionGeometry.hitTarget(
+                at: point,
+                selectionRect: selectionRect,
+                innerSlop: annotationInnerHitSlop,
+                outerSlop: annotationOuterHitSlop
+            )
+        }
+        return CaptureSelectionGeometry.hitTarget(
+            at: point,
+            selectionRect: selectionRect,
+            hitSlop: hitSlop
+        )
     }
 
     func wantsMouseEvents(at point: CGPoint) -> Bool {
         guard passesThroughSelectionBody else { return true }
 
-        switch CaptureSelectionGeometry.hitTarget(
-            at: point,
-            selectionRect: selectionRect,
-            hitSlop: hitSlop
-        ) {
+        switch hitTarget(at: point) {
         case .resize:
             return true
         case .move:

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -1184,9 +1184,11 @@ final class AllInOneSelectionOverlayView: NSView {
     private let hitSlop: CGFloat = 26
     /// Resize hot-zone reach while annotating (`passesThroughSelectionBody`).
     /// The inner reach stays thin so a drag starting near—but inside—the edge
-    /// begins an annotation instead of a resize; the outer reach stays generous
-    /// because nothing outside the selection competes for those points.
-    private let annotationInnerHitSlop: CGFloat = 3
+    /// begins an annotation instead of a resize; it still covers the 3.5pt
+    /// inner radius of the drawn handle dots so clicking a visible handle
+    /// always resizes. The outer reach stays generous because nothing outside
+    /// the selection competes for those points.
+    private let annotationInnerHitSlop: CGFloat = 4
     private let annotationOuterHitSlop: CGFloat = 12
     private var dragOperation: DragOperation = .none
     private var trackingArea: NSTrackingArea?
@@ -1536,6 +1538,12 @@ final class AllInOneSelectionOverlayView: NSView {
 
     func wantsMouseEvents(at point: CGPoint) -> Bool {
         guard passesThroughSelectionBody else { return true }
+        // Keep capturing for the whole gesture once a drag starts: the window's
+        // ignoresMouseEvents is re-evaluated on every event, so without this a
+        // pointer that strays from the edge mid-resize (min-size clamping,
+        // aspect ratio, fast movement) would flip the window to click-through
+        // and the drag would lose its mouseUp.
+        if case .none = dragOperation {} else { return true }
 
         switch hitTarget(at: point) {
         case .resize:

--- a/App/Tests/CaptureOverlayInteractionTests.swift
+++ b/App/Tests/CaptureOverlayInteractionTests.swift
@@ -302,8 +302,28 @@ final class CaptureOverlayInteractionTests: XCTestCase {
         XCTAssertFalse(view.wantsMouseEvents(at: CGPoint(x: 350, y: 260)))
         // …while pressing right on the border still resizes…
         XCTAssertTrue(view.wantsMouseEvents(at: CGPoint(x: 350, y: 358)))
+        // …including the inner half of the drawn handle dot (radius 3.5pt)…
+        XCTAssertTrue(view.wantsMouseEvents(at: CGPoint(x: 350, y: 356.5)))
         // …and the outside reach stays generous.
         XCTAssertTrue(view.wantsMouseEvents(at: CGPoint(x: 350, y: 370)))
+    }
+
+    func testAllInOneAnnotationModeKeepsCapturingUntilMouseUpDuringResize() throws {
+        let (view, _) = makeAllInOneOverlayView(activePreset: .freeform)
+        view.passesThroughSelectionBody = true
+
+        // Grab the top edge right on the border.
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 350, y: 358)))
+
+        // Mid-drag the pointer may stray far from the edge (min-size clamping,
+        // fast movement); the overlay must keep capturing or it loses mouseUp.
+        XCTAssertTrue(view.wantsMouseEvents(at: CGPoint(x: 350, y: 200)))
+        XCTAssertTrue(view.wantsMouseEvents(at: CGPoint(x: 60, y: 500)))
+
+        view.mouseUp(with: try makeMouseEvent(.leftMouseUp, at: NSPoint(x: 350, y: 330)))
+
+        // After the gesture ends, pass-through behavior is restored.
+        XCTAssertFalse(view.wantsMouseEvents(at: CGPoint(x: 350, y: 260)))
     }
 
     func testAllInOneAnnotationModeDragInsideNearEdgeDoesNotResizeSelection() throws {

--- a/App/Tests/CaptureOverlayInteractionTests.swift
+++ b/App/Tests/CaptureOverlayInteractionTests.swift
@@ -291,6 +291,45 @@ final class CaptureOverlayInteractionTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(previews.last), CGRect(x: 200, y: 426, width: 24, height: 24))
     }
 
+    func testAllInOneAnnotationModePassesThroughDragsStartingInsideNearEdge() throws {
+        let (view, _) = makeAllInOneOverlayView(activePreset: .freeform)
+        view.passesThroughSelectionBody = true
+
+        // Selection rect is (200, 160, 300, 200): top edge y = 360.
+        // A point 10pt inside the top edge belongs to the annotation canvas…
+        XCTAssertFalse(view.wantsMouseEvents(at: CGPoint(x: 350, y: 350)))
+        // …so does the selection body…
+        XCTAssertFalse(view.wantsMouseEvents(at: CGPoint(x: 350, y: 260)))
+        // …while pressing right on the border still resizes…
+        XCTAssertTrue(view.wantsMouseEvents(at: CGPoint(x: 350, y: 358)))
+        // …and the outside reach stays generous.
+        XCTAssertTrue(view.wantsMouseEvents(at: CGPoint(x: 350, y: 370)))
+    }
+
+    func testAllInOneAnnotationModeDragInsideNearEdgeDoesNotResizeSelection() throws {
+        let (view, previews) = makeAllInOneOverlayView(activePreset: .freeform)
+        view.passesThroughSelectionBody = true
+
+        // Starting 10pt inside the top edge must not begin a resize; if the
+        // event is delivered directly it moves the selection instead of
+        // shrinking it.
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 350, y: 350)))
+        view.mouseDragged(with: try makeMouseEvent(.leftMouseDragged, at: NSPoint(x: 360, y: 340)))
+
+        XCTAssertEqual(try XCTUnwrap(previews.last), CGRect(x: 210, y: 150, width: 300, height: 200))
+    }
+
+    func testAllInOneAnnotationModeDragOnBorderStillResizesSelection() throws {
+        let (view, previews) = makeAllInOneOverlayView(activePreset: .freeform)
+        view.passesThroughSelectionBody = true
+
+        // Pressing within 3pt of the border (inside) still grabs the top edge.
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 350, y: 358)))
+        view.mouseDragged(with: try makeMouseEvent(.leftMouseDragged, at: NSPoint(x: 350, y: 330)))
+
+        XCTAssertEqual(try XCTUnwrap(previews.last), CGRect(x: 200, y: 160, width: 300, height: 170))
+    }
+
     private func makeAreaOverlayView(
         settings: AppSettings,
         allowsMultiWindowSelection: Bool = true

--- a/Packages/CaptureKit/Sources/CaptureKit/CaptureSelectionGeometry.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/CaptureSelectionGeometry.swift
@@ -341,32 +341,58 @@ public enum CaptureSelectionGeometry {
         selectionRect: CGRect,
         hitSlop: CGFloat
     ) -> CaptureSelectionHitTarget? {
-        let rect = selectionRect.standardized
         let slop = max(1, hitSlop)
+        return hitTarget(
+            at: point,
+            selectionRect: selectionRect,
+            innerSlop: slop,
+            outerSlop: slop
+        )
+    }
 
-        if isNear(point, CGPoint(x: rect.minX, y: rect.maxY), slop: slop) {
+    /// Asymmetric hit test: `innerSlop` bounds how far the resize hot zone
+    /// reaches *inside* the selection, `outerSlop` how far it reaches outside
+    /// the border. Keeping the inner slop thin lets drags that start near—but
+    /// inside—the edge begin an annotation instead of a resize, while points
+    /// exactly on the border (or outside it) still resize.
+    public static func hitTarget(
+        at point: CGPoint,
+        selectionRect: CGRect,
+        innerSlop: CGFloat,
+        outerSlop: CGFloat
+    ) -> CaptureSelectionHitTarget? {
+        let rect = selectionRect.standardized
+        let inner = max(0, innerSlop)
+        let outer = max(0, outerSlop)
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+
+        if isNearCorner(point, corner: CGPoint(x: rect.minX, y: rect.maxY), toward: center, innerSlop: inner, outerSlop: outer) {
             return .resize(.topLeft)
         }
-        if isNear(point, CGPoint(x: rect.maxX, y: rect.maxY), slop: slop) {
+        if isNearCorner(point, corner: CGPoint(x: rect.maxX, y: rect.maxY), toward: center, innerSlop: inner, outerSlop: outer) {
             return .resize(.topRight)
         }
-        if isNear(point, CGPoint(x: rect.maxX, y: rect.minY), slop: slop) {
+        if isNearCorner(point, corner: CGPoint(x: rect.maxX, y: rect.minY), toward: center, innerSlop: inner, outerSlop: outer) {
             return .resize(.bottomRight)
         }
-        if isNear(point, CGPoint(x: rect.minX, y: rect.minY), slop: slop) {
+        if isNearCorner(point, corner: CGPoint(x: rect.minX, y: rect.minY), toward: center, innerSlop: inner, outerSlop: outer) {
             return .resize(.bottomLeft)
         }
-        if abs(point.y - rect.maxY) <= slop, point.x >= rect.minX, point.x <= rect.maxX {
-            return .resize(.top)
+        if point.x >= rect.minX, point.x <= rect.maxX {
+            if isNearEdge(inwardDistance: rect.maxY - point.y, innerSlop: inner, outerSlop: outer) {
+                return .resize(.top)
+            }
+            if isNearEdge(inwardDistance: point.y - rect.minY, innerSlop: inner, outerSlop: outer) {
+                return .resize(.bottom)
+            }
         }
-        if abs(point.x - rect.maxX) <= slop, point.y >= rect.minY, point.y <= rect.maxY {
-            return .resize(.right)
-        }
-        if abs(point.y - rect.minY) <= slop, point.x >= rect.minX, point.x <= rect.maxX {
-            return .resize(.bottom)
-        }
-        if abs(point.x - rect.minX) <= slop, point.y >= rect.minY, point.y <= rect.maxY {
-            return .resize(.left)
+        if point.y >= rect.minY, point.y <= rect.maxY {
+            if isNearEdge(inwardDistance: rect.maxX - point.x, innerSlop: inner, outerSlop: outer) {
+                return .resize(.right)
+            }
+            if isNearEdge(inwardDistance: point.x - rect.minX, innerSlop: inner, outerSlop: outer) {
+                return .resize(.left)
+            }
         }
         if rect.contains(point) {
             return .move
@@ -387,8 +413,30 @@ public enum CaptureSelectionGeometry {
         return Swift.min(Swift.max(value, minimum), maximum)
     }
 
-    private static func isNear(_ point: CGPoint, _ target: CGPoint, slop: CGFloat) -> Bool {
-        abs(point.x - target.x) <= slop && abs(point.y - target.y) <= slop
+    private static func isNearCorner(
+        _ point: CGPoint,
+        corner: CGPoint,
+        toward center: CGPoint,
+        innerSlop: CGFloat,
+        outerSlop: CGFloat
+    ) -> Bool {
+        let xIsInside = center.x >= corner.x ? point.x >= corner.x : point.x <= corner.x
+        let yIsInside = center.y >= corner.y ? point.y >= corner.y : point.y <= corner.y
+        let xSlop = xIsInside ? innerSlop : outerSlop
+        let ySlop = yIsInside ? innerSlop : outerSlop
+        return abs(point.x - corner.x) <= xSlop && abs(point.y - corner.y) <= ySlop
+    }
+
+    /// `inwardDistance` is the point's signed distance from the edge, positive
+    /// toward the inside of the selection.
+    private static func isNearEdge(
+        inwardDistance: CGFloat,
+        innerSlop: CGFloat,
+        outerSlop: CGFloat
+    ) -> Bool {
+        inwardDistance >= 0
+            ? inwardDistance <= innerSlop
+            : -inwardDistance <= outerSlop
     }
 
     private static func direction(

--- a/Packages/CaptureKit/Tests/CaptureKitTests/CaptureSelectionGeometryTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/CaptureSelectionGeometryTests.swift
@@ -87,6 +87,63 @@ struct CaptureSelectionGeometryTests {
         #expect(outside == nil)
     }
 
+    @Test("Asymmetric hit testing keeps the resize zone thin inside the selection")
+    func asymmetricHitTestingKeepsInnerZoneThin() {
+        let rect = CGRect(x: 100, y: 90, width: 120, height: 80)
+
+        func target(at point: CGPoint) -> CaptureSelectionHitTarget? {
+            CaptureSelectionGeometry.hitTarget(
+                at: point,
+                selectionRect: rect,
+                innerSlop: 3,
+                outerSlop: 12
+            )
+        }
+
+        // 10pt inside the top edge: belongs to the body (annotation), not resize.
+        #expect(target(at: CGPoint(x: 160, y: rect.maxY - 10)) == .move)
+        // 10pt inside a corner: still the body, not a corner resize.
+        #expect(target(at: CGPoint(x: rect.minX + 10, y: rect.maxY - 10)) == .move)
+        // Pressing right on the border resizes.
+        #expect(target(at: CGPoint(x: 160, y: rect.maxY - 1)) == .resize(.top))
+        #expect(target(at: CGPoint(x: rect.minX + 1, y: rect.maxY - 1)) == .resize(.topLeft))
+        // The outside reach stays generous.
+        #expect(target(at: CGPoint(x: 160, y: rect.maxY + 10)) == .resize(.top))
+        #expect(target(at: CGPoint(x: rect.minX - 10, y: rect.maxY + 10)) == .resize(.topLeft))
+        // Far outside hits nothing.
+        #expect(target(at: CGPoint(x: 160, y: rect.maxY + 20)) == nil)
+    }
+
+    @Test("Symmetric hitSlop matches the asymmetric form with equal slops")
+    func symmetricHitSlopMatchesAsymmetricForm() {
+        let rect = CGRect(x: 100, y: 90, width: 120, height: 80)
+        let probes = [
+            CGPoint(x: 110, y: 100),
+            CGPoint(x: 219, y: 169),
+            CGPoint(x: 160, y: 175),
+            CGPoint(x: 160, y: 165),
+            CGPoint(x: 95, y: 130),
+            CGPoint(x: 150, y: 120),
+            CGPoint(x: 20, y: 20),
+        ]
+
+        for probe in probes {
+            let symmetric = CaptureSelectionGeometry.hitTarget(
+                at: probe,
+                selectionRect: rect,
+                hitSlop: 12
+            )
+            let asymmetric = CaptureSelectionGeometry.hitTarget(
+                at: probe,
+                selectionRect: rect,
+                innerSlop: 12,
+                outerSlop: 12
+            )
+
+            #expect(symmetric == asymmetric)
+        }
+    }
+
     @Test("Fitting an aspect ratio keeps the selection centered")
     func fittingAspectRatioKeepsCenter() {
         let rect = CGRect(x: 100, y: 90, width: 200, height: 80)


### PR DESCRIPTION
## Problem

In all-in-one capture, after selecting a window and entering annotation mode, starting an annotation drag near (but inside) the window edge was misinterpreted as a selection resize. The cursor never touched the edge — it was just close to it.

Fixes #229

## Root cause

`AllInOneSelectionOverlayView` used a 26pt hit slop on **both** sides of the selection border. While annotating (`passesThroughSelectionBody`), `wantsMouseEvents` still claimed any point within 26pt inside the edge as `.resize`, swallowing the annotation drag start.

## Fix

Following how comparable apps keep the resize hot zone thin (capcap: 8 handle dots only, 6pt each side; macshot: 6pt band straddling the border; CleanShot X: visible handles only):

- `CaptureSelectionGeometry.hitTarget` gains an asymmetric `innerSlop`/`outerSlop` variant; the symmetric `hitSlop` API delegates to it with unchanged behavior.
- While annotating, the all-in-one overlay uses **3pt inside / 12pt outside**: pressing right on the border still resizes, but drags starting near yet inside the edge begin an annotation. The initial selection phase keeps the original 26pt slop.
- Mouse handling, cursor feedback, cursor rects, and event pass-through all share one `hitTarget(at:)` helper so the cursor zone always matches the click zone.

## Tests

- CaptureKit: 80/80 pass, including new tests for the thin inner zone and symmetric/asymmetric equivalence.
- App: `CaptureOverlayInteractionTests` 15/15 pass, including 3 new regression tests (10pt inside the edge passes through to annotation, on-border still resizes, a directly delivered event moves instead of resizing).

## Manual verification

Verified by the reporter's scenario in #229: annotating near a selected window's edge now draws instead of resizing; pressing the border itself still resizes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized capture overlay interaction changes with preserved initial-selection behavior and broad regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes near-edge annotation drags being treated as selection resizes in all-in-one capture after a window is selected (#229).
> 
> **CaptureKit** adds asymmetric `innerSlop` / `outerSlop` on `CaptureSelectionGeometry.hitTarget`; the existing symmetric `hitSlop` API delegates to it so other callers keep the same behavior.
> 
> **All-in-one overlay** routes mouse handling, cursors, cursor rects, and `wantsMouseEvents` through one `hitTarget(at:)`. In annotation mode (`passesThroughSelectionBody`), resize zones use **4pt inside / 12pt outside** instead of 26pt on both sides, so drags slightly inside the border pass through to the annotation layer while border and handle presses still resize. Initial selection still uses the full 26pt slop. Active resize drags keep capturing events until `mouseUp` so mid-gesture pointer movement does not drop the gesture.
> 
> Tests cover asymmetric geometry, symmetric equivalence, and four interaction regressions for pass-through, resize capture, and border vs near-edge drags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eec3a854b5a39bffd01f2cc88d5742289465b62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->