### PR TITLE
Fix OCR onboarding window leak causing constant background CPU use

### DIFF
--- a/App/Sources/OCR/OCRCoordinator.swift
+++ b/App/Sources/OCR/OCRCoordinator.swift
@@ -156,9 +156,11 @@ final class OCRCoordinator {
         onboardingWindow = OCROnboardingWindow(onDismiss: { [weak self] in
             self?.settings.ocrOnboardingShown = true
             self?.onboardingWindow?.close()
-            self?.onboardingWindow = nil
             action()
         })
+        onboardingWindow?.onClose = { [weak self] in
+            self?.onboardingWindow = nil
+        }
         onboardingWindow?.show()
     }
 

--- a/App/Sources/OCR/OCRCoordinator.swift
+++ b/App/Sources/OCR/OCRCoordinator.swift
@@ -153,6 +153,10 @@ final class OCRCoordinator {
     // MARK: - Onboarding
 
     private func showOnboarding(then action: @escaping () -> Void) {
+        // Tear down any existing panel first (same pattern as showOCROverlay):
+        // re-triggering OCR while onboarding is still open would otherwise
+        // orphan the old panel with its repeatForever animations running.
+        onboardingWindow?.close()
         onboardingWindow = OCROnboardingWindow(onDismiss: { [weak self] in
             self?.settings.ocrOnboardingShown = true
             self?.onboardingWindow?.close()

--- a/App/Sources/OCR/OCROnboardingWindow.swift
+++ b/App/Sources/OCR/OCROnboardingWindow.swift
@@ -6,6 +6,8 @@ import SwiftUI
 final class OCROnboardingWindow: NSPanel {
     private var onDismissAction: (() -> Void)?
 
+    var onClose: (() -> Void)?
+
     init(onDismiss: @escaping () -> Void) {
         self.onDismissAction = onDismiss
 
@@ -34,6 +36,7 @@ final class OCROnboardingWindow: NSPanel {
     }
 
     override func close() {
+        onClose?()
         super.close()
     }
 }


### PR DESCRIPTION
## What changed

`OCRCoordinator` only cleared its reference to `OCROnboardingWindow` inside the
"Got it!" dismiss closure. Closing the dialog with the titlebar close button or
Cmd+W calls `close()` directly and never runs that closure, so the coordinator
held onto the window and it was never deallocated.

That alone would just be a small leak, except `OCROnboardingView` starts three
`.repeatForever` animations in `onAppear` (the selection, scan and toast step
cards). Those only stop when the view tree goes away, so a leaked window keeps
submitting Core Animation transactions on every display refresh indefinitely,
with nothing visible on screen.

This moves the cleanup into `close()`, which every dismiss path goes through,
using the same `onClose` callback that `showOCROverlay` already uses a few lines
up in the same file.

### How to reproduce

1. Trigger Capture Text (OCR) for the first time so the onboarding dialog appears
2. Close it with the titlebar close button instead of "Got it!"
3. Capso stays at 15-20% CPU indefinitely, with no window on screen

<img width="439" height="167" alt="Bildschirmfoto 2026-08-10 um 01 36 49" src="https://github.com/user-attachments/assets/67cdf2d4-a85e-4bbf-bd1b-8937fec23216" />
<img width="439" height="167" alt="Bildschirmfoto 2026-08-10 um 01 45 46" src="https://github.com/user-attachments/assets/fd70d84d-424e-4081-b42d-3adc35318b69" />


I ran into this on a machine where Capso had been running for 8 days at a steady
18-20% CPU, roughly 25 hours of CPU time in total. `sample` showed the main
thread spending about a third of all samples under:
```
UC::DriverCore::continueProcessing()
CA::Transaction::flush()
NSHostingView.layout()
+[NSAnimationContext runAnimationGroup:]
ViewGraphRootValueUpdater.render()
```

The window server also listed a 700x448 offscreen window for the process, which
matches `OCROnboardingWindow`'s 700x420 content rect plus the standard titlebar,
and `ocrOnboardingShown` was missing from defaults. Both are consistent with the
dialog having been dismissed without going through "Got it!".

### Notes

`TranslationOnboardingWindow` has the same lifetime pattern and leaks the same
way, but `TranslationOnboardingView` has no animations so it costs nothing at
runtime. I left it out to keep this PR focused, happy to send a follow-up.

Closing from the titlebar also skips setting `ocrOnboardingShown`, so the dialog
comes back next time. That is a separate issue and not touched here.

## Related issue

None, found while tracking down battery drain.

## Screenshots / recordings

No UI change.

## Checklist

- [ ] `xcodegen generate` run if `project.yml` or source layout changed — not needed, neither changed
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass — no package touched, change is in the `App` target
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency