### PR TITLE
fix: guard against nil system fonts in text attribute dictionaries

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationTextEditor.swift
+++ b/App/Sources/AnnotationEditor/AnnotationTextEditor.swift
@@ -1,5 +1,6 @@
 // App/Sources/AnnotationEditor/AnnotationTextEditor.swift
 import AppKit
+import SharedKit
 
 @MainActor
 protocol AnnotationTextEditorDelegate: AnyObject {
@@ -161,7 +162,7 @@ final class AnnotationTextEditor: NSScrollView {
     private var attributes: [NSAttributedString.Key: Any] {
         let effective = max(1, fontSize * zoomScale)
         let font = NSFont(name: fontName, size: effective)
-            ?? NSFont.systemFont(ofSize: effective, weight: .medium)
+            ?? NSFont.safeSystemFont(ofSize: effective, weight: .medium)
         let attrs: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: textColor,
@@ -173,7 +174,7 @@ final class AnnotationTextEditor: NSScrollView {
         guard let glyphStrokeColor, !text.isEmpty else { return }
         let effective = max(1, fontSize * zoomScale)
         let font = NSFont(name: fontName, size: effective)
-            ?? NSFont.systemFont(ofSize: effective, weight: .medium)
+            ?? NSFont.safeSystemFont(ofSize: effective, weight: .medium)
         let attrs: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: NSColor.clear,

--- a/App/Sources/AnnotationEditor/Crop/CropAreaNSView.swift
+++ b/App/Sources/AnnotationEditor/Crop/CropAreaNSView.swift
@@ -1,6 +1,7 @@
 // App/Sources/AnnotationEditor/Crop/CropAreaNSView.swift
 import AppKit
 import AnnotationKit
+import SharedKit
 
 final class CropAreaNSView: NSView {
     var cropRect: CGRect = .zero { didSet { needsDisplay = true } }
@@ -48,7 +49,7 @@ final class CropAreaNSView: NSView {
 
     private func drawDimensionBadge(ctx: CGContext, cropViewRect: CGRect) {
         let text = "\(Int(cropRect.width)) × \(Int(cropRect.height))"
-        let font = NSFont.monospacedSystemFont(ofSize: 11, weight: .semibold)
+        let font = NSFont.safeMonospacedSystemFont(ofSize: 11, weight: .semibold)
         let attrs: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: NSColor.white

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -1634,7 +1634,7 @@ final class AllInOneSelectionOverlayView: NSView {
 
     private func drawDimensionHUD(in context: CGContext, selectionRect: CGRect) {
         let text = CaptureSelectionChromeLayout.dimensionText(for: selectionRect.size) as NSString
-        let font = NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .semibold)
+        let font = NSFont.safeMonospacedDigitSystemFont(ofSize: 12, weight: .semibold)
         let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: NSColor.white,

--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -82,7 +82,7 @@ final class CaptureOverlayView: NSView {
     private let selectionInnerStrokeColor = NSColor.white.withAlphaComponent(0.30)
     private let windowHighlightColor = NSColor.systemBlue.withAlphaComponent(0.3)
     private let windowBorderColor = NSColor.systemBlue
-    private let dimensionFont = NSFont.monospacedSystemFont(ofSize: 12, weight: .medium)
+    private let dimensionFont = NSFont.safeMonospacedSystemFont(ofSize: 12, weight: .medium)
     private let dimensionBgColor = NSColor.black.withAlphaComponent(0.7)
     private let dimensionTextColor = NSColor.white
 
@@ -398,8 +398,8 @@ final class CaptureOverlayView: NSView {
         let hintText = "   R to change"
         let fullText = "\(presetName)\(hintText)"
 
-        let presetFont = NSFont.systemFont(ofSize: 12, weight: .semibold)
-        let hintFont = NSFont.systemFont(ofSize: 12, weight: .regular)
+        let presetFont = NSFont.safeSystemFont(ofSize: 12, weight: .semibold)
+        let hintFont = NSFont.safeSystemFont(ofSize: 12, weight: .regular)
 
         let presetAttrs: [NSAttributedString.Key: Any] = [
             .font: presetFont,
@@ -542,7 +542,7 @@ final class CaptureOverlayView: NSView {
     }
 
     private func drawBottomHintBadge(text: String, in context: CGContext) {
-        let font = NSFont.systemFont(ofSize: 13, weight: .medium)
+        let font = NSFont.safeSystemFont(ofSize: 13, weight: .medium)
         let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: dimensionTextColor
@@ -571,7 +571,7 @@ final class CaptureOverlayView: NSView {
     }
 
     private func drawWindowLabel(name: String, for rect: CGRect, in context: CGContext) {
-        let font = NSFont.systemFont(ofSize: 13, weight: .medium)
+        let font = NSFont.safeSystemFont(ofSize: 13, weight: .medium)
         let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: dimensionTextColor
@@ -665,7 +665,7 @@ final class CaptureOverlayView: NSView {
         if let badge = activePreset.badgeText {
             badgeText = badge
             badgeColor = activePreset.isFixedSize ? .systemGreen : .systemBlue
-            let badgeFont = NSFont.monospacedSystemFont(ofSize: 10, weight: .semibold)
+            let badgeFont = NSFont.safeMonospacedSystemFont(ofSize: 10, weight: .semibold)
             let badgeAttrs: [NSAttributedString.Key: Any] = [.font: badgeFont]
             let badgeSize = (badge as NSString).size(withAttributes: badgeAttrs)
             badgeWidth = badgeSize.width + 8
@@ -689,7 +689,7 @@ final class CaptureOverlayView: NSView {
 
         // Draw preset badge pill
         if let badge = badgeText {
-            let badgeFont = NSFont.monospacedSystemFont(ofSize: 10, weight: .semibold)
+            let badgeFont = NSFont.safeMonospacedSystemFont(ofSize: 10, weight: .semibold)
             let badgeTextAttrs: [NSAttributedString.Key: Any] = [
                 .font: badgeFont,
                 .foregroundColor: NSColor.white
@@ -748,7 +748,7 @@ final class CaptureOverlayView: NSView {
         let x = Int(point.x)
         let y = Int(bounds.height - point.y) // flip to screen coordinates
         let text = "\(x), \(y)"
-        let font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)
+        let font = NSFont.safeMonospacedSystemFont(ofSize: 11, weight: .regular)
         let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: NSColor.white.withAlphaComponent(0.8)
@@ -1201,7 +1201,7 @@ final class CaptureOverlayView: NSView {
 
     /// Create a non-interactive section header menu item.
     private func makeHeaderItem(_ title: String) -> NSMenuItem {
-        let font = NSFont.systemFont(ofSize: 10, weight: .semibold)
+        let font = NSFont.safeSystemFont(ofSize: 10, weight: .semibold)
         let attrs: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: NSColor.secondaryLabelColor

--- a/App/Sources/MenuBar/MenuBarController.swift
+++ b/App/Sources/MenuBar/MenuBarController.swift
@@ -222,12 +222,12 @@ final class MenuBarController: NSObject {
         let duration = "\(settings.selfTimerDurationSeconds)s"
         let attributed = NSMutableAttributedString(
             string: label,
-            attributes: [.font: NSFont.menuFont(ofSize: 0)]
+            attributes: [.font: NSFont.safeMenuFont(ofSize: 0)]
         )
         attributed.append(NSAttributedString(
             string: "   \(duration)",
             attributes: [
-                .font: NSFont.menuFont(ofSize: 0),
+                .font: NSFont.safeMenuFont(ofSize: 0),
                 .foregroundColor: NSColor.tertiaryLabelColor,
             ]
         ))

--- a/Packages/AnnotationKit/Sources/AnnotationKit/Objects/CounterObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/Objects/CounterObject.swift
@@ -2,6 +2,7 @@
 import Foundation
 import CoreGraphics
 import AppKit
+import SharedKit
 
 public final class CounterObject: AnnotationObject, @unchecked Sendable {
     public let id = ObjectID()
@@ -94,7 +95,7 @@ public final class CounterObject: AnnotationObject, @unchecked Sendable {
 
         let text = "\(number)" as NSString
         let fontSize: CGFloat = number < 10 ? radius * 1.1 : radius * 0.85
-        let font = NSFont.systemFont(ofSize: fontSize, weight: .bold)
+        let font = NSFont.safeSystemFont(ofSize: fontSize, weight: .bold)
         let attributes: [NSAttributedString.Key: Any] = [
             .font: font,
             .foregroundColor: NSColor.white,

--- a/Packages/AnnotationKit/Sources/AnnotationKit/Objects/TextObject.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/Objects/TextObject.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreGraphics
 import AppKit
+import SharedKit
 
 public final class TextObject: AnnotationObject, @unchecked Sendable {
     private static let glyphTraceStrokeWidth: CGFloat = 3.0
@@ -39,7 +40,7 @@ public final class TextObject: AnnotationObject, @unchecked Sendable {
     }
 
     private var fillAttributes: [NSAttributedString.Key: Any] {
-        let font = NSFont(name: fontName, size: fontSize) ?? NSFont.systemFont(ofSize: fontSize, weight: .medium)
+        let font = NSFont(name: fontName, size: fontSize) ?? NSFont.safeSystemFont(ofSize: fontSize, weight: .medium)
         return [
             .font: font,
             .foregroundColor: style.color.nsColor.withAlphaComponent(style.opacity),

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/SafeSystemFont.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/SafeSystemFont.swift
@@ -47,6 +47,18 @@ public extension NSFont {
         )
     }
 
+    /// Wraps `menuFont(ofSize:)`. A size of 0 asks for the default menu font
+    /// size, so the fallback chain resolves it to the standard menu size first.
+    static func safeMenuFont(ofSize size: CGFloat) -> NSFont {
+        let effective = size > 0 ? size : NSFont.systemFontSize(for: .regular)
+        return resolve(
+            NSFont.menuFont(ofSize: size),
+            NSFont.systemFont(ofSize: effective),
+            fallbackName: "Helvetica",
+            size: effective
+        )
+    }
+
     private static func resolve(
         _ primary: @autoclosure () -> NSFont?,
         _ secondary: @autoclosure () -> NSFont?,

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/SafeSystemFont.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/SafeSystemFont.swift
@@ -1,0 +1,70 @@
+import AppKit
+import CoreText
+
+/// AppKit's system-font factories are audited `nonnull`, so Swift imports them
+/// as non-optional `NSFont`. They can still hand back `nil` at runtime when the
+/// font system fails to vend the requested UI font. Swift stores that `nil`
+/// straight into a `[NSAttributedString.Key: Any]` literal, the literal bridges
+/// to an `NSDictionary` holding a NULL value, and the first
+/// `size(withAttributes:)` or `draw(at:withAttributes:)` aborts the process
+/// inside CoreText:
+///
+///     *** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]:
+///         attempt to insert nil object from objects[0]
+///
+/// A NULL `.font` is what triggers this — CoreText has to substitute a default
+/// font, and rebuilding the attribute dictionary to inject it is what copies
+/// the NULL. Other attributes such as `.foregroundColor` are not copied during
+/// measurement and so never abort.
+///
+/// These wrappers make the `nil` observable and fall back through progressively
+/// more basic fonts.
+public extension NSFont {
+    static func safeSystemFont(ofSize size: CGFloat, weight: NSFont.Weight) -> NSFont {
+        resolve(
+            NSFont.systemFont(ofSize: size, weight: weight),
+            NSFont.systemFont(ofSize: size),
+            fallbackName: "Helvetica",
+            size: size
+        )
+    }
+
+    static func safeMonospacedSystemFont(ofSize size: CGFloat, weight: NSFont.Weight) -> NSFont {
+        resolve(
+            NSFont.monospacedSystemFont(ofSize: size, weight: weight),
+            NSFont.userFixedPitchFont(ofSize: size),
+            fallbackName: "Menlo",
+            size: size
+        )
+    }
+
+    static func safeMonospacedDigitSystemFont(ofSize size: CGFloat, weight: NSFont.Weight) -> NSFont {
+        resolve(
+            NSFont.monospacedDigitSystemFont(ofSize: size, weight: weight),
+            NSFont.systemFont(ofSize: size),
+            fallbackName: "Helvetica",
+            size: size
+        )
+    }
+
+    private static func resolve(
+        _ primary: @autoclosure () -> NSFont?,
+        _ secondary: @autoclosure () -> NSFont?,
+        fallbackName: String,
+        size: CGFloat
+    ) -> NSFont {
+        if let font = validated(primary()) { return font }
+        if let font = validated(secondary()) { return font }
+        // CTFontCreateWithName substitutes a usable font when the requested name
+        // is unavailable, so it never yields NULL.
+        return unsafeBitCast(CTFontCreateWithName(fallbackName as CFString, size, nil), to: NSFont.self)
+    }
+
+    /// A null reference can reach here wearing a non-optional type, because the
+    /// nullability audit on the AppKit factories is not enforced at runtime.
+    /// Reinterpreting the bits is what makes it observable.
+    private static func validated(_ font: NSFont?) -> NSFont? {
+        guard let font else { return nil }
+        return unsafeBitCast(font, to: NSFont?.self)
+    }
+}

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ScreenshotTimestampRenderer.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ScreenshotTimestampRenderer.swift
@@ -119,7 +119,7 @@ public enum ScreenshotTimestampRenderer {
         NSGraphicsContext.current = NSGraphicsContext(cgContext: context, flipped: false)
         defer { NSGraphicsContext.restoreGraphicsState() }
 
-        let font = NSFont.monospacedDigitSystemFont(ofSize: CGFloat(options.fontSize), weight: .medium)
+        let font = NSFont.safeMonospacedDigitSystemFont(ofSize: CGFloat(options.fontSize), weight: .medium)
         let shadow = NSShadow()
         shadow.shadowColor = NSColor.black.withAlphaComponent(0.65)
         shadow.shadowBlurRadius = max(2, CGFloat(options.fontSize) * 0.16)


### PR DESCRIPTION
## Summary

Capso 1.0.0 (54) aborted every time the area-capture overlay opened, on macOS 26.5.2 (25F84), Apple Silicon. Three consecutive crashes, identical signature each time.

The cause is a nil `NSFont` reaching a text attributes dictionary. AppKit's system-font factories are audited `nonnull`, so Swift imports them as non-optional `NSFont` and never checks the result. When one of them returns nil anyway, the nil is stored straight into a `[NSAttributedString.Key: Any]` literal, that literal bridges to an `NSDictionary` holding a NULL value, and the first `size(withAttributes:)` aborts inside CoreText.

## Crash log

```
Process:             Capso [58129]
Version:             1.0.0 (54)
OS Version:          macOS 26.5.2 (25F84)
Exception Type:      EXC_CRASH (SIGABRT)
Termination Reason:  SIGNAL 6 Abort trap: 6

*** Terminating app due to uncaught exception 'NSInvalidArgumentException',
    reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]:
             attempt to insert nil object from objects[0]'

Last Exception Backtrace:
0   CoreFoundation      __exceptionPreprocess + 164
1   libobjc.A.dylib     objc_exception_throw + 88
2   CoreFoundation      -[__NSPlaceholderDictionary initWithObjects:forKeys:count:] + 764
3   CoreFoundation      -[NSDictionary initWithDictionary:copyItems:] + 420
4   CoreFoundation      -[__NSPlaceholderDictionary initWithDictionary:copyItems:] + 176
5   CoreText            TAttributes::ApplyFont(__CFDictionary const*, __CTFont const*,
                            TCharStream const*, CFRange, void const**) + 320
6   CoreText            TAttributes::TAttributes(__CFDictionary const*, TCharStream const*,
                            CFRange, bool) + 116
7   CoreText            TTypesetterAttrString::Initialize(__CFAttributedString const*, bool) + 720
8   CoreText            TTypesetterAttrString::TTypesetterAttrString(__CFAttributedString const*,
                            __CFDictionary const*, bool) + 160
9   CoreText            CTLineCreateWithAttributedString + 84
10  UIFoundation        __NSCoreTypesetterCreateBaseLineFromAttributedString + 704
11  UIFoundation        -[NSCoreTypesetter _stringDrawingCoreTextEngineWithOriginalString:
                            rect:padding:graphicsContext:forceClipping:attributes:
                            stringDrawingOptions:drawingContext:stringDrawingInterface:] + 2816
12  UIFoundation        __NSStringDrawingEngine + 1844
13  UIFoundation        -[NSString(NSExtendedStringDrawing)
                            boundingRectWithSize:options:attributes:context:] + 124
14  UIFoundation        -[NSString(NSStringDrawing) sizeWithAttributes:] + 40
15  Capso               <4 app frames, release binary is stripped>
19  AppKit              ...
23  AppKit              _NSViewDrawRect + 132
24  AppKit              -[NSView _recursive:displayRectIgnoringOpacity:inContext:
                            stopAtLayerBackedViews:] + 1084
25  AppKit              -[NSView(NSLayerKitGlue) _drawViewBackingLayer:inContext:
                            drawingHandler:] + 536
26  AppKit              -[NSViewBackingLayer drawInContext:] + 56
...
    QuartzCore          CA::Transaction::commit() + 648
    AppKit              -[NSApplication run] + 368
    SwiftUI             static App.main() + 224
```

Machine identifiers (device UUID, crash reporter key, sleep/wake UUID) stripped from the report.

Reproduction sequence, identical across all three crashes, from `log show --predicate 'process == "Capso"'`:

```
17:21:05.741  (AppKit) perform action for menu item          <- capture invoked from the menu bar
17:21:05.7    TCCAccessRequest -> ScreenCaptureKit SLSHWCaptureDesktopProxying
17:21:05.752  SkyLight: New connection ... secondary          <- overlay window created
17:21:06.980  *** Terminating app due to uncaught exception
```

So it dies on the overlay's first `draw(_:)`, roughly a second after the window appears.

## Root cause

The crashing call site is `CaptureOverlayView.drawCoordinateLabel(at:in:)` — the small "x, y" pill that tracks the cursor before a drag starts. It is the first text drawn in the overlay, which is why nothing else got a chance to fail first.

```swift
let font = NSFont.monospacedSystemFont(ofSize: 11, weight: .regular)   // returned nil
let attributes: [NSAttributedString.Key: Any] = [
    .font: font,                                                       // NULL stored here
    .foregroundColor: NSColor.white.withAlphaComponent(0.8)
]
let size = (text as NSString).size(withAttributes: attributes)         // aborts
```

Specifically a NULL `.font` is what triggers the abort, not just any NULL attribute. With no usable font, CoreText substitutes a default one, and `TAttributes::ApplyFont` rebuilds the attribute dictionary to inject it — that rebuild is the `initWithDictionary:copyItems:` that copies the NULL. Attributes such as `.foregroundColor` are not copied during measurement and never abort.

This was confirmed by constructing both malformed dictionaries directly:

| Attributes | Result |
|---|---|
| font + colour, both valid | OK — `61.1982 x 14` |
| **font = NULL**, colour valid | **abort, stack identical to the report incl. every symbol offset** |
| font valid, **colour = NULL** | OK — `61.1982 x 14` |

## Fix

New `NSFont` helpers in SharedKit:

```swift
NSFont.safeSystemFont(ofSize:weight:)
NSFont.safeMonospacedSystemFont(ofSize:weight:)
NSFont.safeMonospacedDigitSystemFont(ofSize:weight:)
```

Each tries the real AppKit factory, then a secondary (`userFixedPitchFont` / plain `systemFont`), then terminates at `CTFontCreateWithName`, which substitutes a usable font rather than returning NULL.

Detection uses `unsafeBitCast(font, to: NSFont?.self)`. The nullability audit means a null reference arrives wearing a non-optional type, and a plain `if let` invites the optimiser to fold the check away on the grounds that a non-optional cannot be nil.

18 call sites now route through the helpers — every place a font is fed into an attributes dictionary:

| File | Sites |
|---|---|
| `CaptureOverlayView.swift` | 9, incl. the crashing one and the `dimensionFont` stored property |
| `AnnotationTextEditor.swift` | 2 |
| `CaptureAllInOneToolbarWindow.swift` | 1 |
| `CropAreaNSView.swift` | 1 |
| `CounterObject.swift` | 1 |
| `TextObject.swift` | 1 |
| `ScreenshotTimestampRenderer.swift` | 1 |
| `MenuBarController.swift` | 2 |

A repo-wide grep finds no unguarded system-font factory calls left outside the helper.

## Testing

- `xcodebuild -scheme Capso -configuration Debug` — builds clean, no new warnings
- Release archive, universal (`x86_64 arm64`) — builds clean
- `swift test --package-path Packages/SharedKit` — 174 tests, 22 suites, passing
- `swift test --package-path Packages/AnnotationKit` — 93 tests, 15 suites, passing
- Helper logic exercised under `-O` against a forced-null font: normal path unchanged, null primary falls back to `Menlo-Regular`, both-null reaches the CTFont terminal, and `size(withAttributes:)` returns a size instead of aborting. The same program with the unguarded code reproduces the crash stack above.
- A Release build with this change has been running the capture overlay without crashing on the affected machine.

## Note on reproducibility

The nil looked transient rather than a permanently broken font install — `monospacedSystemFont` resolves correctly on the affected machine now, and `fontd` logged nothing abnormal during the crashes. I could not make the original trigger fire on demand, so the verification above is against a forced-null font rather than the original condition.

That does not change the defect: the API is documented `nonnull` but not guaranteed to be, several call sites trusted it, and any nil return aborts the process. This makes those paths degrade to a fallback font instead.

