### PR TITLE
fix: keep the scroll capture HUD controls clear of the Dock

### DIFF
--- a/App/Sources/Capture/ScrollCaptureHUD.swift
+++ b/App/Sources/Capture/ScrollCaptureHUD.swift
@@ -188,14 +188,14 @@ final class ScrollCaptureOverlay {
         // Try below the selection first
         var controlsY = screenRect.origin.y - controlsHeight - gap
 
-        // If not enough space below (off-screen), show above the selection
-        if controlsY < screen.frame.origin.y {
+        // If not enough space below (off-screen or under the Dock), show above the selection
+        if controlsY < screen.visibleFrame.origin.y {
             controlsY = screenRect.maxY + gap
         }
 
         // If still off-screen (selection fills entire height), show inside at the bottom
-        if controlsY + controlsHeight > screen.frame.maxY {
-            controlsY = screenRect.origin.y + 8
+        if controlsY + controlsHeight > screen.visibleFrame.maxY {
+            controlsY = max(screen.visibleFrame.origin.y, screenRect.origin.y + 8)
         }
 
         let controlsRect = NSRect(


### PR DESCRIPTION
## What changed

`ScrollCaptureOverlay.showControls` picked the position for the Cancel / Start
bar by testing against `screen.frame`, which spans the whole physical display —
including the strip the Dock sits in. So when a scrolling-capture selection was
dragged near the bottom of the screen, the "is there room below?" check passed
even though the resulting position was inside the Dock's strip, and the buttons
ended up behind the Dock where they can't be clicked. The panel runs at
`.floating`, which is below the Dock's window level, so there was no way to get
at them.

The last-resort branch had the same problem: with a tall selection it falls back
to placing the bar just inside the selection's bottom edge, which can also land
under the Dock.

Both checks now use `screen.visibleFrame`, and the fallback is clamped to its
floor. This is what `CaptureAllInOneToolbarWindow` and the other capture HUDs
already do — `ScrollCaptureHUD` was the only place still measuring against the
physical frame. Reading the live `visibleFrame` also means Dock auto-hide, Dock
size, Dock position and multi-display setups are handled by AppKit rather than
by assumptions in this file.

## Related issue

Closes #243

## Screenshots / recordings

| Before | After |
| --- | --- |
| <img width="420" alt="Before — controls hidden behind the Dock" src="https://github.com/user-attachments/assets/a7a98abb-d209-4307-bdd5-d35aa1b0a091" /> | <img width="420" alt="After — controls placed above the selection" src="https://github.com/user-attachments/assets/62407c24-5294-4124-9c7e-251a2de70c7f" /> |
| Selection dragged to the bottom of the screen — the Cancel / Start bar is placed inside the Dock's strip and is unreachable. | Same selection — the bar now flips above the selection and stays clear of the Dock. |


## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed *(no source layout change; ran it anyway, no diff)*
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass *(no package touched — change is in the app target)*
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)