### PR TITLE
fix: prewarm Vision OCR at launch to speed up first Capture Text (#233)

### DIFF
--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -2,6 +2,7 @@
 import AppKit
 import SharedKit
 import ShareKit
+import OCRKit
 import KeyboardShortcuts
 import Sparkle
 
@@ -101,6 +102,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         Task {
             await permissionManager.checkScreenRecordingPermission()
+        }
+        // Load Vision's OCR models off the critical path so the first
+        // "Capture Text" of a session doesn't stall on one-time model setup.
+        Task.detached(priority: .utility) {
+            await TextRecognizer.prewarm()
         }
     }
 

--- a/App/Sources/OCR/OCRCoordinator.swift
+++ b/App/Sources/OCR/OCRCoordinator.swift
@@ -34,7 +34,10 @@ final class OCRCoordinator {
     }
 
     private func beginInstantOCRFlow() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+        // Defer one run loop turn so the triggering event (menu click / global
+        // hotkey) fully settles before the overlay becomes key — without the
+        // previous fixed 150 ms wait on every invocation.
+        DispatchQueue.main.async { [weak self] in
             self?.showOverlayForOCR()
         }
     }

--- a/Packages/OCRKit/Sources/OCRKit/TextRecognizer.swift
+++ b/Packages/OCRKit/Sources/OCRKit/TextRecognizer.swift
@@ -98,6 +98,31 @@ public enum TextRecognizer {
         }
     }
 
+    /// Prewarm Vision's text-recognition models so the first real OCR request
+    /// doesn't pay the one-time model-loading cost. Runs a throwaway request
+    /// (with the same configuration as a real call) on a blank image.
+    /// Safe to call from a background task at app launch; errors are ignored.
+    public static func prewarm() async {
+        guard let image = makeBlankImage() else { return }
+        _ = try? await recognize(image: image, level: .accurate, detectURLs: false)
+    }
+
+    private static func makeBlankImage() -> CGImage? {
+        let size = 64
+        guard let context = CGContext(
+            data: nil,
+            width: size,
+            height: size,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+        context.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: size, height: size))
+        return context.makeImage()
+    }
+
     /// Convenience: recognize and return joined text string.
     public static func recognizeText(
         image: CGImage,

--- a/Packages/OCRKit/Tests/OCRKitTests/OCRKitTests.swift
+++ b/Packages/OCRKit/Tests/OCRKitTests/OCRKitTests.swift
@@ -12,4 +12,10 @@ final class OCRKitTests: XCTestCase {
 
         XCTAssertEqual(value, "first")
     }
+
+    /// Prewarm must complete without throwing or crashing, even though it
+    /// recognizes a blank image with no text in it.
+    func testPrewarmCompletes() async {
+        await TextRecognizer.prewarm()
+    }
 }


### PR DESCRIPTION
## Summary

Issue #233 reports that the first "Capture Text" after login is slow. This is cold-start latency, not a functional bug: the first `VNRecognizeTextRequest` in a process pays Vision's one-time model load (measured **~13.7s** in a fresh process on M4, via the new smoke test), and `OCRCoordinator` also inserted a fixed 150ms delay before every overlay.

Changes:

- **`TextRecognizer.prewarm()`** (OCRKit) — runs a throwaway `VNRecognizeTextRequest` on a 64×64 blank image with the same configuration as a real call (`.accurate` + automatic language detection), so models are loaded before the user ever triggers OCR.
- **App launch hook** — `AppDelegate` fires the prewarm in a detached `.utility` task, off the startup critical path.
- **Overlay delay** — replaces the fixed 150ms `asyncAfter` with a single run-loop deferral (still lets the triggering menu/hotkey event settle).

## Notes

- Verified the OCR recognition itself already runs off the main actor (OCRKit is Swift 6; the nonisolated async `recognize` executes on the generic executor), so no change was needed there.
- The prewarm matches current call sites, which all pass `languages: nil` → `automaticallyDetectsLanguage = true`.

## Testing

- `swift test --package-path Packages/OCRKit` — 2/2 pass (new prewarm smoke test included)
- `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` — succeeded
- Manual: quit and relaunch the app, then immediately trigger Capture Text (⇧⌥4) — first OCR should no longer stall.

Closes #233

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only changes to OCR startup and overlay timing; prewarm errors are ignored and behavior is unchanged once models are loaded.
> 
> **Overview**
> Addresses slow **first Capture Text** after launch by moving Vision’s one-time model load off the user path.
> 
> **OCRKit** adds `TextRecognizer.prewarm()`, which runs a throwaway `.accurate` `VNRecognizeTextRequest` on a small blank image (same config as real OCR). **App launch** kicks this off in a detached `.utility` task so startup stays off the critical path. **OCRCoordinator** drops the fixed **150 ms** delay before showing the selection overlay and defers only one main run-loop turn so hotkey/menu events can settle.
> 
> Adds a smoke test that `prewarm()` completes without crashing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44fb467aa2e00eccf8b49d295fd46bf4cb548aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->