### PR TITLE
fix: restore ⌘C copy-and-close when no annotation is selected

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -1242,6 +1242,13 @@ final class AnnotationCanvasNSView: NSView {
         }
     }
 
+    /// Handles annotation-object clipboard shortcuts (⌘C / ⌘V / ⌘D).
+    ///
+    /// - Returns: `true` when the event was consumed as an annotation action.
+    ///   For ⌘C, returns `true` only when a selected object was actually copied
+    ///   so callers can fall back to copy-image-and-close when nothing is selected.
+    ///   ⌘V / ⌘D always consume the chord while the canvas is active (even if
+    ///   the pasteboard/selection is empty), matching standard editor behavior.
     func performAnnotationClipboardShortcut(with event: NSEvent) -> Bool {
         let modifiers = event.modifierFlags.intersection([.command, .shift, .option, .control])
         guard modifiers == .command, textEditor == nil, let document else { return false }
@@ -1251,9 +1258,8 @@ final class AnnotationCanvasNSView: NSView {
         let changed: Bool
 
         switch event.keyCode {
-        case 8: // C
-            _ = annotationClipboard.copySelection(from: document)
-            return true
+        case 8: // C — only consume when a selection was copied; otherwise let callers fall back
+            return annotationClipboard.copySelection(from: document)
         case 9: // V
             changed = annotationClipboard.paste(into: document, offset: offset)
         case 2: // D

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -516,13 +516,19 @@ final class CaptureAllInOneToolbarWindow {
 
         guard modifiers == .command else { return event }
 
+        // Prefer annotation-object clipboard when a canvas object is selected.
+        // ⌘C returns false when nothing is selected so we can fall back below.
         if annotationOverlay?.performAnnotationClipboardShortcut(with: event) == true {
             return nil
         }
 
         switch event.charactersIgnoringModifiers?.lowercased() {
         case "c":
-            guard annotationOverlay == nil else { return event }
+            // Fall back to copy-image-and-close when no annotation object is
+            // selected. While editing text, leave ⌘C to the native text field.
+            if annotationOverlay?.isEditingText == true {
+                return event
+            }
             performCopyAction()
             return nil
         case "s":
@@ -1113,8 +1119,21 @@ private struct CaptureAllInOneToolbarView: View {
         }
     }
 
+    /// Shortcut string used inside the hover tooltip. Copy advertises every
+    /// binding that maps to copy-and-close — ⌘C (falls back when no annotation
+    /// object is selected), Return, and ⌘⇧C — so users can discover the
+    /// alternatives without having to guess (issue #237).
+    private func utilityHelpShortcut(for kind: UtilityAction) -> String? {
+        switch kind {
+        case .copy:
+            return "⌘C · ⏎ · ⌘⇧C"
+        case .save, .pin, .cancel, .annotate, .overflow:
+            return utilityShortcut(for: kind)
+        }
+    }
+
     private func utilityHelp(for kind: UtilityAction, fallback: LocalizedStringKey) -> Text {
-        guard let shortcut = utilityShortcut(for: kind) else {
+        guard let shortcut = utilityHelpShortcut(for: kind) else {
             return Text(fallback)
         }
 

--- a/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
@@ -32,20 +32,23 @@ struct ShortcutSettingsView: View {
         let id: String
         let scope: LocalizedStringKey
         let action: LocalizedStringKey
-        let shortcut: String
+        /// One or more keycaps to render for this action. `.copy` in
+        /// All-in-One lists all three bindings (⌘C, Return, ⌘⇧C) so users
+        /// discover Return and ⌘⇧C alongside ⌘C — see issue #237.
+        let shortcuts: [String]
     }
 
     private let contextualShortcuts: [ContextualShortcut] = [
-        ContextualShortcut(id: "all-in-one-copy", scope: "All-in-One", action: "Copy selected area", shortcut: "⌘C"),
-        ContextualShortcut(id: "all-in-one-save", scope: "All-in-One", action: "Save selected area", shortcut: "⌘S"),
-        ContextualShortcut(id: "all-in-one-pin", scope: "All-in-One", action: "Pin selected area", shortcut: "⌘P"),
-        ContextualShortcut(id: "all-in-one-cancel", scope: "All-in-One", action: "Cancel", shortcut: "Esc"),
-        ContextualShortcut(id: "window-multi-select", scope: "Window Capture", action: "Select multiple windows", shortcut: "⇧ + click"),
-        ContextualShortcut(id: "window-multi-confirm", scope: "Window Capture", action: "Capture selected windows", shortcut: "Release ⇧"),
-        ContextualShortcut(id: "quick-access-copy", scope: "Quick Access", action: "Copy", shortcut: "⌘C"),
-        ContextualShortcut(id: "quick-access-save", scope: "Quick Access", action: "Save", shortcut: "⌘S"),
-        ContextualShortcut(id: "quick-access-annotate", scope: "Quick Access", action: "Annotate", shortcut: "⌘E"),
-        ContextualShortcut(id: "quick-access-pin", scope: "Quick Access", action: "Pin", shortcut: "⌘P")
+        ContextualShortcut(id: "all-in-one-copy", scope: "All-in-One", action: "Copy selected area", shortcuts: ["⌘C", "⏎", "⌘⇧C"]),
+        ContextualShortcut(id: "all-in-one-save", scope: "All-in-One", action: "Save selected area", shortcuts: ["⌘S"]),
+        ContextualShortcut(id: "all-in-one-pin", scope: "All-in-One", action: "Pin selected area", shortcuts: ["⌘P"]),
+        ContextualShortcut(id: "all-in-one-cancel", scope: "All-in-One", action: "Cancel", shortcuts: ["Esc"]),
+        ContextualShortcut(id: "window-multi-select", scope: "Window Capture", action: "Select multiple windows", shortcuts: ["⇧ + click"]),
+        ContextualShortcut(id: "window-multi-confirm", scope: "Window Capture", action: "Capture selected windows", shortcuts: ["Release ⇧"]),
+        ContextualShortcut(id: "quick-access-copy", scope: "Quick Access", action: "Copy", shortcuts: ["⌘C"]),
+        ContextualShortcut(id: "quick-access-save", scope: "Quick Access", action: "Save", shortcuts: ["⌘S"]),
+        ContextualShortcut(id: "quick-access-annotate", scope: "Quick Access", action: "Annotate", shortcuts: ["⌘E"]),
+        ContextualShortcut(id: "quick-access-pin", scope: "Quick Access", action: "Pin", shortcuts: ["⌘P"])
     ]
 
     var body: some View {
@@ -128,7 +131,11 @@ struct ShortcutSettingsView: View {
 
     private func contextualShortcutRow(_ item: ContextualShortcut, showDivider: Bool = false) -> some View {
         SettingRow(label: item.action, sublabel: item.scope, showDivider: showDivider) {
-            ShortcutKeycap(text: item.shortcut)
+            HStack(spacing: 6) {
+                ForEach(Array(item.shortcuts.enumerated()), id: \.offset) { _, shortcut in
+                    ShortcutKeycap(text: shortcut)
+                }
+            }
         }
     }
 }

--- a/App/Tests/AnnotationCanvasClipboardShortcutTests.swift
+++ b/App/Tests/AnnotationCanvasClipboardShortcutTests.swift
@@ -34,6 +34,27 @@ final class AnnotationCanvasClipboardShortcutTests: XCTestCase {
         XCTAssertEqual(destinationDocument.selectedObjectID, duplicate.id)
     }
 
+    func testCommandCReturnsFalseWhenNothingIsSelected() throws {
+        let document = AnnotationDocument(imageSize: CGSize(width: 400, height: 300))
+        let canvas = AnnotationCanvasNSView(frame: CGRect(x: 0, y: 0, width: 400, height: 300))
+        canvas.document = document
+        canvas.annotationClipboard = AnnotationClipboard()
+
+        let event = try commandEvent(character: "c", keyCode: 8)
+        XCTAssertFalse(canvas.performAnnotationClipboardShortcut(with: event))
+    }
+
+    func testCommandCReturnsTrueWhenSelectionIsCopied() throws {
+        let document = AnnotationDocument(imageSize: CGSize(width: 400, height: 300))
+        document.addObject(RectangleObject(rect: CGRect(x: 20, y: 30, width: 80, height: 50)))
+        let canvas = AnnotationCanvasNSView(frame: CGRect(x: 0, y: 0, width: 400, height: 300))
+        canvas.document = document
+        canvas.annotationClipboard = AnnotationClipboard()
+
+        let event = try commandEvent(character: "c", keyCode: 8)
+        XCTAssertTrue(canvas.performAnnotationClipboardShortcut(with: event))
+    }
+
     func testFullEditorDispatchesCommandCToTheCanvasSelection() throws {
         let clipboard = AnnotationClipboard()
         var copiedRenderedImage = false

--- a/App/Tests/CaptureAllInOneAnnotationShortcutTests.swift
+++ b/App/Tests/CaptureAllInOneAnnotationShortcutTests.swift
@@ -34,7 +34,7 @@ final class CaptureAllInOneAnnotationShortcutTests: XCTestCase {
         wait(for: [copied], timeout: 1)
     }
 
-    func testCommandCDoesNotCopyTheRenderedImageWhileAnnotationOverlayIsActive() throws {
+    func testCommandCFallsBackToCopyRenderedImageWhenNoAnnotationIsSelected() throws {
         let screen = try XCTUnwrap(NSScreen.main)
         let toolbar = CaptureAllInOneToolbarWindow(
             selectionRect: CGRect(x: 100, y: 100, width: 240, height: 160),
@@ -45,8 +45,9 @@ final class CaptureAllInOneAnnotationShortcutTests: XCTestCase {
         )
         defer { toolbar.close() }
 
-        let copied = expectation(description: "Rendered annotation image is not copied")
-        copied.isInverted = true
+        // Frozen All-in-One always has an annotation overlay, but with no
+        // object selected ⌘C should fall back to copy-image-and-close (Issue #237).
+        let copied = expectation(description: "Rendered annotation image copied with ⌘C fallback")
         toolbar.onCopyRendered = { _, _ in copied.fulfill() }
         toolbar.show()
 
@@ -58,7 +59,56 @@ final class CaptureAllInOneAnnotationShortcutTests: XCTestCase {
         )
         NSApp.sendEvent(event)
 
-        wait(for: [copied], timeout: 0.1)
+        wait(for: [copied], timeout: 1)
+    }
+
+    func testCommandCCopiesSelectedAnnotationObjectFromFrozenOverlay() throws {
+        let screen = try XCTUnwrap(NSScreen.main)
+        let overlay = CaptureAllInOneAnnotationOverlay(screen: screen)
+        defer { overlay.close() }
+        overlay.show(
+            sourceImage: try makeImage(size: CGSize(width: 240, height: 160)),
+            selectionRect: CGRect(x: 100, y: 100, width: 240, height: 160),
+            avoidingFrame: nil
+        )
+
+        let document = try XCTUnwrap(overlay.annotationDocument)
+        let source = RectangleObject(rect: CGRect(x: 20, y: 30, width: 80, height: 50))
+        document.addObject(source)
+
+        let event = try commandEvent(
+            character: "c",
+            keyCode: 8,
+            modifiers: .command,
+            windowNumber: NSApp.keyWindow?.windowNumber ?? 0
+        )
+        // Selected object → consume ⌘C as annotation clipboard (no image fallback).
+        XCTAssertTrue(overlay.performAnnotationClipboardShortcut(with: event))
+
+        let destination = AnnotationDocument(imageSize: CGSize(width: 400, height: 300))
+        XCTAssertTrue(AnnotationClipboard.shared.paste(into: destination, offset: .zero))
+        let pasted = try XCTUnwrap(destination.objects.first as? RectangleObject)
+        XCTAssertEqual(pasted.rect, source.rect)
+    }
+
+    func testCommandCReturnsFalseFromFrozenOverlayWhenNothingIsSelected() throws {
+        let screen = try XCTUnwrap(NSScreen.main)
+        let overlay = CaptureAllInOneAnnotationOverlay(screen: screen)
+        defer { overlay.close() }
+        overlay.show(
+            sourceImage: try makeImage(size: CGSize(width: 240, height: 160)),
+            selectionRect: CGRect(x: 100, y: 100, width: 240, height: 160),
+            avoidingFrame: nil
+        )
+
+        let event = try commandEvent(
+            character: "c",
+            keyCode: 8,
+            modifiers: .command,
+            windowNumber: NSApp.keyWindow?.windowNumber ?? 0
+        )
+        // No selection → do not consume; toolbar falls back to copy-image-and-close.
+        XCTAssertFalse(overlay.performAnnotationClipboardShortcut(with: event))
     }
 
     func testCommandCStillCopiesASelectionWithoutAnAnnotationOverlay() throws {


### PR DESCRIPTION
## Summary
- In All-in-One, ⌘C falls back to copy-image-and-close when no annotation object is selected (still copies the selected object when one is selected; leaves native text copy alone while editing text).
- Copy button tooltip and Preferences → Shortcuts now advertise all three copy-and-close bindings: ⌘C · ⏎ · ⌘⇧C.
- Adds coverage for the fallback and selection paths (issue #237).

## Test plan
- [ ] All-in-One: select area, press ⌘C with no annotation selected → image copied and overlay closes
- [ ] All-in-One: select an annotation object, press ⌘C → object goes to annotation clipboard (no close)
- [ ] All-in-One: edit text annotation, press ⌘C → copies text, does not close
- [ ] Hover Copy button → tooltip shows `⌘C · ⏎ · ⌘⇧C`
- [ ] Preferences → Shortcuts → Contextual: Copy selected area shows three keycaps
- [ ] CI / unit tests for clipboard + All-in-One shortcuts pass

Fixes #237

Made with [Cursor](https://cursor.com)