### PR TITLE
fix: avoid repeated fixed content in scrolling captures

### DIFF
--- a/Packages/CaptureKit/Sources/CaptureKit/Scrolling/ScrollStitcher.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/Scrolling/ScrollStitcher.swift
@@ -75,11 +75,8 @@ public final class ScrollStitcher: @unchecked Sendable {
         // CGContext origin is bottom-left.
         //
         // Canvas layout:
-        //   top:    merged image (non-overlapping portion)
-        //   bottom: entire new frame (covers overlap zone + new content)
-        //
-        // The overlap region is overwritten by the new frame's data,
-        // which is pixel-perfect for the current scroll position.
+        //   top:    existing merged image
+        //   bottom: newly revealed rows from the current frame
 
         // 1. Draw existing merged image at the top
         ctx.draw(mergedImage, in: CGRect(
@@ -89,35 +86,22 @@ public final class ScrollStitcher: @unchecked Sendable {
             height: totalHeight
         ))
 
-        // 2. Prepare the new frame (exclude sticky header if detected)
-        let drawFrame: CGImage
-        let drawHeight: Int
-
-        if headerHeight > 0 && headerHeight < frameHeight {
-            // Crop header from the new frame
-            let contentHeight = frameHeight - headerHeight
-            if let cropped = newFrame.cropping(to: CGRect(
-                x: 0, y: headerHeight, width: newFrame.width, height: contentHeight
-            )) {
-                drawFrame = cropped
-                drawHeight = contentHeight
-            } else {
-                drawFrame = newFrame
-                drawHeight = frameHeight
-            }
-        } else {
-            drawFrame = newFrame
-            drawHeight = frameHeight
+        // 2. Append only the newly revealed bottom rows. Re-drawing the full
+        //    frame would also re-draw fixed page elements whenever header
+        //    detection misses a dynamic pixel.
+        guard let newContent = newFrame.cropping(to: CGRect(
+            x: 0,
+            y: frameHeight - clampedRows,
+            width: newFrame.width,
+            height: clampedRows
+        )) else {
+            return .alignmentFailed
         }
-
-        // 3. Draw the entire new frame at the bottom of the canvas.
-        //    This naturally overlaps with the merged image in the overlap zone,
-        //    replacing it with the latest pixel data.
-        ctx.draw(drawFrame, in: CGRect(
+        ctx.draw(newContent, in: CGRect(
             x: 0,
             y: 0,
             width: mergedWidth,
-            height: drawHeight
+            height: clampedRows
         ))
 
         if let result = ctx.makeImage() {

--- a/Packages/CaptureKit/Tests/CaptureKitTests/ScrollStitcherTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/ScrollStitcherTests.swift
@@ -1,0 +1,144 @@
+import CoreGraphics
+import Testing
+@testable import CaptureKit
+
+@Suite("ScrollStitcher")
+struct ScrollStitcherTests {
+    @Test("A slightly changing fixed header is not repeated in the stitched image")
+    func changingFixedHeaderIsNotRepeated() throws {
+        let first = makeFrame(rowsTopToBottom: [
+            .red,
+            .orange,
+            .yellow,
+            .green,
+            .cyan,
+            .blue,
+        ])
+        let next = makeFrame(
+            rowsTopToBottom: [
+                .red,
+                .green,
+                .cyan,
+                .blue,
+                .purple,
+                .white,
+            ],
+            changedHeaderPixel: true
+        )
+
+        let stitcher = ScrollStitcher()
+        stitcher.setInitialFrame(first)
+        _ = stitcher.stitch(newFrame: next, detectedOffset: 2)
+
+        let result = try #require(stitcher.mergedImage)
+        #expect(result.height == 8)
+        #expect(rowsTopToBottom(in: result) == [
+            .red,
+            .orange,
+            .yellow,
+            .green,
+            .cyan,
+            .blue,
+            .purple,
+            .white,
+        ])
+    }
+
+    private enum RowColor: Equatable {
+        case red, orange, yellow, green, cyan, blue, purple, white
+
+        var components: (CGFloat, CGFloat, CGFloat, CGFloat) {
+            switch self {
+            case .red: (1, 0, 0, 1)
+            case .orange: (1, 0.5, 0, 1)
+            case .yellow: (1, 1, 0, 1)
+            case .green: (0, 1, 0, 1)
+            case .cyan: (0, 1, 1, 1)
+            case .blue: (0, 0, 1, 1)
+            case .purple: (0.5, 0, 1, 1)
+            case .white: (1, 1, 1, 1)
+            }
+        }
+    }
+
+    private func makeFrame(
+        rowsTopToBottom: [RowColor],
+        changedHeaderPixel: Bool = false
+    ) -> CGImage {
+        let width = 32
+        let height = rowsTopToBottom.count
+        let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+
+        for (topRow, color) in rowsTopToBottom.enumerated() {
+            let components = color.components
+            context.setFillColor(
+                red: components.0,
+                green: components.1,
+                blue: components.2,
+                alpha: components.3
+            )
+            context.fill(CGRect(x: 0, y: height - topRow - 1, width: width, height: 1))
+        }
+
+        if changedHeaderPixel {
+            context.setFillColor(red: 0, green: 0, blue: 0, alpha: 1)
+            context.fill(CGRect(x: 0, y: height - 1, width: 1, height: 1))
+        }
+
+        return context.makeImage()!
+    }
+
+    private func rowsTopToBottom(in image: CGImage) -> [RowColor] {
+        (0..<image.height).map { topRow in
+            classify(samplePixel(image, x: image.width / 2, y: image.height - topRow - 1))
+        }
+    }
+
+    private func samplePixel(
+        _ image: CGImage,
+        x: Int,
+        y: Int
+    ) -> (r: CGFloat, g: CGFloat, b: CGFloat) {
+        var pixel = [UInt8](repeating: 0, count: 4)
+        let context = CGContext(
+            data: &pixel,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        context.draw(image, in: CGRect(x: -x, y: -y, width: image.width, height: image.height))
+        return (
+            CGFloat(pixel[0]) / 255,
+            CGFloat(pixel[1]) / 255,
+            CGFloat(pixel[2]) / 255
+        )
+    }
+
+    private func classify(_ pixel: (r: CGFloat, g: CGFloat, b: CGFloat)) -> RowColor {
+        let candidates: [RowColor] = [.red, .orange, .yellow, .green, .cyan, .blue, .purple, .white]
+        return candidates.min { lhs, rhs in
+            distance(pixel, from: lhs) < distance(pixel, from: rhs)
+        }!
+    }
+
+    private func distance(
+        _ pixel: (r: CGFloat, g: CGFloat, b: CGFloat),
+        from color: RowColor
+    ) -> CGFloat {
+        let components = color.components
+        return abs(pixel.r - components.0)
+            + abs(pixel.g - components.1)
+            + abs(pixel.b - components.2)
+    }
+}


### PR DESCRIPTION
## What changed

- append only the newly revealed bottom rows from each scrolling frame
- avoid redrawing fixed or sticky page elements when their pixels change slightly between frames
- add a regression test covering a dynamic pixel inside a fixed header

## Root cause

The stitcher previously drew the entire newest frame over the overlap area. Fixed page elements therefore appeared again whenever fixed-header detection missed them, which can happen when Chrome changes even one pixel in the fixed region. The merged image accumulated those copies as artifacts.

## Verification

- swift test --package-path Packages/CaptureKit (79 tests passed)
- xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build
- manual Google Chrome scrolling-capture reproduction
- git diff --check

Fixes #231

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core scroll-capture compositing logic; overlap alignment now depends on detected offset and crop math rather than full-frame overwrite, which could affect edge cases (large offsets, mis-detected scroll) though the approach matches the intended scroll model.
> 
> **Overview**
> Scrolling capture stitching no longer redraws the **entire** new frame over the overlap zone. **`ScrollStitcher`** now keeps the existing merged image at the top and **crops and appends only the bottom `clampedRows`** from each frame, so fixed or sticky UI is not painted again when header detection misses a slightly changing pixel (e.g. Chrome).
> 
> The previous path that cropped by **`headerHeight`** and drew the full (or cropped) frame at the bottom was removed for this step. **`headerHeight`** is still detected on the first stitch but is no longer used during compositing.
> 
> A **`ScrollStitcherTests`** regression test verifies that a one-pixel header change does not duplicate header rows in the merged image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58d4a68152e35656d1fb5ea6045c35f93810ee47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->