### PR TITLE
fix: keep Dock out of scrolling captures

### DIFF
--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -1176,12 +1176,20 @@ final class CaptureCoordinator {
 
     private func startScrollingCapture(rect: CGRect, screen: NSScreen) {
         let screenFrame = screen.frame
-        // Convert from bottom-left (NSView) to top-left (ScreenCaptureKit) coordinates
-        scrollCaptureRect = CGRect(
-            x: rect.origin.x,
-            y: screenFrame.height - rect.origin.y - rect.height,
-            width: rect.width,
-            height: rect.height
+        let clampedSelection = ScrollCaptureGeometry.clampedScreenLocalSelection(
+            selectionRect: rect,
+            screenFrame: screenFrame,
+            visibleFrame: screen.visibleFrame
+        )
+        guard !clampedSelection.isNull,
+              clampedSelection.width >= 2,
+              clampedSelection.height >= 2 else {
+            return
+        }
+
+        scrollCaptureRect = ScrollCaptureGeometry.topLeftCaptureRect(
+            screenLocalSelection: clampedSelection,
+            screenHeight: screenFrame.height
         )
         scrollCaptureDisplayID = screen.displayID
 
@@ -1201,7 +1209,7 @@ final class CaptureCoordinator {
             self?.cancelScrollingCapture()
         }
 
-        overlay.show(selectionRect: rect, screen: screen)
+        overlay.show(selectionRect: clampedSelection, screen: screen)
     }
 
     /// Called when user clicks Start — begins the capture loop.

--- a/App/Sources/Capture/ScrollCaptureHUD.swift
+++ b/App/Sources/Capture/ScrollCaptureHUD.swift
@@ -2,6 +2,7 @@
 import AppKit
 import SwiftUI
 import CaptureKit
+import SharedKit
 
 /// Persistent overlay shown during scrolling capture.
 /// Shows: selection border, live preview on the left, Cancel/Start/Done at the bottom.
@@ -181,28 +182,9 @@ final class ScrollCaptureOverlay {
     // MARK: - Controls
 
     private func showControls(screenRect: NSRect, screen: NSScreen) {
-        let controlsWidth: CGFloat = 300
-        let controlsHeight: CGFloat = 52
-        let gap: CGFloat = 10
-
-        // Try below the selection first
-        var controlsY = screenRect.origin.y - controlsHeight - gap
-
-        // If not enough space below (off-screen), show above the selection
-        if controlsY < screen.frame.origin.y {
-            controlsY = screenRect.maxY + gap
-        }
-
-        // If still off-screen (selection fills entire height), show inside at the bottom
-        if controlsY + controlsHeight > screen.frame.maxY {
-            controlsY = screenRect.origin.y + 8
-        }
-
-        let controlsRect = NSRect(
-            x: screenRect.midX - controlsWidth / 2,
-            y: controlsY,
-            width: controlsWidth,
-            height: controlsHeight
+        let controlsRect = ScrollCaptureOverlayPlacement.controlsFrame(
+            selectionRect: screenRect,
+            visibleFrame: screen.visibleFrame
         )
 
         let panel = NSPanel(
@@ -232,18 +214,10 @@ final class ScrollCaptureOverlay {
     // MARK: - Preview
 
     private func showPreview(screenRect: NSRect, screen: NSScreen) {
-        let previewWidth: CGFloat = 180
-        let previewHeight: CGFloat = min(screenRect.height, 400)
-        let previewX = screenRect.origin.x - previewWidth - 12
-
-        guard previewX >= screen.frame.origin.x else { return }
-
-        let previewRect = NSRect(
-            x: previewX,
-            y: screenRect.midY - previewHeight / 2,
-            width: previewWidth,
-            height: previewHeight
-        )
+        guard let previewRect = ScrollCaptureOverlayPlacement.previewFrame(
+            selectionRect: screenRect,
+            visibleFrame: screen.visibleFrame
+        ) else { return }
 
         let panel = NSPanel(
             contentRect: previewRect,

--- a/Packages/CaptureKit/Sources/CaptureKit/Scrolling/ScrollCaptureController.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/Scrolling/ScrollCaptureController.swift
@@ -143,13 +143,21 @@ public final class ScrollCaptureController: @unchecked Sendable {
                     return nil
                 }
 
-                // Exclude all Capso windows (our overlay panels)
-                let myBundleID = Bundle.main.bundleIdentifier ?? ""
-                let myWindows = content.windows.filter {
-                    $0.owningApplication?.bundleIdentifier == myBundleID
+                let excludedBundleIDs: Set<String> = [
+                    Bundle.main.bundleIdentifier ?? "",
+                    "com.apple.dock",
+                    "com.apple.controlcenter",
+                    "com.apple.notificationcenterui",
+                    "com.apple.Spotlight",
+                ]
+                let excludedWindows = content.windows.filter { window in
+                    guard let bundleID = window.owningApplication?.bundleIdentifier else {
+                        return false
+                    }
+                    return excludedBundleIDs.contains(bundleID)
                 }
 
-                let filter = SCContentFilter(display: display, excludingWindows: myWindows)
+                let filter = SCContentFilter(display: display, excludingWindows: excludedWindows)
                 let streamConfig = SCStreamConfiguration()
                 streamConfig.captureResolution = .best
                 streamConfig.showsCursor = false

--- a/Packages/CaptureKit/Sources/CaptureKit/Scrolling/ScrollCaptureGeometry.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/Scrolling/ScrollCaptureGeometry.swift
@@ -1,0 +1,49 @@
+import CoreGraphics
+
+/// Geometry helpers for scrolling capture selection and ScreenCaptureKit rects.
+public enum ScrollCaptureGeometry {
+    /// Clamps a screen-local, bottom-left selection into the screen-local
+    /// `visibleFrame` so Dock / menu bar never enter the capture rect.
+    public static func clampedScreenLocalSelection(
+        selectionRect: CGRect,
+        screenFrame: CGRect,
+        visibleFrame: CGRect
+    ) -> CGRect {
+        let selection = selectionRect.standardized
+        let screen = screenFrame.standardized
+        let visible = visibleFrame.standardized
+
+        guard selection.width > 0,
+              selection.height > 0,
+              screen.width > 0,
+              screen.height > 0,
+              visible.width > 0,
+              visible.height > 0 else {
+            return .null
+        }
+
+        let localVisible = CGRect(
+            x: visible.minX - screen.minX,
+            y: visible.minY - screen.minY,
+            width: visible.width,
+            height: visible.height
+        )
+        let intersection = selection.intersection(localVisible)
+        return intersection.isNull || intersection.isEmpty ? .null : intersection
+    }
+
+    /// Converts a screen-local bottom-left rect into a top-left rect for
+    /// ScreenCaptureKit's `sourceRect` (relative to the display origin).
+    public static func topLeftCaptureRect(
+        screenLocalSelection: CGRect,
+        screenHeight: CGFloat
+    ) -> CGRect {
+        let selection = screenLocalSelection.standardized
+        return CGRect(
+            x: selection.origin.x,
+            y: screenHeight - selection.origin.y - selection.height,
+            width: selection.width,
+            height: selection.height
+        )
+    }
+}

--- a/Packages/CaptureKit/Tests/CaptureKitTests/ScrollCaptureGeometryTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/ScrollCaptureGeometryTests.swift
@@ -1,0 +1,61 @@
+import CoreGraphics
+import Testing
+@testable import CaptureKit
+
+@Suite("ScrollCaptureGeometry")
+struct ScrollCaptureGeometryTests {
+    /// 1440×900 display with a 70pt Dock along the bottom and a 25pt menu bar.
+    private let screenFrame = CGRect(x: 0, y: 0, width: 1_440, height: 900)
+    private let visibleFrame = CGRect(x: 0, y: 70, width: 1_440, height: 805)
+
+    @Test("Selection overlapping the Dock is cropped above the Dock")
+    func clampsBottomEdgeAboveDock() {
+        let selection = CGRect(x: 100, y: 0, width: 800, height: 600)
+
+        let clamped = ScrollCaptureGeometry.clampedScreenLocalSelection(
+            selectionRect: selection,
+            screenFrame: screenFrame,
+            visibleFrame: visibleFrame
+        )
+
+        #expect(clamped == CGRect(x: 100, y: 70, width: 800, height: 530))
+    }
+
+    @Test("Selection fully inside the visible frame is unchanged")
+    func leavesInBoundsSelectionUnchanged() {
+        let selection = CGRect(x: 200, y: 120, width: 700, height: 400)
+
+        let clamped = ScrollCaptureGeometry.clampedScreenLocalSelection(
+            selectionRect: selection,
+            screenFrame: screenFrame,
+            visibleFrame: visibleFrame
+        )
+
+        #expect(clamped == selection)
+    }
+
+    @Test("Selection only covering the Dock is rejected")
+    func rejectsDockOnlySelection() {
+        let selection = CGRect(x: 0, y: 0, width: 1_440, height: 60)
+
+        let clamped = ScrollCaptureGeometry.clampedScreenLocalSelection(
+            selectionRect: selection,
+            screenFrame: screenFrame,
+            visibleFrame: visibleFrame
+        )
+
+        #expect(clamped.isNull || clamped.isEmpty)
+    }
+
+    @Test("Top-left conversion flips Y against the full screen height")
+    func topLeftConversionUsesScreenHeight() {
+        let selection = CGRect(x: 100, y: 70, width: 800, height: 530)
+
+        let topLeft = ScrollCaptureGeometry.topLeftCaptureRect(
+            screenLocalSelection: selection,
+            screenHeight: screenFrame.height
+        )
+
+        #expect(topLeft == CGRect(x: 100, y: 300, width: 800, height: 530))
+    }
+}

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ScrollCaptureOverlayPlacement.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ScrollCaptureOverlayPlacement.swift
@@ -1,0 +1,103 @@
+import CoreGraphics
+
+/// Placement for the floating controls/preview shown during scrolling capture.
+///
+/// Coordinates are AppKit bottom-left. Bounds must be the screen's `visibleFrame`
+/// so Dock and menu bar never cover the chrome.
+public enum ScrollCaptureOverlayPlacement {
+    public static let defaultControlsSize = CGSize(width: 300, height: 52)
+    public static let defaultControlsGap: CGFloat = 10
+    public static let defaultMargin: CGFloat = 8
+    public static let defaultPreviewWidth: CGFloat = 180
+    public static let defaultPreviewGap: CGFloat = 12
+    public static let defaultMaxPreviewHeight: CGFloat = 400
+
+    /// Prefer below the selection, then above, then inside the visible area.
+    public static func controlsFrame(
+        selectionRect: CGRect,
+        visibleFrame: CGRect,
+        controlsSize: CGSize = defaultControlsSize,
+        gap: CGFloat = defaultControlsGap,
+        margin: CGFloat = defaultMargin
+    ) -> CGRect {
+        let selection = selectionRect.standardized
+        let visible = visibleFrame.standardized
+        let width = max(0, min(controlsSize.width, max(0, visible.width - margin * 2)))
+        let height = max(0, min(controlsSize.height, max(0, visible.height - margin * 2)))
+
+        let belowY = selection.minY - height - gap
+        let aboveY = selection.maxY + gap
+
+        let y: CGFloat
+        if belowY >= visible.minY + margin {
+            y = belowY
+        } else if aboveY + height <= visible.maxY - margin {
+            y = aboveY
+        } else {
+            y = clampedOrigin(
+                value: selection.minY + margin,
+                lowerBound: visible.minY + margin,
+                upperBound: visible.maxY - height - margin
+            )
+        }
+
+        let x = clampedOrigin(
+            value: selection.midX - width / 2,
+            lowerBound: visible.minX + margin,
+            upperBound: visible.maxX - width - margin
+        )
+
+        return CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    /// Prefer the left of the selection; fall back to the right. Returns `nil`
+    /// when neither side fits inside `visibleFrame`.
+    public static func previewFrame(
+        selectionRect: CGRect,
+        visibleFrame: CGRect,
+        previewWidth: CGFloat = defaultPreviewWidth,
+        maxPreviewHeight: CGFloat = defaultMaxPreviewHeight,
+        gap: CGFloat = defaultPreviewGap,
+        margin: CGFloat = defaultMargin
+    ) -> CGRect? {
+        let selection = selectionRect.standardized
+        let visible = visibleFrame.standardized
+        let width = max(0, min(previewWidth, max(0, visible.width - margin * 2)))
+        guard width > 0 else { return nil }
+
+        let height = max(
+            0,
+            min(min(selection.height, maxPreviewHeight), max(0, visible.height - margin * 2))
+        )
+        guard height > 0 else { return nil }
+
+        let leftX = selection.minX - width - gap
+        let rightX = selection.maxX + gap
+        let x: CGFloat?
+        if leftX >= visible.minX + margin {
+            x = leftX
+        } else if rightX + width <= visible.maxX - margin {
+            x = rightX
+        } else {
+            x = nil
+        }
+        guard let x else { return nil }
+
+        let y = clampedOrigin(
+            value: selection.midY - height / 2,
+            lowerBound: visible.minY + margin,
+            upperBound: visible.maxY - height - margin
+        )
+
+        return CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    private static func clampedOrigin(
+        value: CGFloat,
+        lowerBound: CGFloat,
+        upperBound: CGFloat
+    ) -> CGFloat {
+        guard lowerBound <= upperBound else { return lowerBound }
+        return max(lowerBound, min(value, upperBound))
+    }
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/ScrollCaptureOverlayPlacementTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ScrollCaptureOverlayPlacementTests.swift
@@ -1,0 +1,108 @@
+import CoreGraphics
+import Testing
+@testable import SharedKit
+
+@Suite("ScrollCaptureOverlayPlacement")
+struct ScrollCaptureOverlayPlacementTests {
+    /// Mimics a 1440×900 display with a 70pt Dock along the bottom.
+    private let visibleFrame = CGRect(x: 0, y: 70, width: 1_440, height: 800)
+    private let controlsSize = CGSize(width: 300, height: 52)
+
+    @Test("Controls sit below the selection when there is room above the Dock")
+    func controlsPreferBelowWhenSpaceAllows() {
+        let selection = CGRect(x: 200, y: 300, width: 800, height: 400)
+
+        let frame = ScrollCaptureOverlayPlacement.controlsFrame(
+            selectionRect: selection,
+            visibleFrame: visibleFrame,
+            controlsSize: controlsSize
+        )
+
+        #expect(frame == CGRect(x: 450, y: 238, width: 300, height: 52))
+        #expect(frame.minY >= visibleFrame.minY)
+    }
+
+    @Test("Controls flip above the selection when the Dock would cover them")
+    func controlsFlipAboveNearDock() {
+        // Selection bottom edge is just above the Dock; below-placement would
+        // land inside the Dock exclusion zone (y < 70).
+        let selection = CGRect(x: 200, y: 90, width: 800, height: 500)
+
+        let frame = ScrollCaptureOverlayPlacement.controlsFrame(
+            selectionRect: selection,
+            visibleFrame: visibleFrame,
+            controlsSize: controlsSize
+        )
+
+        #expect(frame.origin == CGPoint(x: 450, y: 600))
+        #expect(frame.minY >= visibleFrame.minY)
+        #expect(frame.maxY <= visibleFrame.maxY)
+    }
+
+    @Test("Controls stay inside the visible frame when the selection is full height")
+    func controlsStayInsideWhenSelectionFillsHeight() {
+        let selection = CGRect(x: 100, y: 70, width: 1_200, height: 800)
+
+        let frame = ScrollCaptureOverlayPlacement.controlsFrame(
+            selectionRect: selection,
+            visibleFrame: visibleFrame,
+            controlsSize: controlsSize
+        )
+
+        #expect(frame.minX >= visibleFrame.minX)
+        #expect(frame.maxX <= visibleFrame.maxX)
+        #expect(frame.minY >= visibleFrame.minY)
+        #expect(frame.maxY <= visibleFrame.maxY)
+    }
+
+    @Test("Controls X is clamped when the selection is near the screen edge")
+    func controlsXIsClampedNearEdge() {
+        let selection = CGRect(x: 0, y: 300, width: 120, height: 200)
+
+        let frame = ScrollCaptureOverlayPlacement.controlsFrame(
+            selectionRect: selection,
+            visibleFrame: visibleFrame,
+            controlsSize: controlsSize
+        )
+
+        #expect(frame.minX == visibleFrame.minX + ScrollCaptureOverlayPlacement.defaultMargin)
+        #expect(frame.maxX <= visibleFrame.maxX)
+    }
+
+    @Test("Preview prefers the left side of the selection")
+    func previewPrefersLeft() {
+        let selection = CGRect(x: 400, y: 200, width: 600, height: 500)
+
+        let frame = ScrollCaptureOverlayPlacement.previewFrame(
+            selectionRect: selection,
+            visibleFrame: visibleFrame
+        )
+
+        #expect(frame == CGRect(x: 208, y: 250, width: 180, height: 400))
+    }
+
+    @Test("Preview falls back to the right when the left side is blocked")
+    func previewFallsBackToRight() {
+        let selection = CGRect(x: 20, y: 200, width: 600, height: 500)
+
+        let frame = ScrollCaptureOverlayPlacement.previewFrame(
+            selectionRect: selection,
+            visibleFrame: visibleFrame
+        )
+
+        #expect(frame?.origin.x == 632)
+        #expect(frame?.width == 180)
+    }
+
+    @Test("Preview is omitted when neither side fits")
+    func previewOmittedWhenNoSideFits() {
+        let selection = CGRect(x: 8, y: 200, width: 1_424, height: 500)
+
+        let frame = ScrollCaptureOverlayPlacement.previewFrame(
+            selectionRect: selection,
+            visibleFrame: visibleFrame
+        )
+
+        #expect(frame == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Clamp scrolling-capture selections to `screen.visibleFrame` so the Dock/menu bar never enter the capture rect.
- Exclude Dock and other system UI windows from scrolling frame capture as a second line of defense.
- Place Cancel/Start/Done with shared visible-frame geometry so controls stay clickable near the bottom.

Closes #243

## Test plan
- [x] `swift test --package-path Packages/CaptureKit --filter ScrollCaptureGeometryTests`
- [x] `swift test --package-path Packages/SharedKit --filter ScrollCaptureOverlayPlacementTests`
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug -destination 'platform=macOS' build`
- [x] Manual: select a scrolling region that overlaps the Dock, scroll multiple steps, confirm Dock is not repeated in the stitched image and controls remain above the Dock

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scrolling capture rects and ScreenCaptureKit window exclusion, which directly affects stitched output; behavior is covered by new unit tests but remains user-visible capture logic.
> 
> **Overview**
> Scrolling capture now **clamps the user’s selection to `visibleFrame`** before starting, so Dock and menu bar pixels are not part of the capture rect; selections that only cover the Dock are **silently dropped** (minimum 2×2 after clamp). Coordinate conversion for ScreenCaptureKit moves into **`ScrollCaptureGeometry`**.
> 
> The scrolling HUD **replaces inline layout math** with **`ScrollCaptureOverlayPlacement`**, placing Cancel/Start/Done and the live preview inside the visible area (below → above → inside for controls; left → right for preview).
> 
> During frame capture, **`ScrollCaptureController`** excludes Capso overlay windows **plus** Dock, Control Center, Notification Center, and Spotlight from the `SCContentFilter`, as a backup if system UI still overlaps the region.
> 
> Unit tests cover geometry clamping and overlay placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75f549222a6cdb51c3e1a16f900238446b241010. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->