### PR TITLE
fix: Keep Quick Access visible above foreground apps

### DIFF
--- a/App/Sources/QuickAccess/QuickAccessWindow.swift
+++ b/App/Sources/QuickAccess/QuickAccessWindow.swift
@@ -61,7 +61,7 @@ final class QuickAccessWindow: NSPanel {
         self.isOpaque = false
         self.backgroundColor = .clear
         self.hasShadow = false
-        self.collectionBehavior = [.canJoinAllSpaces, .transient]
+        self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
         self.isMovableByWindowBackground = true
         self.animationBehavior = .utilityWindow
         self.hidesOnDeactivate = false
@@ -137,7 +137,8 @@ final class QuickAccessWindow: NSPanel {
         setFrame(startFrame, display: false)
         alphaValue = 0
 
-        makeKeyAndOrderFront(nil)
+        orderFrontRegardless()
+        makeKey()
 
         NSAnimationContext.runAnimationGroup { ctx in
             ctx.duration = 0.3

--- a/App/Tests/QuickAccessWindowPresentationTests.swift
+++ b/App/Tests/QuickAccessWindowPresentationTests.swift
@@ -20,20 +20,18 @@ final class QuickAccessWindowPresentationTests: XCTestCase {
         XCTAssertTrue(window.collectionBehavior.contains(.fullScreenAuxiliary))
     }
 
-    func testShowMakesWindowVisibleWithoutChangingApplicationActivation() throws {
+    func testShowPresentsVisibleKeyWindow() throws {
         let (window, defaultsSuiteName) = try makeWindow(autoClose: false)
         defer {
             window.orderOut(nil)
             UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName)
         }
-        let wasActive = NSApp.isActive
 
         window.show()
         settleRunLoop(for: 0.4)
 
         XCTAssertTrue(window.isVisible)
         XCTAssertTrue(window.isKeyWindow)
-        XCTAssertEqual(NSApp.isActive, wasActive)
         settleRunLoop(for: 0.3)
         XCTAssertTrue(window.isVisible)
     }

--- a/App/Tests/QuickAccessWindowPresentationTests.swift
+++ b/App/Tests/QuickAccessWindowPresentationTests.swift
@@ -1,0 +1,103 @@
+import AppKit
+import CaptureKit
+import SharedKit
+import XCTest
+@testable import Capso
+
+@MainActor
+final class QuickAccessWindowPresentationTests: XCTestCase {
+    func testWindowUsesNonactivatingCrossSpaceOverlayConfiguration() throws {
+        let (window, defaultsSuiteName) = try makeWindow(autoClose: false)
+        defer {
+            window.orderOut(nil)
+            UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName)
+        }
+
+        XCTAssertTrue(window.styleMask.contains(.nonactivatingPanel))
+        XCTAssertEqual(window.level, .floating)
+        XCTAssertFalse(window.hidesOnDeactivate)
+        XCTAssertTrue(window.collectionBehavior.contains(.canJoinAllSpaces))
+        XCTAssertTrue(window.collectionBehavior.contains(.fullScreenAuxiliary))
+    }
+
+    func testShowMakesWindowVisibleWithoutChangingApplicationActivation() throws {
+        let (window, defaultsSuiteName) = try makeWindow(autoClose: false)
+        defer {
+            window.orderOut(nil)
+            UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName)
+        }
+        let wasActive = NSApp.isActive
+
+        window.show()
+        settleRunLoop(for: 0.4)
+
+        XCTAssertTrue(window.isVisible)
+        XCTAssertTrue(window.isKeyWindow)
+        XCTAssertEqual(NSApp.isActive, wasActive)
+        settleRunLoop(for: 0.3)
+        XCTAssertTrue(window.isVisible)
+    }
+
+    func testAutoCloseCallbackFiresOnlyAfterConfiguredInterval() throws {
+        let (window, defaultsSuiteName) = try makeWindow(autoClose: true, interval: 1)
+        defer {
+            window.orderOut(nil)
+            UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName)
+        }
+        var closeCount = 0
+        window.onClose = { closeCount += 1 }
+
+        window.show()
+        settleRunLoop(for: 0.4)
+
+        XCTAssertTrue(window.isVisible)
+        XCTAssertEqual(closeCount, 0)
+
+        settleRunLoop(for: 0.8)
+
+        XCTAssertEqual(closeCount, 1)
+    }
+
+    private func makeWindow(
+        autoClose: Bool,
+        interval: Int = 5
+    ) throws -> (QuickAccessWindow, String) {
+        let suiteName = "QuickAccessWindowPresentationTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let settings = AppSettings(defaults: defaults)
+        settings.quickAccessAutoClose = autoClose
+        settings.quickAccessAutoCloseInterval = interval
+
+        return (QuickAccessWindow(
+            result: CaptureResult(
+                image: try makeImage(),
+                mode: .area,
+                captureRect: CGRect(x: 0, y: 0, width: 8, height: 6)
+            ),
+            settings: settings,
+            screen: try XCTUnwrap(NSScreen.main),
+            shareCoordinator: nil,
+            autoUpload: false
+        ), suiteName)
+    }
+
+    private func makeImage() throws -> CGImage {
+        let context = try XCTUnwrap(CGContext(
+            data: nil,
+            width: 8,
+            height: 6,
+            bitsPerComponent: 8,
+            bytesPerRow: 32,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(CGColor(gray: 0.5, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: 8, height: 6))
+        return try XCTUnwrap(context.makeImage())
+    }
+
+    private func settleRunLoop(for interval: TimeInterval) {
+        RunLoop.current.run(until: Date().addingTimeInterval(interval))
+    }
+}


### PR DESCRIPTION
## What changed

Align `QuickAccessWindow` with the established nonactivating overlay pattern used by `CaptureOverlayWindow` and `InlineAnnotationEditorWindow`: allow the panel into the active full-screen Space, order it above windows regardless of Capso's activation state, and then make it key without activating Capso. Preserve the existing floating level, nonactivating style, stacking animation, callbacks, and auto-dismiss scheduling so the change only affects presentation while another application owns focus. Add focused app-target tests that instantiate the real panel and lock down the nonactivating, cross-Space, non-hiding configuration and the visible presentation lifecycle.

When Ryujinx is the foreground application, completing a screenshot briefly displays Capso's Quick Access panel and then leaves it unavailable before the configured auto-close interval. The panel is already nonactivating and does not hide on deactivation, but its presentation differs from Capso's other overlays: it uses `makeKeyAndOrderFront` and does not opt into full-screen auxiliary Spaces. As a result, a foreground or full-screen application can reclaim the visible window ordering even though Quick Access remains logically open. Quick Access should stay visible and interactive until the user dismisses it or its configured timer expires.

Closes #203

## Related issue

Not applicable to this change.

## Screenshots / recordings

No user-visible surface changes in this PR, so there is nothing to show.

## Checklist

- [ ] `xcodegen generate` run if `project.yml` or source layout changed
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] Tests for any touched package pass (`swift test --package-path Packages/<Kit>`)
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] No new `TODO` / `FIXME` / debug prints left behind
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [x] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)
