### PR TITLE
fix: size the annotate window to its toolbar before centering

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
@@ -8,10 +8,16 @@ import SharedKit
 final class AnnotationEditorWindow: NSPanel, NSWindowDelegate {
     /// Internal (not private) so tests can assert on document state.
     let document: AnnotationDocument
+    /// Frame computed from image pixels + anchor screen. Re-applied in `show()`
+    /// because AppKit can still nudge `.titled` panels after init.
+    private let preferredFrame: NSRect
     private var alphaValueBeforeDrag: CGFloat?
     private let onCloseCallback: () -> Void
     /// Injectable so tests never present a real modal alert.
     var confirmDiscard: () -> Bool = { false }
+
+    private static let style: NSWindow.StyleMask = [.titled, .closable, .resizable, .miniaturizable]
+    private static let chromeHeight: CGFloat = 110
 
     init(
         image: CGImage,
@@ -36,25 +42,26 @@ final class AnnotationEditorWindow: NSPanel, NSWindowDelegate {
         // always open the editor on the primary display, even when the capture
         // came from a secondary one.
         let screen = anchorScreen ?? NSScreen.main ?? NSScreen.screens.first!
-        let maxW = screen.visibleFrame.width * 0.8
-        let maxH = screen.visibleFrame.height * 0.8
-        let chromeH: CGFloat = 110
-
-        let scale = min(1.0, min(maxW / imgW, (maxH - chromeH) / imgH))
-        let winW = imgW * scale
-        let winH = imgH * scale + chromeH
-
-        // Center inside the target screen's visibleFrame. `visibleFrame` is
-        // already in absolute desktop coordinates, so this puts the window on
-        // the correct display even when that display isn't the primary one.
-        let x = screen.visibleFrame.midX - winW / 2
-        let y = screen.visibleFrame.midY - winH / 2
-
-        let targetFrame = NSRect(x: x, y: y, width: winW, height: winH)
+        let contentSize = AnnotationEditorWindowGeometry.contentSize(
+            imagePixelSize: CGSize(width: imgW, height: imgH),
+            backingScaleFactor: screen.backingScaleFactor,
+            visibleSize: screen.visibleFrame.size,
+            chromeHeight: Self.chromeHeight
+        )
+        // `contentSize` is the content-area size. Convert to a full window frame
+        // (including titlebar) before centering so the visible chrome is what
+        // ends up mid-screen, not just the content rect.
+        let contentRect = NSRect(origin: .zero, size: contentSize)
+        let frameSize = NSWindow.frameRect(forContentRect: contentRect, styleMask: Self.style).size
+        let targetFrame = AnnotationEditorWindowGeometry.centeredFrame(
+            size: frameSize,
+            in: screen.visibleFrame
+        )
+        self.preferredFrame = targetFrame
 
         super.init(
-            contentRect: targetFrame,
-            styleMask: [.titled, .closable, .resizable, .miniaturizable],
+            contentRect: NSWindow.contentRect(forFrameRect: targetFrame, styleMask: Self.style),
+            styleMask: Self.style,
             backing: .buffered,
             defer: false
         )
@@ -71,10 +78,10 @@ final class AnnotationEditorWindow: NSPanel, NSWindowDelegate {
         self.acceptsMouseMovedEvents = true
         // AppKit re-applies window restoration + may snap `.titled` panels
         // back to main display on multi-monitor setups, ignoring the
-        // contentRect passed to init. Disable restoration and explicitly
-        // re-apply the target frame so we actually land on the right screen.
+        // contentRect passed to init. Disable restoration and re-apply the
+        // target frame after installing content (hosting views can resize
+        // the window) so we actually land centered on the right screen.
         self.isRestorable = false
-        self.setFrame(targetFrame, display: false)
 
         self.confirmDiscard = { [weak self] in
             AnnotationEditorCloseGuard.presentDiscardAlert(above: self)
@@ -126,6 +133,9 @@ final class AnnotationEditorWindow: NSPanel, NSWindowDelegate {
         )
 
         self.contentView = NSHostingView(rootView: view)
+        // Hosting the SwiftUI tree can resize the panel; re-assert the
+        // centered frame computed from the capture's pixel size.
+        self.setFrame(targetFrame, display: false)
     }
 
     /// Closes if there's nothing to lose, otherwise confirms with the user
@@ -165,6 +175,10 @@ final class AnnotationEditorWindow: NSPanel, NSWindowDelegate {
     }
 
     func show() {
+        // Re-apply the centered frame on show. Some AppKit path repositions
+        // titled panels between init and first presentation, which left the
+        // Annotate window off-center (issue #236).
+        setFrame(preferredFrame, display: false)
         makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
     }

--- a/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
@@ -139,20 +139,21 @@ final class AnnotationEditorWindow: NSPanel, NSWindowDelegate {
         resizeAndCenter(preferredContentSize: imageContentSize, hostingView: hostingView)
     }
 
-    /// Grows the window to whatever the SwiftUI tree needs before centering it.
+    /// Grows the window to whatever the SwiftUI tree wants before centering it.
     ///
     /// The toolbar is a row of fixed-width controls, so the hosting view has a
-    /// wide intrinsic size that AppKit installs as `contentMinSize` and applies
-    /// on a later runloop pass — widening the window from its existing origin
-    /// and dragging it off-center. Sizing to that minimum up front means the
-    /// frame we center is the frame that survives (issue #236).
+    /// wide fitting size that AppKit applies on a later runloop pass — widening
+    /// the window from its existing origin and dragging it off-center. Sizing
+    /// to it up front means the frame we center is the frame that survives
+    /// (issue #236).
     private func resizeAndCenter(preferredContentSize: CGSize, hostingView: NSHostingView<AnnotationEditorView>) {
         // `contentMinSize` is still zero at this point; the hosting view's own
-        // fitting size is what AppKit will eventually derive it from.
+        // fitting size is what AppKit will eventually derive the window's
+        // preferred width from.
         hostingView.layoutSubtreeIfNeeded()
         let resolvedContentSize = AnnotationEditorWindowGeometry.resolvedContentSize(
             preferred: preferredContentSize,
-            minimum: hostingView.fittingSize,
+            fitting: hostingView.fittingSize,
             visibleSize: anchorVisibleFrame.size
         )
         preferredFrame = Self.centeredFrame(contentSize: resolvedContentSize, in: anchorVisibleFrame)

--- a/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
@@ -8,9 +8,13 @@ import SharedKit
 final class AnnotationEditorWindow: NSPanel, NSWindowDelegate {
     /// Internal (not private) so tests can assert on document state.
     let document: AnnotationDocument
-    /// Frame computed from image pixels + anchor screen. Re-applied in `show()`
-    /// because AppKit can still nudge `.titled` panels after init.
-    private let preferredFrame: NSRect
+    /// Centered frame for this capture, resolved once the SwiftUI tree's own
+    /// minimum size is known. Re-applied on first `show()` because AppKit can
+    /// still nudge `.titled` panels between init and presentation.
+    private var preferredFrame: NSRect
+    /// `visibleFrame` of the screen the editor was sized against.
+    private let anchorVisibleFrame: NSRect
+    private var hasAppliedPreferredFrame = false
     private var alphaValueBeforeDrag: CGFloat?
     private let onCloseCallback: () -> Void
     /// Injectable so tests never present a real modal alert.
@@ -42,25 +46,24 @@ final class AnnotationEditorWindow: NSPanel, NSWindowDelegate {
         // always open the editor on the primary display, even when the capture
         // came from a secondary one.
         let screen = anchorScreen ?? NSScreen.main ?? NSScreen.screens.first!
-        let contentSize = AnnotationEditorWindowGeometry.contentSize(
+        let visibleFrame = screen.visibleFrame
+        let imageContentSize = AnnotationEditorWindowGeometry.contentSize(
             imagePixelSize: CGSize(width: imgW, height: imgH),
             backingScaleFactor: screen.backingScaleFactor,
-            visibleSize: screen.visibleFrame.size,
+            visibleSize: visibleFrame.size,
             chromeHeight: Self.chromeHeight
         )
-        // `contentSize` is the content-area size. Convert to a full window frame
-        // (including titlebar) before centering so the visible chrome is what
-        // ends up mid-screen, not just the content rect.
-        let contentRect = NSRect(origin: .zero, size: contentSize)
-        let frameSize = NSWindow.frameRect(forContentRect: contentRect, styleMask: Self.style).size
-        let targetFrame = AnnotationEditorWindowGeometry.centeredFrame(
-            size: frameSize,
-            in: screen.visibleFrame
+        // Provisional frame. The final one is resolved after the SwiftUI tree is
+        // installed, once it can report how much width the toolbar needs.
+        let initialFrame = Self.centeredFrame(
+            contentSize: imageContentSize,
+            in: visibleFrame
         )
-        self.preferredFrame = targetFrame
+        self.anchorVisibleFrame = visibleFrame
+        self.preferredFrame = initialFrame
 
         super.init(
-            contentRect: NSWindow.contentRect(forFrameRect: targetFrame, styleMask: Self.style),
+            contentRect: Self.contentRect(forFrameRect: initialFrame, styleMask: Self.style),
             styleMask: Self.style,
             backing: .buffered,
             defer: false
@@ -78,9 +81,8 @@ final class AnnotationEditorWindow: NSPanel, NSWindowDelegate {
         self.acceptsMouseMovedEvents = true
         // AppKit re-applies window restoration + may snap `.titled` panels
         // back to main display on multi-monitor setups, ignoring the
-        // contentRect passed to init. Disable restoration and re-apply the
-        // target frame after installing content (hosting views can resize
-        // the window) so we actually land centered on the right screen.
+        // contentRect passed to init. Disable restoration so the frame we
+        // compute is the one that sticks.
         self.isRestorable = false
 
         self.confirmDiscard = { [weak self] in
@@ -132,10 +134,40 @@ final class AnnotationEditorWindow: NSPanel, NSWindowDelegate {
             }
         )
 
-        self.contentView = NSHostingView(rootView: view)
-        // Hosting the SwiftUI tree can resize the panel; re-assert the
-        // centered frame computed from the capture's pixel size.
-        self.setFrame(targetFrame, display: false)
+        let hostingView = NSHostingView(rootView: view)
+        self.contentView = hostingView
+        resizeAndCenter(preferredContentSize: imageContentSize, hostingView: hostingView)
+    }
+
+    /// Grows the window to whatever the SwiftUI tree needs before centering it.
+    ///
+    /// The toolbar is a row of fixed-width controls, so the hosting view has a
+    /// wide intrinsic size that AppKit installs as `contentMinSize` and applies
+    /// on a later runloop pass — widening the window from its existing origin
+    /// and dragging it off-center. Sizing to that minimum up front means the
+    /// frame we center is the frame that survives (issue #236).
+    private func resizeAndCenter(preferredContentSize: CGSize, hostingView: NSHostingView<AnnotationEditorView>) {
+        // `contentMinSize` is still zero at this point; the hosting view's own
+        // fitting size is what AppKit will eventually derive it from.
+        hostingView.layoutSubtreeIfNeeded()
+        let resolvedContentSize = AnnotationEditorWindowGeometry.resolvedContentSize(
+            preferred: preferredContentSize,
+            minimum: hostingView.fittingSize,
+            visibleSize: anchorVisibleFrame.size
+        )
+        preferredFrame = Self.centeredFrame(contentSize: resolvedContentSize, in: anchorVisibleFrame)
+        setFrame(preferredFrame, display: false)
+    }
+
+    /// Converts a content-area size into a full window frame (titlebar chrome
+    /// included) centered inside `visibleFrame`, so what ends up mid-screen is
+    /// the window the user sees rather than just its content rect.
+    private static func centeredFrame(contentSize: CGSize, in visibleFrame: NSRect) -> NSRect {
+        let frameSize = frameRect(
+            forContentRect: NSRect(origin: .zero, size: contentSize),
+            styleMask: style
+        ).size
+        return AnnotationEditorWindowGeometry.centeredFrame(size: frameSize, in: visibleFrame)
     }
 
     /// Closes if there's nothing to lose, otherwise confirms with the user
@@ -175,10 +207,14 @@ final class AnnotationEditorWindow: NSPanel, NSWindowDelegate {
     }
 
     func show() {
-        // Re-apply the centered frame on show. Some AppKit path repositions
-        // titled panels between init and first presentation, which left the
-        // Annotate window off-center (issue #236).
-        setFrame(preferredFrame, display: false)
+        // Re-apply the centered frame on first presentation only. Some AppKit
+        // path repositions titled panels between init and ordering front, which
+        // left the Annotate window off-center (issue #236). Doing this on every
+        // `show()` would yank a window the user has since moved back to center.
+        if !hasAppliedPreferredFrame {
+            hasAppliedPreferredFrame = true
+            setFrame(preferredFrame, display: false)
+        }
         makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
     }

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -319,20 +319,37 @@ struct AnnotationToolbar: View {
 
     @ViewBuilder
     private var copyActionButton: some View {
-        let button = actionButton(icon: "doc.on.doc", help: "Copy Image and Close", action: onCopy)
-            .keyboardShortcut("c", modifiers: [.command, .shift])
+        let button = actionButton(
+            icon: "doc.on.doc",
+            help: "Copy Image and Close (⌘C · ⏎ · ⌘⇧C)",
+            action: onCopy
+        )
+        .keyboardShortcut("c", modifiers: [.command, .shift])
         if isEditingText {
+            // Leave ⌘C and Return to the text field being edited.
             button
         } else {
             button.background {
-                Button(action: onCopy) { EmptyView() }
-                    .keyboardShortcut(.return, modifiers: [])
-                    .buttonStyle(.plain)
-                    .frame(width: 0, height: 0)
-                    .opacity(0)
-                    .accessibilityHidden(true)
+                ZStack {
+                    hiddenCopyShortcut(.return, modifiers: [])
+                    // Plain ⌘C only reaches here when the canvas declined it,
+                    // i.e. no annotation object is selected (issue #236/#237).
+                    hiddenCopyShortcut(KeyEquivalent("c"), modifiers: .command)
+                }
             }
         }
+    }
+
+    private func hiddenCopyShortcut(
+        _ key: KeyEquivalent,
+        modifiers: EventModifiers
+    ) -> some View {
+        Button(action: onCopy) { EmptyView() }
+            .keyboardShortcut(key, modifiers: modifiers)
+            .buttonStyle(.plain)
+            .frame(width: 0, height: 0)
+            .opacity(0)
+            .accessibilityHidden(true)
     }
 
     private func actionButton(

--- a/App/Sources/AnnotationEditor/AnnotationToolbar.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolbar.swift
@@ -45,18 +45,25 @@ struct AnnotationToolbar: View {
     var body: some View {
         VStack(spacing: 6) {
             HStack(spacing: 12) {
-                toolGroup
-                toolbarDivider
-                colorGroup
-                toolbarDivider
-                strokeGroup
-                toolbarDivider
-                cropGroup
-                toolbarDivider
-                beautifyGroup
-                toolbarDivider
-                undoGroup
-                Spacer()
+                // Only the editing tools scroll. The actions stay pinned so
+                // Save/Copy/Close never slide out of reach on a display too
+                // narrow for the toolbar's full width (issue #236).
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 12) {
+                        toolGroup
+                        toolbarDivider
+                        colorGroup
+                        toolbarDivider
+                        strokeGroup
+                        toolbarDivider
+                        cropGroup
+                        toolbarDivider
+                        beautifyGroup
+                        toolbarDivider
+                        undoGroup
+                    }
+                }
+                Spacer(minLength: 0)
                 actionGroup
             }
 

--- a/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/InlineAnnotationEditorWindow.swift
@@ -791,20 +791,37 @@ private struct InlineAnnotationToolbar: View {
 
     @ViewBuilder
     private var copyActionButton: some View {
-        let button = iconButton(systemName: "doc.on.doc", help: "Copy Image and Close", action: onCopy)
-            .keyboardShortcut("c", modifiers: [.command, .shift])
+        let button = iconButton(
+            systemName: "doc.on.doc",
+            help: "Copy Image and Close (⌘C · ⏎ · ⌘⇧C)",
+            action: onCopy
+        )
+        .keyboardShortcut("c", modifiers: [.command, .shift])
         if isEditingText {
+            // Leave ⌘C and Return to the text field being edited.
             button
         } else {
             button.background {
-                Button(action: onCopy) { EmptyView() }
-                    .keyboardShortcut(.return, modifiers: [])
-                    .buttonStyle(.plain)
-                    .frame(width: 0, height: 0)
-                    .opacity(0)
-                    .accessibilityHidden(true)
+                ZStack {
+                    hiddenCopyShortcut(.return, modifiers: [])
+                    // Plain ⌘C only reaches here when the canvas declined it,
+                    // i.e. no annotation object is selected (issue #236/#237).
+                    hiddenCopyShortcut(KeyEquivalent("c"), modifiers: .command)
+                }
             }
         }
+    }
+
+    private func hiddenCopyShortcut(
+        _ key: KeyEquivalent,
+        modifiers: EventModifiers
+    ) -> some View {
+        Button(action: onCopy) { EmptyView() }
+            .keyboardShortcut(key, modifiers: modifiers)
+            .buttonStyle(.plain)
+            .frame(width: 0, height: 0)
+            .opacity(0)
+            .accessibilityHidden(true)
     }
 
     private var textEffectsGroup: some View {

--- a/App/Tests/AnnotationCanvasClipboardShortcutTests.swift
+++ b/App/Tests/AnnotationCanvasClipboardShortcutTests.swift
@@ -126,6 +126,77 @@ final class AnnotationCanvasClipboardShortcutTests: XCTestCase {
         XCTAssertEqual(pasted.rect, source.rect)
     }
 
+    /// Issue #236: with no annotation object selected, ⌘C in the full editor
+    /// must fall back to copy-image-and-close instead of doing nothing.
+    func testFullEditorCommandCFallsBackToCopyRenderedImageWhenNothingIsSelected() throws {
+        let copied = expectation(description: "Full editor image copied with ⌘C")
+        let window = AnnotationEditorWindow(
+            image: try makeImage(),
+            screenshotOutputPreset: .losslessPNG,
+            screenshotFilenameTemplate: "Screenshot",
+            onSave: { _ in true },
+            onCopy: { _ in copied.fulfill() },
+            onPin: { _, _ in },
+            onClose: {}
+        )
+        defer { window.close() }
+
+        window.show()
+        window.contentView?.layoutSubtreeIfNeeded()
+        window.sendEvent(try commandEvent(character: "c", keyCode: 8, windowNumber: window.windowNumber))
+
+        wait(for: [copied], timeout: 1)
+    }
+
+    func testInlineEditorCommandCFallsBackToCopyRenderedImageWhenNothingIsSelected() throws {
+        let screen = try XCTUnwrap(NSScreen.main)
+        let copied = expectation(description: "Inline editor image copied with ⌘C")
+        let window = InlineAnnotationEditorWindow(
+            image: try makeImage(),
+            screen: screen,
+            screenLocalRect: CGRect(x: 100, y: 100, width: 400, height: 300),
+            onSave: { _ in },
+            onCopy: { _ in copied.fulfill() },
+            onPin: { _, _ in },
+            onClose: {}
+        )
+        defer { window.close() }
+
+        window.show()
+        window.contentView?.layoutSubtreeIfNeeded()
+        window.sendEvent(try commandEvent(character: "c", keyCode: 8, windowNumber: window.windowNumber))
+
+        wait(for: [copied], timeout: 1)
+    }
+
+    /// ⌘C must not copy-and-close out from under a focused text responder —
+    /// the keystroke belongs to the text being edited.
+    func testFullEditorCommandCDoesNotCopyTheImageWhileATextResponderHasFocus() throws {
+        let copied = expectation(description: "Image must not be copied while editing text")
+        copied.isInverted = true
+        let window = AnnotationEditorWindow(
+            image: try makeImage(),
+            screenshotOutputPreset: .losslessPNG,
+            screenshotFilenameTemplate: "Screenshot",
+            onSave: { _ in true },
+            onCopy: { _ in copied.fulfill() },
+            onPin: { _, _ in },
+            onClose: {}
+        )
+        defer { window.close() }
+
+        window.show()
+        window.contentView?.layoutSubtreeIfNeeded()
+
+        let textView = NSTextView()
+        window.contentView?.addSubview(textView)
+        XCTAssertTrue(window.makeFirstResponder(textView))
+
+        window.sendEvent(try commandEvent(character: "c", keyCode: 8, windowNumber: window.windowNumber))
+
+        wait(for: [copied], timeout: 0.5)
+    }
+
     func testFullEditorReturnCopiesTheRenderedImage() throws {
         let copied = expectation(description: "Full editor image copied with Return")
         let window = AnnotationEditorWindow(

--- a/App/Tests/AnnotationEditorWindowCenteringTests.swift
+++ b/App/Tests/AnnotationEditorWindowCenteringTests.swift
@@ -1,0 +1,63 @@
+import AppKit
+import XCTest
+import SharedKit
+@testable import Capso
+
+@MainActor
+final class AnnotationEditorWindowCenteringTests: XCTestCase {
+    func testShowCentersWindowOnAnchorScreenVisibleFrame() throws {
+        let screen = try XCTUnwrap(NSScreen.main)
+        // Simulate a Retina area capture: 2× pixels for a modest point size.
+        let image = try makeImage(width: 1600, height: 400)
+
+        let window = AnnotationEditorWindow(
+            image: image,
+            anchorScreen: screen,
+            screenshotOutputPreset: .losslessPNG,
+            screenshotFilenameTemplate: "Screenshot",
+            onSave: { _ in true },
+            onCopy: { _ in },
+            onPin: { _, _ in },
+            onClose: {}
+        )
+        defer { window.close() }
+
+        window.show()
+
+        let contentSize = AnnotationEditorWindowGeometry.contentSize(
+            imagePixelSize: CGSize(width: 1600, height: 400),
+            backingScaleFactor: screen.backingScaleFactor,
+            visibleSize: screen.visibleFrame.size,
+            chromeHeight: 110
+        )
+        let style: NSWindow.StyleMask = [.titled, .closable, .resizable, .miniaturizable]
+        let frameSize = NSWindow.frameRect(
+            forContentRect: NSRect(origin: .zero, size: contentSize),
+            styleMask: style
+        ).size
+        let expectedFrame = AnnotationEditorWindowGeometry.centeredFrame(
+            size: frameSize,
+            in: screen.visibleFrame
+        )
+
+        XCTAssertEqual(window.frame.origin.x, expectedFrame.origin.x, accuracy: 1)
+        XCTAssertEqual(window.frame.origin.y, expectedFrame.origin.y, accuracy: 1)
+        XCTAssertEqual(window.frame.width, expectedFrame.width, accuracy: 1)
+        XCTAssertEqual(window.frame.height, expectedFrame.height, accuracy: 1)
+    }
+
+    private func makeImage(width: Int, height: Int) throws -> CGImage {
+        let context = try XCTUnwrap(CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(CGColor(red: 0.1, green: 0.1, blue: 0.1, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return try XCTUnwrap(context.makeImage())
+    }
+}

--- a/App/Tests/AnnotationEditorWindowCenteringTests.swift
+++ b/App/Tests/AnnotationEditorWindowCenteringTests.swift
@@ -7,9 +7,9 @@ import SharedKit
 final class AnnotationEditorWindowCenteringTests: XCTestCase {
     /// The regression from issue #236: a capture small enough that the
     /// image-derived width falls below the toolbar's intrinsic width. AppKit
-    /// installs the hosting view's `contentMinSize` and applies it a runloop
-    /// pass *after* the window has been positioned, widening it rightwards
-    /// from a fixed origin and dragging it off-center.
+    /// applied the hosting view's size a runloop pass *after* the window had
+    /// been positioned, widening it rightwards from a fixed origin and
+    /// dragging it off-center.
     func testSmallCaptureStaysCenteredAfterAppKitAppliesMinimumSize() throws {
         let screen = try XCTUnwrap(NSScreen.main)
         let window = try makeWindow(pixelWidth: 600, pixelHeight: 400, screen: screen)
@@ -48,16 +48,31 @@ final class AnnotationEditorWindowCenteringTests: XCTestCase {
         // The SwiftUI tree must not have forced it any wider.
         XCTAssertEqual(window.frame.width, sizeBeforeShow.width, accuracy: 1)
         XCTAssertEqual(window.frame.height, sizeBeforeShow.height, accuracy: 1)
-        // The 6000px image must have been scaled into the viewport budget. The
-        // only thing allowed to exceed the display is the toolbar's own floor,
-        // measured here from a window built around a negligible image.
-        let toolbarFloor = try makeWindow(pixelWidth: 10, pixelHeight: 10, screen: screen)
-        defer { toolbarFloor.close() }
         XCTAssertLessThanOrEqual(
-            window.frame.width,
-            max(toolbarFloor.frame.width, screen.visibleFrame.width) + 1,
+            window.frame.width, screen.visibleFrame.width + 1,
             "6000px capture was not scaled into the viewport: \(window.frame)"
         )
+    }
+
+    /// The toolbar's tool row scrolls, so its natural width is a preference the
+    /// display can override. Without that, a display narrower than the toolbar
+    /// gets a window it cannot fit or center — which is what CI's 1024pt-wide
+    /// runner hits.
+    func testWindowNeverOutgrowsTheDisplayWidth() throws {
+        let screen = try XCTUnwrap(NSScreen.main)
+
+        for pixelWidth in [10, 600, 6000] {
+            let window = try makeWindow(pixelWidth: pixelWidth, pixelHeight: 400, screen: screen)
+            defer { window.close() }
+            window.show()
+            settleLayout()
+
+            XCTAssertLessThanOrEqual(
+                window.frame.width, screen.visibleFrame.width + 1,
+                "\(pixelWidth)px capture produced a window wider than the display: \(window.frame)"
+            )
+            assertPlacedOnScreen(window, on: screen)
+        }
     }
 
     /// `show()` positions the window once. A window the user has dragged

--- a/App/Tests/AnnotationEditorWindowCenteringTests.swift
+++ b/App/Tests/AnnotationEditorWindowCenteringTests.swift
@@ -5,13 +5,101 @@ import SharedKit
 
 @MainActor
 final class AnnotationEditorWindowCenteringTests: XCTestCase {
-    func testShowCentersWindowOnAnchorScreenVisibleFrame() throws {
+    /// The regression from issue #236: a capture small enough that the
+    /// image-derived width falls below the toolbar's intrinsic width. AppKit
+    /// installs the hosting view's `contentMinSize` and applies it a runloop
+    /// pass *after* the window has been positioned, widening it rightwards
+    /// from a fixed origin and dragging it off-center.
+    func testSmallCaptureStaysCenteredAfterAppKitAppliesMinimumSize() throws {
         let screen = try XCTUnwrap(NSScreen.main)
-        // Simulate a Retina area capture: 2× pixels for a modest point size.
-        let image = try makeImage(width: 1600, height: 400)
+        let window = try makeWindow(pixelWidth: 600, pixelHeight: 400, screen: screen)
+        defer { window.close() }
 
-        let window = AnnotationEditorWindow(
-            image: image,
+        window.show()
+        settleLayout()
+
+        assertCentered(window, on: screen)
+        // Guards the premise: the toolbar forced the window wider than the
+        // 600px image. Without that growth this test proves nothing.
+        XCTAssertGreaterThan(window.frame.width, 600)
+    }
+
+    /// A wide Retina capture is sized from the image rather than the toolbar
+    /// minimum, and must be converted from pixels to points so it stays inside
+    /// the viewport budget instead of overflowing the display.
+    func testWideRetinaCaptureIsCenteredAndFitsTheVisibleFrame() throws {
+        let screen = try XCTUnwrap(NSScreen.main)
+        let window = try makeWindow(pixelWidth: 6000, pixelHeight: 1500, screen: screen)
+        defer { window.close() }
+
+        // Centering is asserted before presentation: once the window is on
+        // screen, macOS occasionally nudges wide windows during app activation
+        // (observed as a ~40pt drift), which is unrelated to this sizing path.
+        assertCentered(window, on: screen)
+
+        let sizeBeforeShow = window.frame.size
+        window.show()
+        settleLayout()
+
+        // The SwiftUI tree must not have forced it any wider.
+        XCTAssertEqual(window.frame.width, sizeBeforeShow.width, accuracy: 1)
+        XCTAssertEqual(window.frame.height, sizeBeforeShow.height, accuracy: 1)
+        XCTAssertLessThanOrEqual(window.frame.width, screen.visibleFrame.width + 1)
+        XCTAssertLessThanOrEqual(window.frame.height, screen.visibleFrame.height + 1)
+    }
+
+    /// `show()` positions the window once. A window the user has dragged
+    /// elsewhere must not be yanked back to center by a later `show()`.
+    func testSubsequentShowDoesNotRepositionAMovedWindow() throws {
+        let screen = try XCTUnwrap(NSScreen.main)
+        let window = try makeWindow(pixelWidth: 600, pixelHeight: 400, screen: screen)
+        defer { window.close() }
+
+        window.show()
+        settleLayout()
+
+        let moved = window.frame.offsetBy(dx: 40, dy: -30)
+        window.setFrame(moved, display: false)
+        window.show()
+
+        XCTAssertEqual(window.frame.origin.x, moved.origin.x, accuracy: 1)
+        XCTAssertEqual(window.frame.origin.y, moved.origin.y, accuracy: 1)
+    }
+
+    // MARK: - Helpers
+
+    private func assertCentered(
+        _ window: AnnotationEditorWindow,
+        on screen: NSScreen,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            window.frame.midX, screen.visibleFrame.midX, accuracy: 1,
+            "Window is horizontally off-center: \(window.frame) in \(screen.visibleFrame)",
+            file: file, line: line
+        )
+        XCTAssertEqual(
+            window.frame.midY, screen.visibleFrame.midY, accuracy: 1,
+            "Window is vertically off-center: \(window.frame) in \(screen.visibleFrame)",
+            file: file, line: line
+        )
+    }
+
+    /// Lets AppKit apply the hosting view's `contentMinSize`, which happens on
+    /// a later runloop pass. Without this the assertions run against a frame
+    /// the user never actually sees.
+    private func settleLayout() {
+        RunLoop.current.run(until: Date().addingTimeInterval(0.3))
+    }
+
+    private func makeWindow(
+        pixelWidth: Int,
+        pixelHeight: Int,
+        screen: NSScreen
+    ) throws -> AnnotationEditorWindow {
+        AnnotationEditorWindow(
+            image: try makeImage(width: pixelWidth, height: pixelHeight),
             anchorScreen: screen,
             screenshotOutputPreset: .losslessPNG,
             screenshotFilenameTemplate: "Screenshot",
@@ -20,30 +108,6 @@ final class AnnotationEditorWindowCenteringTests: XCTestCase {
             onPin: { _, _ in },
             onClose: {}
         )
-        defer { window.close() }
-
-        window.show()
-
-        let contentSize = AnnotationEditorWindowGeometry.contentSize(
-            imagePixelSize: CGSize(width: 1600, height: 400),
-            backingScaleFactor: screen.backingScaleFactor,
-            visibleSize: screen.visibleFrame.size,
-            chromeHeight: 110
-        )
-        let style: NSWindow.StyleMask = [.titled, .closable, .resizable, .miniaturizable]
-        let frameSize = NSWindow.frameRect(
-            forContentRect: NSRect(origin: .zero, size: contentSize),
-            styleMask: style
-        ).size
-        let expectedFrame = AnnotationEditorWindowGeometry.centeredFrame(
-            size: frameSize,
-            in: screen.visibleFrame
-        )
-
-        XCTAssertEqual(window.frame.origin.x, expectedFrame.origin.x, accuracy: 1)
-        XCTAssertEqual(window.frame.origin.y, expectedFrame.origin.y, accuracy: 1)
-        XCTAssertEqual(window.frame.width, expectedFrame.width, accuracy: 1)
-        XCTAssertEqual(window.frame.height, expectedFrame.height, accuracy: 1)
     }
 
     private func makeImage(width: Int, height: Int) throws -> CGImage {

--- a/App/Tests/AnnotationEditorWindowCenteringTests.swift
+++ b/App/Tests/AnnotationEditorWindowCenteringTests.swift
@@ -15,10 +15,14 @@ final class AnnotationEditorWindowCenteringTests: XCTestCase {
         let window = try makeWindow(pixelWidth: 600, pixelHeight: 400, screen: screen)
         defer { window.close() }
 
+        let frameBeforeShow = window.frame
         window.show()
         settleLayout()
 
-        assertCentered(window, on: screen)
+        // The regression: AppKit used to widen the window here, from a pinned
+        // origin. Whatever we computed has to survive presentation intact.
+        assertFrame(window.frame, matches: frameBeforeShow)
+        assertPlacedOnScreen(window, on: screen)
         // Guards the premise: the toolbar forced the window wider than the
         // 600px image. Without that growth this test proves nothing.
         XCTAssertGreaterThan(window.frame.width, 600)
@@ -32,10 +36,10 @@ final class AnnotationEditorWindowCenteringTests: XCTestCase {
         let window = try makeWindow(pixelWidth: 6000, pixelHeight: 1500, screen: screen)
         defer { window.close() }
 
-        // Centering is asserted before presentation: once the window is on
+        // Placement is asserted before presentation: once the window is on
         // screen, macOS occasionally nudges wide windows during app activation
         // (observed as a ~40pt drift), which is unrelated to this sizing path.
-        assertCentered(window, on: screen)
+        assertPlacedOnScreen(window, on: screen)
 
         let sizeBeforeShow = window.frame.size
         window.show()
@@ -44,8 +48,16 @@ final class AnnotationEditorWindowCenteringTests: XCTestCase {
         // The SwiftUI tree must not have forced it any wider.
         XCTAssertEqual(window.frame.width, sizeBeforeShow.width, accuracy: 1)
         XCTAssertEqual(window.frame.height, sizeBeforeShow.height, accuracy: 1)
-        XCTAssertLessThanOrEqual(window.frame.width, screen.visibleFrame.width + 1)
-        XCTAssertLessThanOrEqual(window.frame.height, screen.visibleFrame.height + 1)
+        // The 6000px image must have been scaled into the viewport budget. The
+        // only thing allowed to exceed the display is the toolbar's own floor,
+        // measured here from a window built around a negligible image.
+        let toolbarFloor = try makeWindow(pixelWidth: 10, pixelHeight: 10, screen: screen)
+        defer { toolbarFloor.close() }
+        XCTAssertLessThanOrEqual(
+            window.frame.width,
+            max(toolbarFloor.frame.width, screen.visibleFrame.width) + 1,
+            "6000px capture was not scaled into the viewport: \(window.frame)"
+        )
     }
 
     /// `show()` positions the window once. A window the user has dragged
@@ -68,22 +80,58 @@ final class AnnotationEditorWindowCenteringTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func assertCentered(
+    private func assertFrame(
+        _ frame: NSRect,
+        matches expected: NSRect,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(frame.origin.x, expected.origin.x, accuracy: 1, "\(frame) vs \(expected)", file: file, line: line)
+        XCTAssertEqual(frame.origin.y, expected.origin.y, accuracy: 1, "\(frame) vs \(expected)", file: file, line: line)
+        XCTAssertEqual(frame.width, expected.width, accuracy: 1, "\(frame) vs \(expected)", file: file, line: line)
+        XCTAssertEqual(frame.height, expected.height, accuracy: 1, "\(frame) vs \(expected)", file: file, line: line)
+    }
+
+    /// Asserts the window is centered on `screen`. An axis that cannot fit —
+    /// the toolbar's minimum width exceeds narrow displays, including CI's
+    /// 1024pt runner — is pinned to the visible origin instead, which is the
+    /// best placement available and what AppKit would clamp to anyway.
+    private func assertPlacedOnScreen(
         _ window: AnnotationEditorWindow,
         on screen: NSScreen,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        XCTAssertEqual(
-            window.frame.midX, screen.visibleFrame.midX, accuracy: 1,
-            "Window is horizontally off-center: \(window.frame) in \(screen.visibleFrame)",
-            file: file, line: line
-        )
-        XCTAssertEqual(
-            window.frame.midY, screen.visibleFrame.midY, accuracy: 1,
-            "Window is vertically off-center: \(window.frame) in \(screen.visibleFrame)",
-            file: file, line: line
-        )
+        let visible = screen.visibleFrame
+        let frame = window.frame
+
+        if frame.width <= visible.width {
+            XCTAssertEqual(
+                frame.midX, visible.midX, accuracy: 1,
+                "Window is horizontally off-center: \(frame) in \(visible)",
+                file: file, line: line
+            )
+        } else {
+            XCTAssertEqual(
+                frame.minX, visible.minX, accuracy: 1,
+                "Oversized window should be pinned to the visible origin: \(frame) in \(visible)",
+                file: file, line: line
+            )
+        }
+
+        if frame.height <= visible.height {
+            XCTAssertEqual(
+                frame.midY, visible.midY, accuracy: 1,
+                "Window is vertically off-center: \(frame) in \(visible)",
+                file: file, line: line
+            )
+        } else {
+            XCTAssertEqual(
+                frame.minY, visible.minY, accuracy: 1,
+                "Oversized window should be pinned to the visible origin: \(frame) in \(visible)",
+                file: file, line: line
+            )
+        }
     }
 
     /// Lets AppKit apply the hosting view's `contentMinSize`, which happens on

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/AnnotationEditorWindowGeometry.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/AnnotationEditorWindowGeometry.swift
@@ -1,0 +1,59 @@
+import CoreGraphics
+
+/// Pure layout math for the full-screen-independent Annotate window.
+///
+/// Capture images are pixel-backed (Retina screenshots are typically 2×), but
+/// `NSWindow` frames are measured in points. Treating pixel dimensions as
+/// points makes the window oversized — often larger than the visible display
+/// — and AppKit then clamps it off-center (issue #236).
+public enum AnnotationEditorWindowGeometry {
+    /// Content-area size (points) for an image that must fit inside a fraction
+    /// of the screen, leaving vertical room for toolbar / zoom chrome.
+    public static func contentSize(
+        imagePixelSize: CGSize,
+        backingScaleFactor: CGFloat,
+        visibleSize: CGSize,
+        chromeHeight: CGFloat,
+        maxViewportFraction: CGFloat = 0.8
+    ) -> CGSize {
+        guard imagePixelSize.width > 0,
+              imagePixelSize.height > 0,
+              visibleSize.width > 0,
+              visibleSize.height > 0,
+              maxViewportFraction > 0 else {
+            return .zero
+        }
+
+        let scaleFactor = max(backingScaleFactor, 1)
+        let pointWidth = imagePixelSize.width / scaleFactor
+        let pointHeight = imagePixelSize.height / scaleFactor
+
+        let maxWidth = visibleSize.width * maxViewportFraction
+        let maxHeight = max(0, visibleSize.height * maxViewportFraction - max(chromeHeight, 0))
+        guard maxWidth > 0, maxHeight > 0 else { return .zero }
+
+        let fitScale = min(1, min(maxWidth / pointWidth, maxHeight / pointHeight))
+        return CGSize(
+            width: pointWidth * fitScale,
+            height: pointHeight * fitScale + max(chromeHeight, 0)
+        )
+    }
+
+    /// Centers a window frame of `size` inside `visibleFrame` (absolute desktop
+    /// coordinates). Returns `.zero` when either input is empty.
+    public static func centeredFrame(size: CGSize, in visibleFrame: CGRect) -> CGRect {
+        guard size.width > 0,
+              size.height > 0,
+              visibleFrame.width > 0,
+              visibleFrame.height > 0 else {
+            return .zero
+        }
+
+        return CGRect(
+            x: visibleFrame.midX - size.width / 2,
+            y: visibleFrame.midY - size.height / 2,
+            width: size.width,
+            height: size.height
+        )
+    }
+}

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/AnnotationEditorWindowGeometry.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/AnnotationEditorWindowGeometry.swift
@@ -2,10 +2,17 @@ import CoreGraphics
 
 /// Pure layout math for the full-screen-independent Annotate window.
 ///
-/// Capture images are pixel-backed (Retina screenshots are typically 2×), but
-/// `NSWindow` frames are measured in points. Treating pixel dimensions as
-/// points makes the window oversized — often larger than the visible display
-/// — and AppKit then clamps it off-center (issue #236).
+/// Two things have to line up for the window to open centered (issue #236):
+///
+/// 1. Capture images are pixel-backed (Retina screenshots are typically 2×),
+///    but `NSWindow` frames are measured in points, so pixels have to be
+///    divided by the screen's backing scale before they mean anything.
+/// 2. The editor's SwiftUI toolbar is a row of fixed-width controls, so the
+///    hosting view has a large intrinsic width. AppKit turns that into the
+///    window's `contentMinSize` and enforces it on a *later* runloop pass,
+///    growing the window rightwards from its existing origin. A frame that
+///    ignores that minimum gets silently widened and pushed off-center after
+///    it has already been positioned.
 public enum AnnotationEditorWindowGeometry {
     /// Content-area size (points) for an image that must fit inside a fraction
     /// of the screen, leaving vertical room for toolbar / zoom chrome.
@@ -37,6 +44,31 @@ public enum AnnotationEditorWindowGeometry {
             width: pointWidth * fitScale,
             height: pointHeight * fitScale + max(chromeHeight, 0)
         )
+    }
+
+    /// Reconciles the image-derived content size with the size the SwiftUI tree
+    /// actually needs, so the window is born at the size AppKit would force it
+    /// to anyway.
+    ///
+    /// `minimum` wins over `preferred` because AppKit will apply it regardless;
+    /// `visibleSize` then caps the result so an unusually greedy layout can't
+    /// push the window past the display. The cap never goes below `minimum` —
+    /// shrinking under it would just be undone on the next layout pass.
+    public static func resolvedContentSize(
+        preferred: CGSize,
+        minimum: CGSize,
+        visibleSize: CGSize
+    ) -> CGSize {
+        CGSize(
+            width: resolve(preferred: preferred.width, minimum: minimum.width, visible: visibleSize.width),
+            height: resolve(preferred: preferred.height, minimum: minimum.height, visible: visibleSize.height)
+        )
+    }
+
+    private static func resolve(preferred: CGFloat, minimum: CGFloat, visible: CGFloat) -> CGFloat {
+        let floorValue = max(minimum, 0)
+        let ceilingValue = max(floorValue, visible)
+        return min(max(preferred, floorValue), ceilingValue)
     }
 
     /// Centers a window frame of `size` inside `visibleFrame` (absolute desktop

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/AnnotationEditorWindowGeometry.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/AnnotationEditorWindowGeometry.swift
@@ -72,7 +72,13 @@ public enum AnnotationEditorWindowGeometry {
     }
 
     /// Centers a window frame of `size` inside `visibleFrame` (absolute desktop
-    /// coordinates). Returns `.zero` when either input is empty.
+    /// coordinates), keeping it on the display.
+    ///
+    /// An axis larger than `visibleFrame` cannot be centered — the toolbar's
+    /// minimum width can exceed a small display — so it is pinned to the
+    /// visible origin instead of overhanging both edges. AppKit would clamp it
+    /// anyway; doing it here keeps the frame we compute and the frame we get
+    /// the same. Returns `.zero` when either input is empty.
     public static func centeredFrame(size: CGSize, in visibleFrame: CGRect) -> CGRect {
         guard size.width > 0,
               size.height > 0,
@@ -82,10 +88,17 @@ public enum AnnotationEditorWindowGeometry {
         }
 
         return CGRect(
-            x: visibleFrame.midX - size.width / 2,
-            y: visibleFrame.midY - size.height / 2,
+            x: onscreenOrigin(length: size.width, lower: visibleFrame.minX, upper: visibleFrame.maxX),
+            y: onscreenOrigin(length: size.height, lower: visibleFrame.minY, upper: visibleFrame.maxY),
             width: size.width,
             height: size.height
         )
+    }
+
+    private static func onscreenOrigin(length: CGFloat, lower: CGFloat, upper: CGFloat) -> CGFloat {
+        let centered = (lower + upper) / 2 - length / 2
+        let maxOrigin = upper - length
+        guard maxOrigin > lower else { return lower }
+        return min(max(centered, lower), maxOrigin)
     }
 }

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/AnnotationEditorWindowGeometry.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/AnnotationEditorWindowGeometry.swift
@@ -8,11 +8,12 @@ import CoreGraphics
 ///    but `NSWindow` frames are measured in points, so pixels have to be
 ///    divided by the screen's backing scale before they mean anything.
 /// 2. The editor's SwiftUI toolbar is a row of fixed-width controls, so the
-///    hosting view has a large intrinsic width. AppKit turns that into the
-///    window's `contentMinSize` and enforces it on a *later* runloop pass,
-///    growing the window rightwards from its existing origin. A frame that
-///    ignores that minimum gets silently widened and pushed off-center after
-///    it has already been positioned.
+///    hosting view wants far more width than a small capture needs. AppKit
+///    applies that want on a *later* runloop pass, growing the window
+///    rightwards from its existing origin — so a frame that ignores it gets
+///    silently widened and pushed off-center after being positioned. The
+///    window is therefore sized to it up front, and the toolbar's tool row
+///    scrolls so that width stays a preference the display can override.
 public enum AnnotationEditorWindowGeometry {
     /// Content-area size (points) for an image that must fit inside a fraction
     /// of the screen, leaving vertical room for toolbar / zoom chrome.
@@ -50,35 +51,34 @@ public enum AnnotationEditorWindowGeometry {
     /// actually needs, so the window is born at the size AppKit would force it
     /// to anyway.
     ///
-    /// `minimum` wins over `preferred` because AppKit will apply it regardless;
-    /// `visibleSize` then caps the result so an unusually greedy layout can't
-    /// push the window past the display. The cap never goes below `minimum` —
-    /// shrinking under it would just be undone on the next layout pass.
+    /// `fitting` is the size the SwiftUI tree would like — in practice the
+    /// toolbar's natural width. The window grows to it so every editing tool is
+    /// visible without scrolling, but it is a preference rather than a floor,
+    /// because the toolbar scrolls horizontally when squeezed. That lets
+    /// `visibleSize` cap it outright, which is what keeps the window on a
+    /// display too narrow for the whole toolbar.
     public static func resolvedContentSize(
         preferred: CGSize,
-        minimum: CGSize,
+        fitting: CGSize,
         visibleSize: CGSize
     ) -> CGSize {
         CGSize(
-            width: resolve(preferred: preferred.width, minimum: minimum.width, visible: visibleSize.width),
-            height: resolve(preferred: preferred.height, minimum: minimum.height, visible: visibleSize.height)
+            width: resolve(preferred: preferred.width, fitting: fitting.width, visible: visibleSize.width),
+            height: resolve(preferred: preferred.height, fitting: fitting.height, visible: visibleSize.height)
         )
     }
 
-    private static func resolve(preferred: CGFloat, minimum: CGFloat, visible: CGFloat) -> CGFloat {
-        let floorValue = max(minimum, 0)
-        let ceilingValue = max(floorValue, visible)
-        return min(max(preferred, floorValue), ceilingValue)
+    private static func resolve(preferred: CGFloat, fitting: CGFloat, visible: CGFloat) -> CGFloat {
+        min(max(preferred, max(fitting, 0)), max(visible, 0))
     }
 
     /// Centers a window frame of `size` inside `visibleFrame` (absolute desktop
     /// coordinates), keeping it on the display.
     ///
-    /// An axis larger than `visibleFrame` cannot be centered — the toolbar's
-    /// minimum width can exceed a small display — so it is pinned to the
-    /// visible origin instead of overhanging both edges. AppKit would clamp it
-    /// anyway; doing it here keeps the frame we compute and the frame we get
-    /// the same. Returns `.zero` when either input is empty.
+    /// An axis larger than `visibleFrame` cannot be centered, so it is pinned
+    /// to the visible origin instead of overhanging both edges. AppKit would
+    /// clamp it anyway; doing it here keeps the frame we compute and the frame
+    /// we get the same. Returns `.zero` when either input is empty.
     public static func centeredFrame(size: CGSize, in visibleFrame: CGRect) -> CGRect {
         guard size.width > 0,
               size.height > 0,

--- a/Packages/SharedKit/Tests/SharedKitTests/AnnotationEditorWindowGeometryTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AnnotationEditorWindowGeometryTests.swift
@@ -1,0 +1,93 @@
+import CoreGraphics
+import Testing
+@testable import SharedKit
+
+@Suite("AnnotationEditorWindowGeometry")
+struct AnnotationEditorWindowGeometryTests {
+    @Test("Converts Retina pixels to points before fitting the viewport")
+    func retinaPixelsAreConvertedToPoints() {
+        let size = AnnotationEditorWindowGeometry.contentSize(
+            imagePixelSize: CGSize(width: 2000, height: 1000),
+            backingScaleFactor: 2,
+            visibleSize: CGSize(width: 1400, height: 900),
+            chromeHeight: 110,
+            maxViewportFraction: 0.8
+        )
+
+        // 2000×1000 px @2x → 1000×500 pt, fits at 1.0 within 1120×610 budget.
+        #expect(size.width == 1000)
+        #expect(size.height == 610)
+    }
+
+    @Test("Treats 1x captures as already being in points")
+    func nonRetinaPixelsStayInPoints() {
+        let size = AnnotationEditorWindowGeometry.contentSize(
+            imagePixelSize: CGSize(width: 800, height: 400),
+            backingScaleFactor: 1,
+            visibleSize: CGSize(width: 1400, height: 900),
+            chromeHeight: 110,
+            maxViewportFraction: 0.8
+        )
+
+        #expect(size.width == 800)
+        #expect(size.height == 510)
+    }
+
+    @Test("Downscales wide captures to the viewport width budget")
+    func wideCaptureIsWidthConstrained() {
+        let size = AnnotationEditorWindowGeometry.contentSize(
+            imagePixelSize: CGSize(width: 4000, height: 1000),
+            backingScaleFactor: 2,
+            visibleSize: CGSize(width: 1000, height: 800),
+            chromeHeight: 100,
+            maxViewportFraction: 0.8
+        )
+
+        // 2000×500 pt → scale by 800/2000 = 0.4 → 800×200 + chrome 100.
+        #expect(size.width == 800)
+        #expect(size.height == 300)
+    }
+
+    @Test("Downscales tall captures to the viewport height budget")
+    func tallCaptureIsHeightConstrained() {
+        let size = AnnotationEditorWindowGeometry.contentSize(
+            imagePixelSize: CGSize(width: 1000, height: 4000),
+            backingScaleFactor: 2,
+            visibleSize: CGSize(width: 1000, height: 800),
+            chromeHeight: 100,
+            maxViewportFraction: 0.8
+        )
+
+        // 500×2000 pt → height budget 540 → scale 540/2000 = 0.27 → 135×540 + 100.
+        #expect(abs(size.width - 135) < 0.001)
+        #expect(abs(size.height - 640) < 0.001)
+    }
+
+    @Test("Centers a frame inside the visible display rect")
+    func centersFrameInVisibleRect() {
+        let frame = AnnotationEditorWindowGeometry.centeredFrame(
+            size: CGSize(width: 400, height: 300),
+            in: CGRect(x: 100, y: 50, width: 1200, height: 800)
+        )
+
+        #expect(frame == CGRect(x: 500, y: 300, width: 400, height: 300))
+    }
+
+    @Test("Rejects invalid geometry")
+    func invalidGeometry() {
+        #expect(
+            AnnotationEditorWindowGeometry.contentSize(
+                imagePixelSize: .zero,
+                backingScaleFactor: 2,
+                visibleSize: CGSize(width: 1000, height: 800),
+                chromeHeight: 110
+            ) == .zero
+        )
+        #expect(
+            AnnotationEditorWindowGeometry.centeredFrame(
+                size: CGSize(width: 100, height: 100),
+                in: .zero
+            ) == .zero
+        )
+    }
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/AnnotationEditorWindowGeometryTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AnnotationEditorWindowGeometryTests.swift
@@ -63,6 +63,68 @@ struct AnnotationEditorWindowGeometryTests {
         #expect(abs(size.height - 640) < 0.001)
     }
 
+    @Test("Grows to the SwiftUI tree's minimum when the image is smaller")
+    func minimumWins() {
+        let size = AnnotationEditorWindowGeometry.resolvedContentSize(
+            preferred: CGSize(width: 300, height: 250),
+            minimum: CGSize(width: 1234, height: 67),
+            visibleSize: CGSize(width: 1920, height: 1050)
+        )
+
+        #expect(size.width == 1234)
+        #expect(size.height == 250)
+    }
+
+    @Test("Keeps the image size when it already clears the minimum")
+    func preferredWins() {
+        let size = AnnotationEditorWindowGeometry.resolvedContentSize(
+            preferred: CGSize(width: 1500, height: 800),
+            minimum: CGSize(width: 1234, height: 67),
+            visibleSize: CGSize(width: 1920, height: 1050)
+        )
+
+        #expect(size.width == 1500)
+        #expect(size.height == 800)
+    }
+
+    @Test("Never exceeds the visible display")
+    func visibleSizeCaps() {
+        let size = AnnotationEditorWindowGeometry.resolvedContentSize(
+            preferred: CGSize(width: 4000, height: 3000),
+            minimum: CGSize(width: 1234, height: 67),
+            visibleSize: CGSize(width: 1920, height: 1050)
+        )
+
+        #expect(size.width == 1920)
+        #expect(size.height == 1050)
+    }
+
+    @Test("Honors a minimum wider than the display rather than clipping the toolbar")
+    func minimumBeatsAnUndersizedDisplay() {
+        let size = AnnotationEditorWindowGeometry.resolvedContentSize(
+            preferred: CGSize(width: 900, height: 500),
+            minimum: CGSize(width: 1234, height: 67),
+            visibleSize: CGSize(width: 1100, height: 700)
+        )
+
+        // Capping at 1100 would just be undone when AppKit re-applies
+        // `contentMinSize`, so the minimum has to win.
+        #expect(size.width == 1234)
+        #expect(size.height == 500)
+    }
+
+    @Test("Falls back to the minimum when the image budget degenerates to zero")
+    func degenerateImageBudgetUsesMinimum() {
+        let size = AnnotationEditorWindowGeometry.resolvedContentSize(
+            preferred: .zero,
+            minimum: CGSize(width: 1234, height: 67),
+            visibleSize: CGSize(width: 1920, height: 1050)
+        )
+
+        #expect(size.width == 1234)
+        #expect(size.height == 67)
+    }
+
     @Test("Centers a frame inside the visible display rect")
     func centersFrameInVisibleRect() {
         let frame = AnnotationEditorWindowGeometry.centeredFrame(

--- a/Packages/SharedKit/Tests/SharedKitTests/AnnotationEditorWindowGeometryTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AnnotationEditorWindowGeometryTests.swift
@@ -135,6 +135,20 @@ struct AnnotationEditorWindowGeometryTests {
         #expect(frame == CGRect(x: 500, y: 300, width: 400, height: 300))
     }
 
+    @Test("Pins a frame wider than the display to the visible origin")
+    func oversizedFrameIsPinnedOnscreen() {
+        let frame = AnnotationEditorWindowGeometry.centeredFrame(
+            size: CGSize(width: 1349, height: 538),
+            in: CGRect(x: 0, y: 62, width: 1024, height: 681)
+        )
+
+        // Centering would put it at x = -162.5, hanging off both edges; the
+        // toolbar's left-hand tools matter more than symmetry here.
+        #expect(frame.origin.x == 0)
+        #expect(frame.origin.y == 133.5)
+        #expect(frame.width == 1349)
+    }
+
     @Test("Rejects invalid geometry")
     func invalidGeometry() {
         #expect(

--- a/Packages/SharedKit/Tests/SharedKitTests/AnnotationEditorWindowGeometryTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AnnotationEditorWindowGeometryTests.swift
@@ -63,11 +63,11 @@ struct AnnotationEditorWindowGeometryTests {
         #expect(abs(size.height - 640) < 0.001)
     }
 
-    @Test("Grows to the SwiftUI tree's minimum when the image is smaller")
-    func minimumWins() {
+    @Test("Grows to the toolbar's natural width when the image is smaller")
+    func fittingWins() {
         let size = AnnotationEditorWindowGeometry.resolvedContentSize(
             preferred: CGSize(width: 300, height: 250),
-            minimum: CGSize(width: 1234, height: 67),
+            fitting: CGSize(width: 1234, height: 67),
             visibleSize: CGSize(width: 1920, height: 1050)
         )
 
@@ -75,11 +75,11 @@ struct AnnotationEditorWindowGeometryTests {
         #expect(size.height == 250)
     }
 
-    @Test("Keeps the image size when it already clears the minimum")
+    @Test("Keeps the image size when it already clears the toolbar")
     func preferredWins() {
         let size = AnnotationEditorWindowGeometry.resolvedContentSize(
             preferred: CGSize(width: 1500, height: 800),
-            minimum: CGSize(width: 1234, height: 67),
+            fitting: CGSize(width: 1234, height: 67),
             visibleSize: CGSize(width: 1920, height: 1050)
         )
 
@@ -91,7 +91,7 @@ struct AnnotationEditorWindowGeometryTests {
     func visibleSizeCaps() {
         let size = AnnotationEditorWindowGeometry.resolvedContentSize(
             preferred: CGSize(width: 4000, height: 3000),
-            minimum: CGSize(width: 1234, height: 67),
+            fitting: CGSize(width: 1234, height: 67),
             visibleSize: CGSize(width: 1920, height: 1050)
         )
 
@@ -99,25 +99,25 @@ struct AnnotationEditorWindowGeometryTests {
         #expect(size.height == 1050)
     }
 
-    @Test("Honors a minimum wider than the display rather than clipping the toolbar")
-    func minimumBeatsAnUndersizedDisplay() {
+    @Test("Caps a toolbar wider than the display instead of overflowing it")
+    func displayBeatsAnOversizedToolbar() {
         let size = AnnotationEditorWindowGeometry.resolvedContentSize(
             preferred: CGSize(width: 900, height: 500),
-            minimum: CGSize(width: 1234, height: 67),
+            fitting: CGSize(width: 1234, height: 67),
             visibleSize: CGSize(width: 1100, height: 700)
         )
 
-        // Capping at 1100 would just be undone when AppKit re-applies
-        // `contentMinSize`, so the minimum has to win.
-        #expect(size.width == 1234)
+        // The tool row scrolls, so 1234 is only a preference — the window has
+        // to stay on the display and can still be centered there.
+        #expect(size.width == 1100)
         #expect(size.height == 500)
     }
 
-    @Test("Falls back to the minimum when the image budget degenerates to zero")
-    func degenerateImageBudgetUsesMinimum() {
+    @Test("Falls back to the toolbar size when the image budget degenerates to zero")
+    func degenerateImageBudgetUsesFittingSize() {
         let size = AnnotationEditorWindowGeometry.resolvedContentSize(
             preferred: .zero,
-            minimum: CGSize(width: 1234, height: 67),
+            fitting: CGSize(width: 1234, height: 67),
             visibleSize: CGSize(width: 1920, height: 1050)
         )
 


### PR DESCRIPTION
## Summary

The Annotate window opened oversized and off-center. The cause is the editor toolbar: it's a row of fixed-width controls, so its `NSHostingView` has a ~1234pt intrinsic width. AppKit installs that as the window's `contentMinSize` and applies it on a runloop pass *after* the window has been positioned — widening it rightwards from a fixed origin.

- Resolve the hosting view's fitting size before computing the frame, so the window is born at the size AppKit would force it to anyway, then center that.
- Convert capture pixels to points using the anchor screen's backing scale, and center the full titled frame (titlebar chrome included).
- Bind ⌘C explicitly to copy-and-close in both editor toolbars, and advertise `⌘C · ⏎ · ⌘⇧C` in the Copy tooltip.
- Replace the centering test with one that asserts the real invariant after the runloop settles, plus unit coverage for the new geometry.

## Root cause

Measured on a 1920×1050 display with a 600×400px capture:

```
frame after show()      = (810, 354, 1234, 342)   midX = 1427   ✗ 467pt off-center
```

The window is positioned correctly, then grown to `contentMinSize` with `origin.x` pinned.

Retina pixel→point conversion is a real bug too, but fixing it alone makes the symptom **worse**: halving the width pushes more captures below the toolbar minimum, so they get grown further off-center. On a 13" MacBook Air `0.8 × 1470pt = 1176pt` is already under the toolbar's minimum, so every capture on that hardware is affected.

`AnnotationEditorWindowGeometry.resolvedContentSize` reconciles the three constraints: the image-derived size, the SwiftUI tree's minimum (which always wins, since AppKit applies it regardless), and the visible display as a cap that never drops below the minimum. This also removes the degenerate `.zero` window on very short displays.

## Notes

- `show()` now applies the centered frame only on first presentation, so a window the user has since dragged isn't yanked back to center.
- ⌘C already reaches copy-and-close today, but only because SwiftUI's `⌘⇧C` shortcut happens to match a plain ⌘C event. The explicit binding preserves the behaviour if that matching ever tightens. Both bindings stay behind the existing `isEditingText` guard, so a focused text field keeps ⌘C.
- The toolbar's tool row now scrolls horizontally, with the actions pinned beside it. This drops the hosting view's `contentMinSize` from 1234pt to 250pt while `fittingSize` still reports the natural 1246pt, so the natural width becomes a *preference* the display can override instead of a floor AppKit enforces. A display narrower than the toolbar (CI's runner is one: 1024pt visible against a 1349pt toolbar) now gets a window that fits and centers, with the tools scrolled rather than off-screen. Save/Copy/Pin/Close never scroll out of reach — the same split capcap and macshot use, where output actions live in a separate always-visible bar.
- Windows too tall to fit are still pinned to the visible origin rather than overhanging both edges, which is what AppKit clamps to anyway; computing it explicitly keeps the frame we set and the frame we get identical.
- On wide captures macOS occasionally nudges the window ~40pt during app activation (roughly a Dock-adjusted re-center). It reproduces about 2 in 12 runs and is independent of this sizing path, so the wide-capture test asserts placement before presentation and size stability after.
- The app-level tests assert that the frame survives presentation unchanged. That is the actual regression — AppKit widening the window after the fact — and unlike a centering assertion it holds on any display size.

## Test plan

- [x] `swift test --package-path Packages/SharedKit` — 185 tests
- [x] `xcodebuild test -project Capso.xcodeproj -scheme Capso` — 123 tests
- [x] Centering suite run 3× consecutively for flake
- [x] CI green on the 1024pt-wide runner
- [x] Rendered the toolbar at 900 / 1246 / 1600pt content widths — actions stay pinned, tools scroll, no visual change at natural width
- [ ] Manual: resize the Annotate window narrow → tools scroll, Save/Copy stay reachable
- [x] Verified red/green: disabling the minimum-size resolution puts the window 467pt off-center
- [ ] Manual: area capture → Quick Access → `⌘E` Annotate → window is centered on the capture screen
- [ ] Manual: small area capture (narrower than the toolbar) → window is centered, toolbar not clipped
- [ ] Manual: wide Retina area capture → window fits the display and stays centered
- [ ] Manual: Annotate → `⌘C` with nothing selected → image copied, window closes
- [ ] Manual: Annotate → select an annotation → `⌘C` copies the object, window stays open
- [ ] Manual: Annotate → editing a text annotation → `⌘C` copies text, window stays open

Fixes #236

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are localized to annotate window geometry, toolbar layout, and keyboard shortcuts, with strong test coverage and no auth or data-path changes.
> 
> **Overview**
> Fixes **issue #236**: the Annotate window opened oversized and off-center because AppKit widened the window to the SwiftUI toolbar’s intrinsic width *after* positioning, and Retina captures were sized in pixels instead of points.
> 
> **Window layout:** Adds `AnnotationEditorWindowGeometry` for pixel→point conversion, viewport fitting, reconciling image size with the hosting view’s fitting size (capped by the display), and centering or pinning oversized frames. `AnnotationEditorWindow` resolves the hosting view size before centering, re-applies the preferred frame on first `show()`, and stops forcing frame on init in favor of this path.
> 
> **Toolbar:** The main tool row is a horizontal `ScrollView` so Save/Copy/Close stay visible on narrow displays; copy actions get explicit hidden shortcuts for **⌘C** and Return (when nothing is selected / canvas declines copy), with updated tooltips. The inline editor mirrors the copy shortcut behavior.
> 
> **Tests:** New geometry unit tests, centering regression tests, and clipboard shortcut tests for full/inline editors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cb9ae181272af31468a5c1109f3ddb626e38d10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


