### PR TITLE
feat: choose the screenshot output format and quality

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -2979,6 +2979,50 @@
         }
       }
     },
+    "HEIC" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HEIC"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HEIC"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HEIC"
+          }
+        }
+      }
+    },
+    "HEIC produces the smallest files; PNG is lossless" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HEIC が最小のファイルサイズになります。PNG は劣化なしです"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HEIC가 파일 크기가 가장 작고, PNG는 무손실입니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "HEIC 生成的文件最小；PNG 为无损"
+          }
+        }
+      }
+    },
     "JPEG" : {
       "localizations" : {
         "ja" : {
@@ -4030,7 +4074,6 @@
       }
     },
     "Screenshot Format" : {
-      "extractionState" : "stale",
       "localizations" : {
         "ja" : {
           "stringUnit" : {

--- a/App/Sources/AnnotationEditor/AnnotationEditorView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorView.swift
@@ -12,7 +12,7 @@ struct AnnotationEditorView: View {
     let sourceAppName: String?
     let sourceWindowTitle: String?
     let captureDate: Date
-    let screenshotOutputPreset: ScreenshotOutputPreset
+    let screenshotOutput: ScreenshotOutputOptions
     let screenshotFilenameTemplate: String
     let onSave: (CGImage) -> Void
     let onCopy: (CGImage) -> Void
@@ -32,7 +32,7 @@ struct AnnotationEditorView: View {
         sourceAppName: String?,
         sourceWindowTitle: String?,
         captureDate: Date,
-        screenshotOutputPreset: ScreenshotOutputPreset,
+        screenshotOutput: ScreenshotOutputOptions,
         screenshotFilenameTemplate: String,
         onSave: @escaping (CGImage) -> Void,
         onCopy: @escaping (CGImage) -> Void,
@@ -46,7 +46,7 @@ struct AnnotationEditorView: View {
         self.sourceAppName = sourceAppName
         self.sourceWindowTitle = sourceWindowTitle
         self.captureDate = captureDate
-        self.screenshotOutputPreset = screenshotOutputPreset
+        self.screenshotOutput = screenshotOutput
         self.screenshotFilenameTemplate = screenshotFilenameTemplate
         self.onSave = onSave
         self.onCopy = onCopy
@@ -628,7 +628,7 @@ struct AnnotationEditorView: View {
             let fileURL = try dragFileStore.fileURL(
                 for: cache.renderedImage,
                 id: dragFileID,
-                preset: screenshotOutputPreset,
+                output: screenshotOutput,
                 date: captureDate,
                 sourceAppName: sourceAppName,
                 sourceWindowTitle: sourceWindowTitle,

--- a/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorWindow.swift
@@ -29,7 +29,7 @@ final class AnnotationEditorWindow: NSPanel, NSWindowDelegate {
         sourceAppName: String? = nil,
         sourceWindowTitle: String? = nil,
         captureDate: Date = Date(),
-        screenshotOutputPreset: ScreenshotOutputPreset,
+        screenshotOutput: ScreenshotOutputOptions,
         screenshotFilenameTemplate: String,
         onSave: @escaping (CGImage) -> Bool,
         onCopy: @escaping (CGImage) -> Void,
@@ -96,7 +96,7 @@ final class AnnotationEditorWindow: NSPanel, NSWindowDelegate {
             sourceAppName: sourceAppName,
             sourceWindowTitle: sourceWindowTitle,
             captureDate: captureDate,
-            screenshotOutputPreset: screenshotOutputPreset,
+            screenshotOutput: screenshotOutput,
             screenshotFilenameTemplate: screenshotFilenameTemplate,
             onSave: { [weak self] rendered in
                 // `onSave` may cancel (e.g. the user dismisses an "overwrite

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -1713,7 +1713,7 @@ final class CaptureCoordinator {
             sourceAppName: result.appName,
             sourceWindowTitle: result.windowName,
             captureDate: result.timestamp,
-            screenshotOutputPreset: settings.screenshotOutputPreset,
+            screenshotOutput: settings.screenshotOutputOptions,
             screenshotFilenameTemplate: settings.screenshotFilenameTemplate,
             onSave: { [weak self] (rendered: CGImage) -> Bool in
                 guard let self else { return false }
@@ -1921,7 +1921,7 @@ final class CaptureCoordinator {
             try temporaryFileStore.fileURL(
                 for: image,
                 id: UUID(),
-                preset: self.settings.screenshotOutputPreset,
+                output: self.settings.screenshotOutputOptions,
                 template: self.settings.screenshotFilenameTemplate
             )
         }
@@ -1948,7 +1948,7 @@ final class CaptureCoordinator {
             return try temporaryFileStore.fileURL(
                 for: result.image,
                 id: entryID,
-                preset: self.settings.screenshotOutputPreset,
+                output: self.settings.screenshotOutputOptions,
                 date: result.timestamp,
                 sourceAppName: result.appName,
                 sourceWindowTitle: result.windowName,
@@ -2010,7 +2010,7 @@ final class CaptureCoordinator {
         let url = FileNaming.generateFileURL(
             in: directory,
             type: .screenshot,
-            format: encoded.format,
+            format: encoded.format.fileFormat,
             date: date,
             sourceAppName: sourceAppName,
             sourceWindowTitle: sourceWindowTitle,
@@ -2025,18 +2025,12 @@ final class CaptureCoordinator {
         }
     }
 
-    private func screenshotData(from image: CGImage) -> (data: Data, format: FileFormat)? {
-        let preset = settings.screenshotOutputPreset
-        let data: Data? = switch preset.fileFormat {
-        case .png:
-            ImageUtilities.pngData(from: image)
-        case .jpeg:
-            ImageUtilities.jpegData(from: image, quality: preset.jpegQuality ?? 0.85)
-        case .mp4, .gif, .mov:
-            nil
-        }
-        guard let data else { return nil }
-        return (data, preset.fileFormat)
+    private func screenshotData(from image: CGImage) -> (data: Data, format: ScreenshotOutputFormat)? {
+        let output = settings.screenshotOutputOptions
+        guard let data = ImageEncoders.default.encode(
+            image, format: output.format, quality: output.quality
+        ) else { return nil }
+        return (data, output.format)
     }
 
     private func saveRenderedImage(
@@ -2076,14 +2070,17 @@ final class CaptureCoordinator {
         coord: ShareCoordinator
     ) async {
         let image = result.image
+        let output = settings.screenshotOutputOptions
 
-        // Encode + write off the main actor so large PNGs don't block the UI.
+        // Encode + write off the main actor so large images don't block the UI.
         logDiagnostic("Cloud Share encode starting size=\(image.width)x\(image.height)")
         let tempURL: URL? = await Task.detached(priority: .userInitiated) { () -> URL? in
             let url = FileManager.default.temporaryDirectory
                 .appendingPathComponent(UUID().uuidString)
-                .appendingPathExtension("png")
-            guard let data = ImageUtilities.pngData(from: image) else { return nil }
+                .appendingPathExtension(output.format.fileFormat.rawValue)
+            guard let data = ImageEncoders.default.encode(
+                image, format: output.format, quality: output.quality
+            ) else { return nil }
             do {
                 try data.write(to: url)
                 return url
@@ -2104,7 +2101,7 @@ final class CaptureCoordinator {
 
         do {
             logDiagnostic("Cloud Share upload starting")
-            let url = try await coord.upload(file: tempURL, contentType: "image/png")
+            let url = try await coord.upload(file: tempURL, contentType: output.format.mimeType)
             // ShareCoordinator already copied the URL to clipboard on success.
             logDiagnostic("Cloud Share upload succeeded host=\(url.host ?? "unknown")")
             historyCoordinator?.setCloudURL(id: entryID, url: url.absoluteString)

--- a/App/Sources/History/HistoryCoordinator.swift
+++ b/App/Sources/History/HistoryCoordinator.swift
@@ -2,6 +2,7 @@
 import AppKit
 import AVFoundation
 import ImageIO
+import UniformTypeIdentifiers
 import Observation
 import CaptureKit
 import ExportKit
@@ -156,7 +157,12 @@ final class HistoryCoordinator {
             fileExtension = "gif"
             contentType = "image/gif"
         case .area, .fullscreen, .window:
-            return PreparedUpload(url: sourceURL, contentType: "image/png", temporaryURL: nil)
+            let type = UTType(filenameExtension: sourceURL.pathExtension.lowercased())
+            return PreparedUpload(
+                url: sourceURL,
+                contentType: type?.preferredMIMEType ?? "image/png",
+                temporaryURL: nil
+            )
         }
 
         let quality = settings.exportQuality
@@ -405,7 +411,7 @@ final class HistoryCoordinator {
               let fullURL = fullImageURL(for: entry) else { return }
 
         let id = entry.id
-        let preset = settings.screenshotOutputPreset
+        let output = settings.screenshotOutputOptions
         let date = entry.createdAt
         let sourceAppName = entry.sourceAppName
         let sourceWindowTitle = entry.sourceWindowTitle
@@ -418,7 +424,7 @@ final class HistoryCoordinator {
                 return try? store.fileURL(
                     for: image,
                     id: id,
-                    preset: preset,
+                    output: output,
                     date: date,
                     sourceAppName: sourceAppName,
                     sourceWindowTitle: sourceWindowTitle,
@@ -464,7 +470,7 @@ final class HistoryCoordinator {
             let fileURL = try dragFileStore.fileURL(
                 for: image,
                 id: entry.id,
-                preset: settings.screenshotOutputPreset,
+                output: settings.screenshotOutputOptions,
                 date: entry.createdAt,
                 sourceAppName: entry.sourceAppName,
                 sourceWindowTitle: entry.sourceWindowTitle,
@@ -492,7 +498,7 @@ final class HistoryCoordinator {
             sourceAppName: entry.sourceAppName,
             sourceWindowTitle: entry.sourceWindowTitle,
             captureDate: entry.createdAt,
-            screenshotOutputPreset: settings.screenshotOutputPreset,
+            screenshotOutput: settings.screenshotOutputOptions,
             screenshotFilenameTemplate: settings.screenshotFilenameTemplate,
             onSave: { [weak self] rendered in
                 self?.replaceImage(for: entry, with: rendered)
@@ -620,7 +626,7 @@ final class HistoryCoordinator {
             return try temporaryFileStore.fileURL(
                 for: image,
                 id: UUID(),
-                preset: self.settings.screenshotOutputPreset,
+                output: self.settings.screenshotOutputOptions,
                 template: self.settings.screenshotFilenameTemplate
             )
         }
@@ -661,16 +667,10 @@ final class HistoryCoordinator {
         sourceWindowTitle: String?,
         date: Date
     ) {
-        let preset = settings.screenshotOutputPreset
-        let data: Data? = switch preset.fileFormat {
-        case .png:
-            ImageUtilities.pngData(from: image)
-        case .jpeg:
-            ImageUtilities.jpegData(from: image, quality: preset.jpegQuality ?? 0.85)
-        case .mp4, .gif, .mov:
-            nil
-        }
-        guard let data else { return }
+        let output = settings.screenshotOutputOptions
+        guard let data = ImageEncoders.default.encode(
+            image, format: output.format, quality: output.quality
+        ) else { return }
 
         let directory = settings.screenshotMonthlyFolders
             ? FileNaming.monthlyDirectory(in: settings.exportLocation)
@@ -678,7 +678,7 @@ final class HistoryCoordinator {
         let url = FileNaming.generateFileURL(
             in: directory,
             type: .screenshot,
-            format: preset.fileFormat,
+            format: output.format.fileFormat,
             date: date,
             sourceAppName: sourceAppName,
             sourceWindowTitle: sourceWindowTitle,
@@ -799,7 +799,7 @@ final class HistoryCoordinator {
             } else {
                 try await exportVideo(from: sourceURL, to: destinationURL, format: .mp4, exportQuality: exportQuality)
             }
-        case .png, .jpeg, .mov:
+        case .png, .jpeg, .heic, .mov:
             try copyItemReplacingExisting(from: sourceURL, to: destinationURL)
         }
     }

--- a/App/Sources/History/HistoryCoordinator.swift
+++ b/App/Sources/History/HistoryCoordinator.swift
@@ -97,7 +97,7 @@ final class HistoryCoordinator {
     /// format (H.264 .mp4 or actual .gif) BEFORE upload. Without this, Chrome
     /// and Firefox often fail to play .mov inline even when the codec is H.264 —
     /// the user gets a blank page when opening the share link. Screenshots
-    /// (.png) upload as-is.
+    /// upload as-is in their stored format.
     func uploadEntry(_ entry: HistoryEntry) async throws -> URL {
         guard let coord = shareCoordinator else {
             throw ShareError.notConfigured

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -137,14 +137,25 @@ final class PreferencesViewModel {
             }
         }
     }
-    var screenshotOutputPreset: ScreenshotOutputPreset {
+    var screenshotOutputFormat: ScreenshotOutputFormat {
         get {
-            access(keyPath: \.screenshotOutputPreset)
-            return settings.screenshotOutputPreset
+            access(keyPath: \.screenshotOutputFormat)
+            return settings.screenshotOutputFormat
         }
         set {
-            withMutation(keyPath: \.screenshotOutputPreset) {
-                settings.screenshotOutputPreset = newValue
+            withMutation(keyPath: \.screenshotOutputFormat) {
+                settings.screenshotOutputFormat = newValue
+            }
+        }
+    }
+    var screenshotOutputQualityPercent: Int {
+        get {
+            access(keyPath: \.screenshotOutputQualityPercent)
+            return settings.screenshotOutputQualityPercent
+        }
+        set {
+            withMutation(keyPath: \.screenshotOutputQualityPercent) {
+                settings.screenshotOutputQualityPercent = newValue
             }
         }
     }
@@ -570,7 +581,7 @@ final class PreferencesViewModel {
     var screenshotFilenamePreview: String {
         FileNaming.generateFileName(
             for: .screenshot,
-            format: screenshotOutputPreset.fileFormat,
+            format: screenshotOutputFormat.fileFormat,
             date: Self.filenamePreviewDate,
             sourceAppName: "Safari",
             sourceWindowTitle: "Example Window",

--- a/App/Sources/Preferences/Tabs/ExportSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ExportSettingsView.swift
@@ -11,6 +11,11 @@ struct ExportSettingsView: View {
         viewModel.exportLocation.path.replacingOccurrences(of: NSHomeDirectory(), with: "~")
     }
 
+    /// Hides formats this Mac has no encoder for, as on Intel models lacking HEVC.
+    private var availableScreenshotFormats: [ScreenshotOutputFormat] {
+        ScreenshotOutputFormat.allCases.filter(\.isAvailable)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             Text("Export")
@@ -27,14 +32,38 @@ struct ExportSettingsView: View {
                         .pickerStyle(.segmented)
                         .frame(width: 220)
                     }
-                    SettingRow(label: "Screenshot Quality", sublabel: "Applies to screenshot files", showDivider: true) {
-                        Picker("", selection: $viewModel.screenshotOutputPreset) {
-                            Text("PNG").tag(ScreenshotOutputPreset.losslessPNG)
-                            Text("JPEG 85%").tag(ScreenshotOutputPreset.standardJPEG)
-                            Text("JPEG 70%").tag(ScreenshotOutputPreset.compactJPEG)
+                    SettingRow(
+                        label: "Screenshot Format",
+                        sublabel: "HEIC produces the smallest files; PNG is lossless",
+                        showDivider: true
+                    ) {
+                        Picker("", selection: $viewModel.screenshotOutputFormat) {
+                            ForEach(availableScreenshotFormats, id: \.self) { format in
+                                switch format {
+                                case .png: Text("PNG").tag(format)
+                                case .jpeg: Text("JPEG").tag(format)
+                                case .heic: Text("HEIC").tag(format)
+                                }
+                            }
                         }
-                        .pickerStyle(.segmented)
-                        .frame(width: 240)
+                        .pickerStyle(.menu)
+                        .frame(width: 120)
+                    }
+                    if viewModel.screenshotOutputFormat.isLossy {
+                        SettingRow(label: "Screenshot Quality", showDivider: true) {
+                            HStack(spacing: 8) {
+                                Text("\(viewModel.screenshotOutputQualityPercent) %")
+                                    .font(.system(size: 13, weight: .medium).monospacedDigit())
+                                    .frame(minWidth: 42, alignment: .trailing)
+                                Stepper(
+                                    "",
+                                    value: $viewModel.screenshotOutputQualityPercent,
+                                    in: ScreenshotOutputFormat.qualityPercentRange,
+                                    step: 5
+                                )
+                                .labelsHidden()
+                            }
+                        }
                     }
                 }
             }

--- a/App/Sources/QuickAccess/QuickAccessView.swift
+++ b/App/Sources/QuickAccess/QuickAccessView.swift
@@ -12,7 +12,7 @@ struct QuickAccessView: View {
     let capturedAt: Date
     let sourceAppName: String?
     let sourceWindowTitle: String?
-    let screenshotOutputPreset: ScreenshotOutputPreset
+    let screenshotOutput: ScreenshotOutputOptions
     let screenshotFilenameTemplate: String
     let targetLanguageDisplay: String?  // e.g. "Simplified Chinese"
     let shareCoordinator: ShareCoordinator?
@@ -357,7 +357,7 @@ struct QuickAccessView: View {
             let url = try dragFileStore.fileURL(
                 for: captureImage,
                 id: dragFileID,
-                preset: screenshotOutputPreset,
+                output: screenshotOutput,
                 date: capturedAt,
                 sourceAppName: sourceAppName,
                 sourceWindowTitle: sourceWindowTitle,
@@ -380,7 +380,7 @@ struct QuickAccessView: View {
 
         let image = captureImage
         let id = dragFileID
-        let preset = screenshotOutputPreset
+        let output = screenshotOutput
         let date = capturedAt
         let sourceAppName = sourceAppName
         let sourceWindowTitle = sourceWindowTitle
@@ -393,7 +393,7 @@ struct QuickAccessView: View {
                     let url = try store.fileURL(
                         for: image,
                         id: id,
-                        preset: preset,
+                        output: output,
                         date: date,
                         sourceAppName: sourceAppName,
                         sourceWindowTitle: sourceWindowTitle,
@@ -448,13 +448,16 @@ struct QuickAccessView: View {
         defer { uploadAttemptGate.finish() }
 
         let image = captureImage  // capture into local for the detached closure
+        let output = screenshotOutput
 
-        // Encode + write off main actor — large PNGs block UI for hundreds of ms otherwise
+        // Encode + write off main actor — large images block UI for hundreds of ms otherwise
         let tempURL: URL? = await Task.detached(priority: .userInitiated) { () -> URL? in
             let url = FileManager.default.temporaryDirectory
                 .appendingPathComponent(UUID().uuidString)
-                .appendingPathExtension("png")
-            guard let data = ImageUtilities.pngData(from: image) else { return nil }
+                .appendingPathExtension(output.format.fileFormat.rawValue)
+            guard let data = ImageEncoders.default.encode(
+                image, format: output.format, quality: output.quality
+            ) else { return nil }
             do {
                 try data.write(to: url)
                 return url
@@ -471,7 +474,7 @@ struct QuickAccessView: View {
         defer { try? FileManager.default.removeItem(at: tempURL) }
 
         do {
-            let cloudURL = try await coord.upload(file: tempURL, contentType: "image/png")
+            let cloudURL = try await coord.upload(file: tempURL, contentType: output.format.mimeType)
             onUploadSucceeded?(cloudURL.absoluteString)
             visualState = .succeeded
             try? await Task.sleep(for: .seconds(3))

--- a/App/Sources/QuickAccess/QuickAccessWindow.swift
+++ b/App/Sources/QuickAccess/QuickAccessWindow.swift
@@ -80,7 +80,7 @@ final class QuickAccessWindow: NSPanel {
             capturedAt: result.timestamp,
             sourceAppName: result.appName,
             sourceWindowTitle: result.windowName,
-            screenshotOutputPreset: settings.screenshotOutputPreset,
+            screenshotOutput: settings.screenshotOutputOptions,
             screenshotFilenameTemplate: settings.screenshotFilenameTemplate,
             targetLanguageDisplay: targetDisplay,
             shareCoordinator: shareCoordinator,

--- a/App/Tests/AnnotationCanvasClipboardShortcutTests.swift
+++ b/App/Tests/AnnotationCanvasClipboardShortcutTests.swift
@@ -1,5 +1,6 @@
 import AnnotationKit
 import AppKit
+import SharedKit
 import XCTest
 
 @testable import Capso
@@ -60,7 +61,7 @@ final class AnnotationCanvasClipboardShortcutTests: XCTestCase {
         var copiedRenderedImage = false
         let window = AnnotationEditorWindow(
             image: try makeImage(),
-            screenshotOutputPreset: .losslessPNG,
+            screenshotOutput: ScreenshotOutputOptions(format: .png, quality: 0.85),
             screenshotFilenameTemplate: "Screenshot",
             onSave: { _ in true },
             onCopy: { _ in copiedRenderedImage = true },
@@ -132,7 +133,7 @@ final class AnnotationCanvasClipboardShortcutTests: XCTestCase {
         let copied = expectation(description: "Full editor image copied with ⌘C")
         let window = AnnotationEditorWindow(
             image: try makeImage(),
-            screenshotOutputPreset: .losslessPNG,
+            screenshotOutput: ScreenshotOutputOptions(format: .png, quality: 0.85),
             screenshotFilenameTemplate: "Screenshot",
             onSave: { _ in true },
             onCopy: { _ in copied.fulfill() },
@@ -176,7 +177,7 @@ final class AnnotationCanvasClipboardShortcutTests: XCTestCase {
         copied.isInverted = true
         let window = AnnotationEditorWindow(
             image: try makeImage(),
-            screenshotOutputPreset: .losslessPNG,
+            screenshotOutput: ScreenshotOutputOptions(format: .png, quality: 0.85),
             screenshotFilenameTemplate: "Screenshot",
             onSave: { _ in true },
             onCopy: { _ in copied.fulfill() },
@@ -201,7 +202,7 @@ final class AnnotationCanvasClipboardShortcutTests: XCTestCase {
         let copied = expectation(description: "Full editor image copied with Return")
         let window = AnnotationEditorWindow(
             image: try makeImage(),
-            screenshotOutputPreset: .losslessPNG,
+            screenshotOutput: ScreenshotOutputOptions(format: .png, quality: 0.85),
             screenshotFilenameTemplate: "Screenshot",
             onSave: { _ in true },
             onCopy: { _ in copied.fulfill() },
@@ -247,7 +248,7 @@ final class AnnotationCanvasClipboardShortcutTests: XCTestCase {
 
         let window = AnnotationEditorWindow(
             image: try makeImage(),
-            screenshotOutputPreset: .losslessPNG,
+            screenshotOutput: ScreenshotOutputOptions(format: .png, quality: 0.85),
             screenshotFilenameTemplate: "Screenshot",
             onSave: { _ in true },
             onCopy: { _ in },

--- a/App/Tests/AnnotationEditorWindowCenteringTests.swift
+++ b/App/Tests/AnnotationEditorWindowCenteringTests.swift
@@ -164,7 +164,7 @@ final class AnnotationEditorWindowCenteringTests: XCTestCase {
         AnnotationEditorWindow(
             image: try makeImage(width: pixelWidth, height: pixelHeight),
             anchorScreen: screen,
-            screenshotOutputPreset: .losslessPNG,
+            screenshotOutput: ScreenshotOutputOptions(format: .png, quality: 0.85),
             screenshotFilenameTemplate: "Screenshot",
             onSave: { _ in true },
             onCopy: { _ in },

--- a/App/Tests/AnnotationEditorWindowCloseTests.swift
+++ b/App/Tests/AnnotationEditorWindowCloseTests.swift
@@ -24,7 +24,7 @@ final class AnnotationEditorWindowCloseTests: XCTestCase {
     private func makeWindow(onClose: @escaping () -> Void) throws -> AnnotationEditorWindow {
         AnnotationEditorWindow(
             image: try makeTestImage(),
-            screenshotOutputPreset: .losslessPNG,
+            screenshotOutput: ScreenshotOutputOptions(format: .png, quality: 0.85),
             screenshotFilenameTemplate: "Screenshot",
             onSave: { _ in true },
             onCopy: { _ in },

--- a/App/Tests/ScreenshotClipboardContentTests.swift
+++ b/App/Tests/ScreenshotClipboardContentTests.swift
@@ -9,7 +9,7 @@ final class ScreenshotClipboardContentTests: XCTestCase {
     func testFilePathContentCopiesReadableManagedFileWithoutPreview() throws {
         let settings = makeSettings()
         settings.screenshotClipboardContent = .filePath
-        settings.screenshotOutputPreset = .losslessPNG
+        settings.screenshotOutputFormat = .png
         let coordinator = CaptureCoordinator(settings: settings)
         let pasteboard = makePasteboard()
 

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -77,7 +77,7 @@ public struct ScreenshotOutputOptions: Equatable, Sendable {
 }
 
 /// Superseded by `ScreenshotOutputFormat` plus a quality percentage; retained to migrate
-/// defaults written by 1.0.1 and earlier.
+/// defaults written by 1.0.1 and earlier and kept in sync for downgrade compatibility.
 public enum ScreenshotOutputPreset: String, CaseIterable, Sendable {
     case losslessPNG
     case standardJPEG
@@ -331,7 +331,12 @@ public final class AppSettings: @unchecked Sendable {
             )
         }
         set {
+            let qualityPercent = screenshotOutputQualityPercent
+            if defaults.object(forKey: "screenshotOutputQualityPercent") == nil {
+                defaults.set(qualityPercent, forKey: "screenshotOutputQualityPercent")
+            }
             defaults.set(newValue.rawValue, forKey: "screenshotOutputFormat")
+            writeLegacyOutputPreset(format: newValue, qualityPercent: qualityPercent)
             screenshotFormat = newValue == .png ? .png : .jpeg
         }
     }
@@ -343,7 +348,14 @@ public final class AppSettings: @unchecked Sendable {
             }
             return Self.clampedQualityPercent(stored)
         }
-        set { defaults.set(Self.clampedQualityPercent(newValue), forKey: "screenshotOutputQualityPercent") }
+        set {
+            let qualityPercent = Self.clampedQualityPercent(newValue)
+            defaults.set(qualityPercent, forKey: "screenshotOutputQualityPercent")
+            writeLegacyOutputPreset(
+                format: screenshotOutputFormat,
+                qualityPercent: qualityPercent
+            )
+        }
     }
 
     public var screenshotOutputOptions: ScreenshotOutputOptions {
@@ -360,7 +372,10 @@ public final class AppSettings: @unchecked Sendable {
         legacy: ScreenshotOutputPreset?,
         isAvailable: (ScreenshotOutputFormat) -> Bool
     ) -> ScreenshotOutputFormat {
-        if let stored, let value = ScreenshotOutputFormat(rawValue: stored), isAvailable(value) {
+        if let stored {
+            guard let value = ScreenshotOutputFormat(rawValue: stored), isAvailable(value) else {
+                return .png
+            }
             return value
         }
         let migrated = legacy?.outputFormat ?? .png
@@ -376,7 +391,34 @@ public final class AppSettings: @unchecked Sendable {
         )
     }
 
-    /// Defaults written by 1.0.1 and earlier, used only until the new keys are written.
+    private static func downgradeOutputPreset(
+        format: ScreenshotOutputFormat,
+        qualityPercent: Int
+    ) -> ScreenshotOutputPreset {
+        guard format != .png else { return .losslessPNG }
+        return qualityPercent < standardJPEGDowngradeQualityThreshold
+            ? .compactJPEG
+            : .standardJPEG
+    }
+
+    /// The midpoint between the two lossy presets supported by 1.0.1 and earlier.
+    private static let standardJPEGDowngradeQualityThreshold = (
+        ScreenshotOutputPreset.compactJPEG.qualityPercent
+            + ScreenshotOutputPreset.standardJPEG.qualityPercent
+            + 1
+    ) / 2
+
+    private func writeLegacyOutputPreset(
+        format: ScreenshotOutputFormat,
+        qualityPercent: Int
+    ) {
+        defaults.set(
+            Self.downgradeOutputPreset(format: format, qualityPercent: qualityPercent).rawValue,
+            forKey: "screenshotOutputPreset"
+        )
+    }
+
+    /// Defaults written by 1.0.1 and earlier, also maintained as a downgrade projection.
     private var legacyOutputPreset: ScreenshotOutputPreset? {
         if let raw = defaults.string(forKey: "screenshotOutputPreset"),
            let preset = ScreenshotOutputPreset(rawValue: raw) {

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -19,6 +19,65 @@ public enum ScreenshotClipboardContent: String, CaseIterable, Sendable {
     case filePath
 }
 
+/// The still-image format screenshots are written in.
+public enum ScreenshotOutputFormat: String, CaseIterable, Sendable {
+    case png
+    case jpeg
+    case heic
+
+    public static let qualityPercentRange: ClosedRange<Int> = 30...100
+
+    public init?(_ fileFormat: FileFormat) {
+        switch fileFormat {
+        case .png:
+            self = .png
+        case .jpeg:
+            self = .jpeg
+        case .heic:
+            self = .heic
+        case .mp4, .gif, .mov:
+            return nil
+        }
+    }
+
+    public var fileFormat: FileFormat {
+        switch self {
+        case .png:
+            return .png
+        case .jpeg:
+            return .jpeg
+        case .heic:
+            return .heic
+        }
+    }
+
+    public var isLossy: Bool {
+        self != .png
+    }
+
+    public var mimeType: String {
+        fileFormat.contentType.preferredMIMEType ?? "image/png"
+    }
+
+    /// False when this Mac has no encoder for the format, as on Intel models lacking HEVC.
+    public var isAvailable: Bool {
+        ImageIOEncoder.writableTypeIdentifiers.contains(fileFormat.contentType.identifier)
+    }
+}
+
+/// How screenshots are encoded: the format, plus the compression quality lossy formats use.
+public struct ScreenshotOutputOptions: Equatable, Sendable {
+    public let format: ScreenshotOutputFormat
+    public let quality: Double
+
+    public init(format: ScreenshotOutputFormat, quality: Double) {
+        self.format = format
+        self.quality = quality
+    }
+}
+
+/// Superseded by `ScreenshotOutputFormat` plus a quality percentage; retained to migrate
+/// defaults written by 1.0.1 and earlier.
 public enum ScreenshotOutputPreset: String, CaseIterable, Sendable {
     case losslessPNG
     case standardJPEG
@@ -41,6 +100,24 @@ public enum ScreenshotOutputPreset: String, CaseIterable, Sendable {
             return 0.85
         case .compactJPEG:
             return 0.70
+        }
+    }
+
+    var outputFormat: ScreenshotOutputFormat {
+        switch self {
+        case .losslessPNG:
+            return .png
+        case .standardJPEG, .compactJPEG:
+            return .jpeg
+        }
+    }
+
+    var qualityPercent: Int {
+        switch self {
+        case .losslessPNG, .standardJPEG:
+            return 85
+        case .compactJPEG:
+            return 70
         }
     }
 }
@@ -245,18 +322,67 @@ public final class AppSettings: @unchecked Sendable {
         set { defaults.set(newValue.rawValue, forKey: "screenshotFormat") }
     }
 
-    public var screenshotOutputPreset: ScreenshotOutputPreset {
+    public var screenshotOutputFormat: ScreenshotOutputFormat {
         get {
-            if let raw = defaults.string(forKey: "screenshotOutputPreset"),
-               let value = ScreenshotOutputPreset(rawValue: raw) {
-                return value
-            }
-            return screenshotFormat == .jpeg ? .standardJPEG : .losslessPNG
+            Self.resolvedOutputFormat(
+                stored: defaults.string(forKey: "screenshotOutputFormat"),
+                legacy: legacyOutputPreset,
+                isAvailable: { $0.isAvailable }
+            )
         }
         set {
-            defaults.set(newValue.rawValue, forKey: "screenshotOutputPreset")
-            screenshotFormat = newValue.fileFormat == .png ? .png : .jpeg
+            defaults.set(newValue.rawValue, forKey: "screenshotOutputFormat")
+            screenshotFormat = newValue == .png ? .png : .jpeg
         }
+    }
+
+    public var screenshotOutputQualityPercent: Int {
+        get {
+            guard let stored = defaults.object(forKey: "screenshotOutputQualityPercent") as? Int else {
+                return legacyOutputPreset?.qualityPercent ?? Self.defaultOutputQualityPercent
+            }
+            return Self.clampedQualityPercent(stored)
+        }
+        set { defaults.set(Self.clampedQualityPercent(newValue), forKey: "screenshotOutputQualityPercent") }
+    }
+
+    public var screenshotOutputOptions: ScreenshotOutputOptions {
+        ScreenshotOutputOptions(
+            format: screenshotOutputFormat,
+            quality: Double(screenshotOutputQualityPercent) / 100
+        )
+    }
+
+    /// Never returns a format this Mac cannot encode, so the setting can't silently
+    /// produce bytes that disagree with the file's extension.
+    static func resolvedOutputFormat(
+        stored: String?,
+        legacy: ScreenshotOutputPreset?,
+        isAvailable: (ScreenshotOutputFormat) -> Bool
+    ) -> ScreenshotOutputFormat {
+        if let stored, let value = ScreenshotOutputFormat(rawValue: stored), isAvailable(value) {
+            return value
+        }
+        let migrated = legacy?.outputFormat ?? .png
+        return isAvailable(migrated) ? migrated : .png
+    }
+
+    private static let defaultOutputQualityPercent = 85
+
+    private static func clampedQualityPercent(_ value: Int) -> Int {
+        min(
+            max(value, ScreenshotOutputFormat.qualityPercentRange.lowerBound),
+            ScreenshotOutputFormat.qualityPercentRange.upperBound
+        )
+    }
+
+    /// Defaults written by 1.0.1 and earlier, used only until the new keys are written.
+    private var legacyOutputPreset: ScreenshotOutputPreset? {
+        if let raw = defaults.string(forKey: "screenshotOutputPreset"),
+           let preset = ScreenshotOutputPreset(rawValue: raw) {
+            return preset
+        }
+        return screenshotFormat == .jpeg ? .standardJPEG : nil
     }
 
     public var recordingFormat: RecordingFormat {

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/FileNaming.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/FileNaming.swift
@@ -10,6 +10,7 @@ public enum CaptureType: Sendable {
 public enum FileFormat: String, Sendable {
     case png
     case jpeg
+    case heic
     case mp4
     case gif
     case mov
@@ -20,6 +21,8 @@ public enum FileFormat: String, Sendable {
             self = .png
         case "jpg", "jpeg":
             self = .jpeg
+        case "heic", "heif":
+            self = .heic
         case "mp4":
             self = .mp4
         case "gif":
@@ -37,6 +40,8 @@ public enum FileFormat: String, Sendable {
             return .png
         case .jpeg:
             return .jpeg
+        case .heic:
+            return .heic
         case .mp4:
             return .mpeg4Movie
         case .gif:

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ImageEncoding.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ImageEncoding.swift
@@ -1,0 +1,45 @@
+// Packages/SharedKit/Sources/SharedKit/Utilities/ImageEncoding.swift
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// Encodes a rendered image into the bytes of a chosen output format.
+public protocol ImageEncoding: Sendable {
+    /// Returns nil when the format cannot be encoded, so callers can surface a failure
+    /// rather than write bytes that disagree with the file's extension.
+    func encode(_ image: CGImage, format: ScreenshotOutputFormat, quality: Double) -> Data?
+}
+
+/// Encodes through ImageIO, covering every format macOS can write natively.
+public struct ImageIOEncoder: ImageEncoding {
+    public init() {}
+
+    static let writableTypeIdentifiers: Set<String> = {
+        guard let identifiers = CGImageDestinationCopyTypeIdentifiers() as? [String] else { return [] }
+        return Set(identifiers)
+    }()
+
+    public func encode(_ image: CGImage, format: ScreenshotOutputFormat, quality: Double) -> Data? {
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data, format.fileFormat.contentType.identifier as CFString, 1, nil
+        ) else {
+            return nil
+        }
+
+        let properties = format.isLossy
+            ? [kCGImageDestinationLossyCompressionQuality: quality] as CFDictionary
+            : nil
+        CGImageDestinationAddImage(destination, image, properties)
+
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return data as Data
+    }
+}
+
+public enum ImageEncoders {
+    /// The encoder used app-wide. WebP support arrives by pointing this at an encoder
+    /// that handles WebP itself and delegates the rest to `ImageIOEncoder`.
+    public static let `default`: any ImageEncoding = ImageIOEncoder()
+}

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ImageFileReader.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ImageFileReader.swift
@@ -3,7 +3,14 @@ import AppKit
 import UniformTypeIdentifiers
 
 public enum ImageFileReader {
-    public static let supportedContentTypes: [UTType] = [.png, .jpeg, .heic, .tiff, .gif]
+    public static let supportedContentTypes: [UTType] = {
+        var types: [UTType] = [.png, .jpeg, .heic]
+        if let heif = UTType(filenameExtension: "heif") {
+            types.append(heif)
+        }
+        types.append(contentsOf: [.tiff, .gif])
+        return types
+    }()
 
     public static func isSupported(_ url: URL) -> Bool {
         guard url.isFileURL,

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ImageFileWriter.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ImageFileWriter.swift
@@ -6,16 +6,20 @@ import UniformTypeIdentifiers
 /// Encodes a rendered CGImage back into the byte format of an existing file,
 /// so overwriting an opened image preserves its original format.
 public enum ImageFileWriter {
-    public static func data(from cgImage: CGImage, matchingFormatOf url: URL) -> Data? {
-        guard let type = UTType(filenameExtension: url.pathExtension.lowercased()) else {
-            return ImageUtilities.pngData(from: cgImage)
+    public static func data(
+        from cgImage: CGImage,
+        matchingFormatOf url: URL,
+        quality: Double = 0.85
+    ) -> Data? {
+        let pathExtension = url.pathExtension.lowercased()
+
+        if let format = FileFormat(pathExtension: pathExtension),
+           let outputFormat = ScreenshotOutputFormat(format) {
+            return ImageEncoders.default.encode(cgImage, format: outputFormat, quality: quality)
         }
 
-        if type.conforms(to: .jpeg) {
-            return ImageUtilities.jpegData(from: cgImage)
-        }
-        if type.conforms(to: .heic) {
-            return heicData(from: cgImage)
+        guard let type = UTType(filenameExtension: pathExtension) else {
+            return ImageUtilities.pngData(from: cgImage)
         }
         if type.conforms(to: .tiff) {
             return NSBitmapImageRep(cgImage: cgImage).representation(using: .tiff, properties: [:])
@@ -24,17 +28,5 @@ public enum ImageFileWriter {
             return NSBitmapImageRep(cgImage: cgImage).representation(using: .gif, properties: [:])
         }
         return ImageUtilities.pngData(from: cgImage)
-    }
-
-    private static func heicData(from cgImage: CGImage) -> Data? {
-        let mutableData = NSMutableData()
-        guard let destination = CGImageDestinationCreateWithData(
-            mutableData, UTType.heic.identifier as CFString, 1, nil
-        ) else {
-            return nil
-        }
-        CGImageDestinationAddImage(destination, cgImage, nil)
-        guard CGImageDestinationFinalize(destination) else { return nil }
-        return mutableData as Data
     }
 }

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/QuickAccessDragFileStore.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/QuickAccessDragFileStore.swift
@@ -36,7 +36,7 @@ public final class QuickAccessDragFileStore {
     public func fileURL(
         for image: CGImage,
         id: UUID,
-        preset: ScreenshotOutputPreset = .losslessPNG,
+        output: ScreenshotOutputOptions = ScreenshotOutputOptions(format: .png, quality: 0.85),
         date: Date = Date(),
         sourceAppName: String? = nil,
         sourceWindowTitle: String? = nil,
@@ -48,14 +48,14 @@ public final class QuickAccessDragFileStore {
             return cachedURL
         }
 
-        guard let data = encodedData(from: image, preset: preset) else {
+        guard let data = encodedData(from: image, output: output) else {
             throw QuickAccessDragFileStoreError.encodingFailed
         }
 
         let preferredURL = FileNaming.generateFileURL(
             in: directory,
             type: .screenshot,
-            format: preset.fileFormat,
+            format: output.format.fileFormat,
             date: date,
             sourceAppName: sourceAppName,
             sourceWindowTitle: sourceWindowTitle,
@@ -109,21 +109,15 @@ public final class QuickAccessDragFileStore {
         try fileManager.removeItem(at: fileURL)
     }
 
-    private static let prunableExtensions: Set<String> = ["png", "jpg", "jpeg"]
+    private static let prunableExtensions: Set<String> = Set(
+        ScreenshotOutputFormat.allCases.map { $0.fileFormat.rawValue }
+    ).union(["jpg"])
 
-    private func encodedData(from image: CGImage, preset: ScreenshotOutputPreset) -> Data? {
+    private func encodedData(from image: CGImage, output: ScreenshotOutputOptions) -> Data? {
         if let encoder {
             return encoder(image)
         }
-
-        switch preset.fileFormat {
-        case .png:
-            return ImageUtilities.pngData(from: image)
-        case .jpeg:
-            return ImageUtilities.jpegData(from: image, quality: preset.jpegQuality ?? 0.85)
-        case .mp4, .gif, .mov:
-            return nil
-        }
+        return ImageEncoders.default.encode(image, format: output.format, quality: output.quality)
     }
 
     private func availableFileURL(for preferredURL: URL) -> URL {

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -33,11 +33,11 @@ struct AppSettingsTests {
         defaults.removePersistentDomain(forName: suite)
 
         let first = AppSettings(defaults: defaults)
-        first.screenshotOutputFormat = .heic
+        first.screenshotOutputFormat = .jpeg
         first.screenshotOutputQualityPercent = 60
 
         let second = AppSettings(defaults: defaults)
-        #expect(second.screenshotOutputFormat == .heic)
+        #expect(second.screenshotOutputFormat == .jpeg)
         #expect(second.screenshotOutputQualityPercent == 60)
         #expect(second.screenshotOutputOptions.quality == 0.6)
     }
@@ -95,6 +95,17 @@ struct AppSettingsTests {
         #expect(resolved == .png)
     }
 
+    @Test("An unavailable stored format does not revive a legacy preset")
+    func screenshotOutputFormatRejectsUnavailableCodecBeforeLegacyFallback() {
+        let resolved = AppSettings.resolvedOutputFormat(
+            stored: "heic",
+            legacy: .standardJPEG,
+            isAvailable: { $0 != .heic }
+        )
+
+        #expect(resolved == .png)
+    }
+
     @Test("Screenshot output format honours an available stored codec")
     func screenshotOutputFormatHonoursAvailableCodec() {
         let resolved = AppSettings.resolvedOutputFormat(
@@ -126,6 +137,64 @@ struct AppSettingsTests {
 
         settings.screenshotOutputFormat = .png
         #expect(settings.screenshotFormat == .png)
+    }
+
+    @Test("Changing the screenshot output format replaces a stale legacy preset")
+    func screenshotOutputFormatReplacesLegacyPreset() {
+        let suite = "test.screenshotOutput.legacyPresetWriteBack"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set(ScreenshotOutputPreset.compactJPEG.rawValue, forKey: "screenshotOutputPreset")
+        let settings = AppSettings(defaults: defaults)
+
+        settings.screenshotOutputFormat = .png
+
+        #expect(defaults.string(forKey: "screenshotOutputPreset") == ScreenshotOutputPreset.losslessPNG.rawValue)
+        #expect(settings.screenshotFormat == .png)
+    }
+
+    @Test("Changing the screenshot output format preserves migrated quality")
+    func screenshotOutputFormatPreservesMigratedQuality() {
+        let suite = "test.screenshotOutput.migratedQualityWriteBack"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set(ScreenshotOutputPreset.compactJPEG.rawValue, forKey: "screenshotOutputPreset")
+        let settings = AppSettings(defaults: defaults)
+
+        settings.screenshotOutputFormat = .png
+
+        #expect(settings.screenshotOutputQualityPercent == 70)
+        #expect(defaults.object(forKey: "screenshotOutputQualityPercent") as? Int == 70)
+    }
+
+    @Test("Changing screenshot quality keeps the legacy preset in sync")
+    func screenshotOutputQualityWritesLegacyPreset() {
+        let suite = "test.screenshotOutput.legacyQualityWriteBack"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        settings.screenshotOutputFormat = .jpeg
+
+        settings.screenshotOutputQualityPercent = 70
+        #expect(defaults.string(forKey: "screenshotOutputPreset") == ScreenshotOutputPreset.compactJPEG.rawValue)
+
+        settings.screenshotOutputQualityPercent = 85
+        #expect(defaults.string(forKey: "screenshotOutputPreset") == ScreenshotOutputPreset.standardJPEG.rawValue)
+    }
+
+    @Test("Legacy preset quality projection changes at the midpoint")
+    func screenshotOutputQualityUsesNearestLegacyPreset() {
+        let suite = "test.screenshotOutput.legacyQualityBoundary"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = AppSettings(defaults: defaults)
+        settings.screenshotOutputFormat = .jpeg
+
+        settings.screenshotOutputQualityPercent = 77
+        #expect(defaults.string(forKey: "screenshotOutputPreset") == ScreenshotOutputPreset.compactJPEG.rawValue)
+
+        settings.screenshotOutputQualityPercent = 78
+        #expect(defaults.string(forKey: "screenshotOutputPreset") == ScreenshotOutputPreset.standardJPEG.rawValue)
     }
 
     private func makeSettings(_ suite: String) -> AppSettings {

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -17,24 +17,121 @@ struct AppSettingsTests {
         #expect(settings.screenshotFormat == .png)
     }
 
-    @Test("Default screenshot output preset is lossless PNG")
-    func defaultScreenshotOutputPreset() {
-        let suite = "test.screenshotOutputPreset.default"
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-        let settings = AppSettings(defaults: defaults)
+    @Test("Screenshot output defaults to lossless PNG at 85% quality")
+    func defaultScreenshotOutput() {
+        let settings = makeSettings("test.screenshotOutput.default")
 
-        #expect(settings.screenshotOutputPreset == .losslessPNG)
-        #expect(settings.screenshotOutputPreset.fileFormat == .png)
-        #expect(settings.screenshotOutputPreset.jpegQuality == nil)
+        #expect(settings.screenshotOutputFormat == .png)
+        #expect(settings.screenshotOutputQualityPercent == 85)
+        #expect(settings.screenshotOutputOptions == ScreenshotOutputOptions(format: .png, quality: 0.85))
     }
 
-    @Test("Screenshot output presets expose JPEG quality")
-    func screenshotOutputPresetJPEGQuality() {
-        #expect(ScreenshotOutputPreset.standardJPEG.fileFormat == .jpeg)
-        #expect(ScreenshotOutputPreset.standardJPEG.jpegQuality == 0.85)
-        #expect(ScreenshotOutputPreset.compactJPEG.fileFormat == .jpeg)
-        #expect(ScreenshotOutputPreset.compactJPEG.jpegQuality == 0.70)
+    @Test("Screenshot output format and quality persist")
+    func screenshotOutputPersists() {
+        let suite = "test.screenshotOutput.persist"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let first = AppSettings(defaults: defaults)
+        first.screenshotOutputFormat = .heic
+        first.screenshotOutputQualityPercent = 60
+
+        let second = AppSettings(defaults: defaults)
+        #expect(second.screenshotOutputFormat == .heic)
+        #expect(second.screenshotOutputQualityPercent == 60)
+        #expect(second.screenshotOutputOptions.quality == 0.6)
+    }
+
+    @Test("Screenshot output migrates from the legacy preset", arguments: [
+        (ScreenshotOutputPreset.losslessPNG, ScreenshotOutputFormat.png, 85),
+        (.standardJPEG, .jpeg, 85),
+        (.compactJPEG, .jpeg, 70),
+    ])
+    func screenshotOutputMigratesFromPreset(
+        preset: ScreenshotOutputPreset,
+        format: ScreenshotOutputFormat,
+        percent: Int
+    ) {
+        let suite = "test.screenshotOutput.migrate.\(preset.rawValue)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set(preset.rawValue, forKey: "screenshotOutputPreset")
+
+        let settings = AppSettings(defaults: defaults)
+
+        #expect(settings.screenshotOutputFormat == format)
+        #expect(settings.screenshotOutputQualityPercent == percent)
+    }
+
+    @Test("Screenshot output quality clamps to the supported range")
+    func screenshotOutputQualityClamps() {
+        let settings = makeSettings("test.screenshotOutput.clamp")
+
+        settings.screenshotOutputQualityPercent = 0
+        #expect(settings.screenshotOutputQualityPercent == ScreenshotOutputFormat.qualityPercentRange.lowerBound)
+
+        settings.screenshotOutputQualityPercent = 500
+        #expect(settings.screenshotOutputQualityPercent == ScreenshotOutputFormat.qualityPercentRange.upperBound)
+    }
+
+    @Test("Screenshot output format ignores an unrecognized stored value")
+    func screenshotOutputFormatIgnoresUnknownValue() {
+        let suite = "test.screenshotOutput.unknown"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set("webp", forKey: "screenshotOutputFormat")
+
+        #expect(AppSettings(defaults: defaults).screenshotOutputFormat == .png)
+    }
+
+    @Test("Screenshot output format falls back to PNG when the codec is unavailable")
+    func screenshotOutputFormatRejectsUnavailableCodec() {
+        let resolved = AppSettings.resolvedOutputFormat(
+            stored: "heic",
+            legacy: nil,
+            isAvailable: { $0 != .heic }
+        )
+
+        #expect(resolved == .png)
+    }
+
+    @Test("Screenshot output format honours an available stored codec")
+    func screenshotOutputFormatHonoursAvailableCodec() {
+        let resolved = AppSettings.resolvedOutputFormat(
+            stored: "heic",
+            legacy: nil,
+            isAvailable: { _ in true }
+        )
+
+        #expect(resolved == .heic)
+    }
+
+    @Test("Screenshot output format falls back to PNG when a migrated codec is unavailable")
+    func screenshotOutputFormatRejectsUnavailableMigratedCodec() {
+        let resolved = AppSettings.resolvedOutputFormat(
+            stored: nil,
+            legacy: .standardJPEG,
+            isAvailable: { $0 != .jpeg }
+        )
+
+        #expect(resolved == .png)
+    }
+
+    @Test("Setting the screenshot output format keeps the legacy format key in sync")
+    func screenshotOutputFormatWritesLegacyKey() {
+        let settings = makeSettings("test.screenshotOutput.legacyWriteBack")
+
+        settings.screenshotOutputFormat = .heic
+        #expect(settings.screenshotFormat == .jpeg)
+
+        settings.screenshotOutputFormat = .png
+        #expect(settings.screenshotFormat == .png)
+    }
+
+    private func makeSettings(_ suite: String) -> AppSettings {
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return AppSettings(defaults: defaults)
     }
 
     @Test("Screenshot clipboard format defaults to PNG and persists")
@@ -67,16 +164,14 @@ struct AppSettingsTests {
         #expect(second.screenshotClipboardContent == .filePath)
     }
 
-    @Test("Screenshot output preset falls back to legacy JPEG format")
-    func screenshotOutputPresetLegacyFormatFallback() {
-        let suite = "test.screenshotOutputPreset.legacy"
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
-        let settings = AppSettings(defaults: defaults)
+    @Test("Screenshot output format falls back to the legacy JPEG format key")
+    func screenshotOutputFormatLegacyFallback() {
+        let settings = makeSettings("test.screenshotOutput.legacyRead")
 
         settings.screenshotFormat = .jpeg
 
-        #expect(settings.screenshotOutputPreset == .standardJPEG)
+        #expect(settings.screenshotOutputFormat == .jpeg)
+        #expect(settings.screenshotOutputQualityPercent == 85)
     }
 
     @Test("Default screenshot filename template matches FileNaming default")
@@ -396,7 +491,16 @@ struct AppSettingsTests {
         #expect(FileFormat(pathExtension: "gif") == .gif)
         #expect(FileFormat(pathExtension: "mp4") == .mp4)
         #expect(FileFormat(pathExtension: "mov") == .mov)
+        #expect(FileFormat(pathExtension: "heic") == .heic)
+        #expect(FileFormat(pathExtension: "HEIC") == .heic)
+        #expect(FileFormat(pathExtension: "heif") == .heic)
         #expect(FileFormat(pathExtension: "webm") == nil)
+        #expect(FileFormat(pathExtension: "webp") == nil)
+    }
+
+    @Test("HEIC maps to the public.heic content type")
+    func heicContentType() {
+        #expect(FileFormat.heic.contentType == .heic)
     }
 
     @Test("Generated file names preserve the requested extension")
@@ -411,6 +515,9 @@ struct AppSettingsTests {
         )
         #expect(
             FileNaming.generateFileName(for: .recording, format: .mov, date: date).hasSuffix(".mov")
+        )
+        #expect(
+            FileNaming.generateFileName(for: .screenshot, format: .heic, date: date).hasSuffix(".heic")
         )
     }
 

--- a/Packages/SharedKit/Tests/SharedKitTests/ImageEncodingTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ImageEncodingTests.swift
@@ -1,0 +1,115 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+import Testing
+@testable import SharedKit
+
+@Suite("ImageEncoding")
+struct ImageEncodingTests {
+    private let encoder = ImageIOEncoder()
+
+    @Test("PNG encodes to PNG bytes")
+    func encodesPNG() throws {
+        let data = try #require(encoder.encode(makeImage(), format: .png, quality: 1))
+
+        #expect(encodedFormatUTI(data) == UTType.png.identifier)
+    }
+
+    @Test("JPEG encodes to JPEG bytes")
+    func encodesJPEG() throws {
+        let data = try #require(encoder.encode(makeImage(), format: .jpeg, quality: 0.85))
+
+        #expect(encodedFormatUTI(data) == UTType.jpeg.identifier)
+    }
+
+    @Test("HEIC encodes to HEIC bytes when an encoder is available")
+    func encodesHEIC() throws {
+        // Some Intel Macs lack an HEVC encoder; skip rather than fail the suite.
+        guard ScreenshotOutputFormat.heic.isAvailable else { return }
+
+        let data = try #require(encoder.encode(makeImage(), format: .heic, quality: 0.85))
+
+        #expect(encodedFormatUTI(data) == UTType.heic.identifier)
+    }
+
+    @Test("Lower quality produces fewer bytes for lossy formats", arguments: [ScreenshotOutputFormat.jpeg, .heic])
+    func lowerQualityShrinksLossyOutput(format: ScreenshotOutputFormat) throws {
+        guard format.isAvailable else { return }
+        let image = makeImage()
+
+        let low = try #require(encoder.encode(image, format: format, quality: 0.3))
+        let high = try #require(encoder.encode(image, format: format, quality: 1))
+
+        #expect(low.count < high.count)
+    }
+
+    @Test("PNG ignores quality")
+    func pngIgnoresQuality() throws {
+        let image = makeImage()
+
+        let low = try #require(encoder.encode(image, format: .png, quality: 0.3))
+        let high = try #require(encoder.encode(image, format: .png, quality: 1))
+
+        #expect(low == high)
+    }
+
+    @Test("An unavailable format encodes to nil rather than substituting another format")
+    func unavailableFormatReturnsNil() {
+        for format in ScreenshotOutputFormat.allCases where !format.isAvailable {
+            #expect(encoder.encode(makeImage(), format: format, quality: 0.85) == nil)
+        }
+    }
+
+    @Test("Only PNG is lossless")
+    func lossyFormats() {
+        #expect(ScreenshotOutputFormat.png.isLossy == false)
+        #expect(ScreenshotOutputFormat.jpeg.isLossy)
+        #expect(ScreenshotOutputFormat.heic.isLossy)
+    }
+
+    @Test("Output formats map to their file format and back")
+    func fileFormatRoundTrip() {
+        for format in ScreenshotOutputFormat.allCases {
+            #expect(ScreenshotOutputFormat(format.fileFormat) == format)
+        }
+        #expect(ScreenshotOutputFormat(.mp4) == nil)
+        #expect(ScreenshotOutputFormat(.gif) == nil)
+        #expect(ScreenshotOutputFormat(.mov) == nil)
+    }
+
+    @Test("Output formats expose an image MIME type")
+    func mimeTypes() {
+        #expect(ScreenshotOutputFormat.png.mimeType == "image/png")
+        #expect(ScreenshotOutputFormat.jpeg.mimeType == "image/jpeg")
+        #expect(ScreenshotOutputFormat.heic.mimeType == "image/heic")
+    }
+
+    /// Varied content so lossy quality changes measurably alter the byte count.
+    private func makeImage(width: Int = 256, height: Int = 256) -> CGImage {
+        let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        for index in 0..<400 {
+            context.setFillColor(CGColor(
+                red: Double(index % 97) / 97,
+                green: Double(index % 53) / 53,
+                blue: Double(index % 31) / 31,
+                alpha: 1
+            ))
+            context.fill(CGRect(x: (index * 37) % width, y: (index * 61) % height, width: 19, height: 13))
+        }
+        return context.makeImage()!
+    }
+
+    private func encodedFormatUTI(_ data: Data) -> String? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+        return CGImageSourceGetType(source) as String?
+    }
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/ImageFileReaderTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ImageFileReaderTests.swift
@@ -110,6 +110,28 @@ struct ImageFileReaderTests {
         return try #require(context.makeImage())
     }
 
+    /// Overwriting an opened image reuses its own extension, so a readable format Capso
+    /// cannot write would produce bytes that disagree with the file name.
+    @Test("Every readable format can also be written")
+    func everyReadableFormatIsWritable() throws {
+        let image = try makeImage(width: 8, height: 8)
+
+        for type in ImageFileReader.supportedContentTypes {
+            let ext = try #require(type.preferredFilenameExtension)
+            let url = URL(fileURLWithPath: "/tmp/capso-invariant.\(ext)")
+
+            guard let data = ImageFileWriter.data(from: image, matchingFormatOf: url) else {
+                // Absent codec, as on Intel Macs without HEVC.
+                continue
+            }
+            let source = try #require(CGImageSourceCreateWithData(data as CFData, nil))
+            let written = try #require(CGImageSourceGetType(source) as String?)
+            let writtenType = try #require(UTType(written))
+
+            #expect(writtenType.conforms(to: type), "\(ext) was written as \(written)")
+        }
+    }
+
     private func writeImage(_ cgImage: CGImage, extension ext: String, using type: NSBitmapImageRep.FileType) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("capso-imagefile-\(UUID().uuidString)")

--- a/Packages/SharedKit/Tests/SharedKitTests/ImageFileReaderTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ImageFileReaderTests.swift
@@ -18,7 +18,7 @@ struct ImageFileReaderTests {
 
     @Test("accepts image extensions case-insensitively")
     func isSupportedAcceptsImageExtensionsCaseInsensitively() {
-        for name in ["b.PNG", "b.jpg", "b.jpeg", "b.heic", "b.tif", "b.tiff", "b.gif"] {
+        for name in ["b.PNG", "b.jpg", "b.jpeg", "b.heic", "b.heif", "b.tif", "b.tiff", "b.gif"] {
             let url = URL(fileURLWithPath: "/tmp/\(name)")
             #expect(ImageFileReader.isSupported(url), "expected \(name) to be supported")
         }
@@ -128,7 +128,11 @@ struct ImageFileReaderTests {
             let written = try #require(CGImageSourceGetType(source) as String?)
             let writtenType = try #require(UTType(written))
 
-            #expect(writtenType.conforms(to: type), "\(ext) was written as \(written)")
+            if ext == "heif" {
+                #expect(writtenType == .heic, "\(ext) was written as \(written)")
+            } else {
+                #expect(writtenType.conforms(to: type), "\(ext) was written as \(written)")
+            }
         }
     }
 

--- a/Packages/SharedKit/Tests/SharedKitTests/ImageFileWriterTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ImageFileWriterTests.swift
@@ -59,6 +59,27 @@ struct ImageFileWriterTests {
         #expect(writtenFormatUTI(data) == UTType.heic.identifier)
     }
 
+    @Test("matches HEIC format for a .heif URL when an encoder is available")
+    func matchesHEICFormatForHEIFURLWhenEncoderAvailable() throws {
+        let image = try makeImage(width: 4, height: 4)
+        let url = URL(fileURLWithPath: "/tmp/photo.heif")
+
+        guard let data = ImageFileWriter.data(from: image, matchingFormatOf: url) else { return }
+
+        #expect(writtenFormatUTI(data) == UTType.heic.identifier)
+    }
+
+    @Test("honours the requested quality for lossy destinations")
+    func honoursQualityForLossyDestinations() throws {
+        let image = try makeImage(width: 128, height: 128)
+        let url = URL(fileURLWithPath: "/tmp/photo.jpg")
+
+        let low = try #require(ImageFileWriter.data(from: image, matchingFormatOf: url, quality: 0.3))
+        let high = try #require(ImageFileWriter.data(from: image, matchingFormatOf: url, quality: 1))
+
+        #expect(low.count < high.count)
+    }
+
     @Test("falls back to PNG for an unrecognized extension")
     func fallsBackToPNGForUnknownExtension() throws {
         let image = try makeImage(width: 4, height: 4)

--- a/Packages/SharedKit/Tests/SharedKitTests/QuickAccessDragFileStoreTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/QuickAccessDragFileStoreTests.swift
@@ -1,6 +1,8 @@
 // Packages/SharedKit/Tests/SharedKitTests/QuickAccessDragFileStoreTests.swift
 import CoreGraphics
 import Foundation
+import ImageIO
+import UniformTypeIdentifiers
 import Testing
 @testable import SharedKit
 
@@ -22,8 +24,8 @@ struct QuickAccessDragFileStoreTests {
         #expect(data.starts(with: [0x89, 0x50, 0x4E, 0x47]))
     }
 
-    @Test("uses screenshot export preset and filename template")
-    func usesExportPresetAndFilenameTemplate() throws {
+    @Test("uses screenshot output options and filename template")
+    func usesOutputOptionsAndFilenameTemplate() throws {
         let directory = temporaryDirectory()
         defer { remove(directory) }
         let store = QuickAccessDragFileStore(directory: directory)
@@ -32,7 +34,7 @@ struct QuickAccessDragFileStoreTests {
         let url = try store.fileURL(
             for: image,
             id: UUID(),
-            preset: .standardJPEG,
+            output: ScreenshotOutputOptions(format: .jpeg, quality: 0.85),
             date: Date(timeIntervalSince1970: 1_800),
             sourceAppName: "Safari",
             sourceWindowTitle: "Example",
@@ -43,6 +45,27 @@ struct QuickAccessDragFileStoreTests {
         #expect(url.lastPathComponent == "Drag Safari Example.jpeg")
         let data = try Data(contentsOf: url)
         #expect(data.starts(with: [0xFF, 0xD8]))
+    }
+
+    @Test("writes HEIC bytes when the output format is HEIC")
+    func writesHEICOutput() throws {
+        guard ScreenshotOutputFormat.heic.isAvailable else { return }
+        let directory = temporaryDirectory()
+        defer { remove(directory) }
+        let store = QuickAccessDragFileStore(directory: directory)
+        let image = try makeImage()
+
+        let url = try store.fileURL(
+            for: image,
+            id: UUID(),
+            output: ScreenshotOutputOptions(format: .heic, quality: 0.85),
+            date: Date(timeIntervalSince1970: 1_800),
+            template: "Drag"
+        )
+
+        #expect(url.lastPathComponent == "Drag.heic")
+        let source = try #require(CGImageSourceCreateWithURL(url as CFURL, nil))
+        #expect(CGImageSourceGetType(source) as String? == UTType.heic.identifier)
     }
 
     @Test("returns the same readable file for repeated access")
@@ -99,29 +122,30 @@ struct QuickAccessDragFileStoreTests {
         #expect(secondURL.lastPathComponent == "Same Name 2.png")
     }
 
-    @Test("prunes stale PNG files while preserving active drag files")
+    @Test("prunes every stale output format while preserving active drag files")
     func prunesStaleFiles() throws {
         let directory = temporaryDirectory()
         defer { remove(directory) }
         let now = Date(timeIntervalSince1970: 2_000)
         let store = QuickAccessDragFileStore(directory: directory, staleFileAge: 60)
         let activeURL = try store.fileURL(for: try makeImage(), id: UUID())
-        let staleURL = directory.appendingPathComponent("stale.png")
-        let staleJPEGURL = directory.appendingPathComponent("stale.jpeg")
+        let staleURLs = ["stale.png", "stale.jpeg", "stale.jpg", "stale.heic"]
+            .map { directory.appendingPathComponent($0) }
         let recentURL = directory.appendingPathComponent("recent.png")
-        try Data([1]).write(to: staleURL)
-        try Data([1]).write(to: staleJPEGURL)
+        for url in staleURLs {
+            try Data([1]).write(to: url)
+            try FileManager.default.setAttributes([.modificationDate: now.addingTimeInterval(-120)], ofItemAtPath: url.path)
+        }
         try Data([2]).write(to: recentURL)
-        try FileManager.default.setAttributes([.modificationDate: now.addingTimeInterval(-120)], ofItemAtPath: staleURL.path)
-        try FileManager.default.setAttributes([.modificationDate: now.addingTimeInterval(-120)], ofItemAtPath: staleJPEGURL.path)
         try FileManager.default.setAttributes([.modificationDate: now.addingTimeInterval(-10)], ofItemAtPath: recentURL.path)
         try FileManager.default.setAttributes([.modificationDate: now.addingTimeInterval(-120)], ofItemAtPath: activeURL.path)
 
         let removed = try store.pruneStaleFiles(referenceDate: now)
 
-        #expect(removed.map(\.lastPathComponent).sorted() == [staleJPEGURL.lastPathComponent, staleURL.lastPathComponent].sorted())
-        #expect(!FileManager.default.fileExists(atPath: staleURL.path))
-        #expect(!FileManager.default.fileExists(atPath: staleJPEGURL.path))
+        #expect(removed.map(\.lastPathComponent).sorted() == staleURLs.map(\.lastPathComponent).sorted())
+        for url in staleURLs {
+            #expect(!FileManager.default.fileExists(atPath: url.path))
+        }
         #expect(FileManager.default.fileExists(atPath: recentURL.path))
         #expect(FileManager.default.fileExists(atPath: activeURL.path))
     }


### PR DESCRIPTION
## What changed

You can save screenshots as HEIC now, and set the quality yourself instead of picking from fixed presets.

Preferences > Export > Quality had one three-way control (PNG, JPEG 85%, JPEG 70%). Now it's two rows:

<p align="center">
  <img width="680" height="514" alt="Capso Screenshot 2026-08-11 at 14 50 23" src="https://github.com/user-attachments/assets/f8047f9f-8290-43f5-ab6d-9136fcd5731a" />
</p>

HEIC is the point. On a 3024×1964 capture: PNG 124 KB, JPEG 85% 422 KB, HEIC 85% 75 KB. Screenshots are mostly flat UI, which is exactly where PNG already beats JPEG, so JPEG alone was never much help if you were trying to get under an upload limit.

Your setting carries over: `losslessPNG` → PNG 85%, `standardJPEG` → JPEG 85%, `compactJPEG` → JPEG 70%. The old `screenshotFormat` key still gets written, so downgrading to 1.0.1 still works.

Three things were quietly broken on this code path, so they're fixed here too:

- Overwriting an annotated `.heif` wrote PNG bytes into it. `UTType(filenameExtension: "heif")` is `public.heif`, and HEIC conforms to HEIF rather than the reverse, so the old `conforms(to: .heic)` check fell through to the PNG fallback.
- Cloud Share hard-coded a `.png` temp file and `image/png`, so it uploaded PNG whatever you'd picked. That's the exact path the reporter hit the limit on.
- Quick Access drag temp files were pruned against a hard-coded `["png", "jpg", "jpeg"]`, so HEIC ones would never get cleaned up.

### What's not here

**WebP, which is what #228 actually asked for.** macOS can't encode it. `CGImageDestinationCopyTypeIdentifiers()` lists png, jpeg, heic and avif but not `org.webmproject.webp`, and creating that destination returns nil — on 26.5 as much as on the 15.0 target. Decode works, encode doesn't. Shipping it means bundling libwebp, which is a first C dependency plus notices and a hardened-runtime pass, so it wants its own PR. Hence `Refs`, not `Closes`.

The seam's ready for it: `ImageEncoders.default` is one binding, and a `WebPEncoder` that forwards everything else to `ImageIOEncoder` drops in.

WebP is deliberately still missing from `ImageFileReader` too. Overwriting an opened image reuses its extension, so a format we can read but not write would put PNG bytes in a `.webp`. Read and write land together, and there's a test holding that line.

AVIF is out as well — it encodes natively and is smaller still (41 KB on the same capture), so it's a one-case addition if you ever want it. History stays PNG since it's what the annotation editor reads back from, and re-encoding lossy every round-trip would stack up artifacts. Clipboard format is untouched; HEIC on the pasteboard isn't well supported.

## How it works

New `ImageEncoding` protocol in SharedKit with one ImageIO implementation. It replaced three copies of the same switch (`CaptureCoordinator.screenshotData`, `HistoryCoordinator.saveImageToExportLocation`, `QuickAccessDragFileStore.encodedData`) — adding a `FileFormat` case broke all three anyway, so merging them was the smaller diff. PNG and JPEG moved off `NSBitmapImageRep` onto `CGImageDestination` so everything goes one way.

`screenshotOutputPreset` ran through eight signatures, so rather than split it into two arguments everywhere it became one `ScreenshotOutputOptions`, same shape as `ScreenshotTimestampOptions` next to it.

One gotcha: some Intel Macs have no HEVC encoder, so HEIC isn't a given. `isAvailable` checks the writable type identifiers, the picker only offers what passes, and the getter falls back to PNG rather than hand back something that won't encode. PNG bytes in a `.heic` would be worse than not offering it.

That guard only fires on hardware I don't have, so the logic is a pure `resolvedOutputFormat(stored:legacy:isAvailable:)` that a fake can drive. Worth it — my first test passed with the guard deleted, because the value I'd stored wasn't a valid case and never reached it.

HEIC takes ~112 ms on that capture vs 26 ms for PNG, and `saveImageToFile` is sync on the main actor. Default stays PNG and only opt-in users pay it, so I left the threading alone rather than make it async and cascade through the history and toast paths.

## Related issue

Refs #228

## Screenshots / recordings

<!-- Preferences > Export > Quality: PNG selected (quality row hidden), HEIC selected (quality row shown) -->

## Testing

Test-first, and each one checked by putting the bug back to confirm it went red. Two survived that: the availability guard above, and `compactJPEG` migrating to the wrong quality. SharedKit goes 193 → 214 tests.

- `ImageEncoding` (new): each format round-trips to its own UTI, lower quality means strictly fewer bytes, PNG ignores quality, unavailable formats return nil instead of substituting someone else's bytes
- `AppSettings`: default PNG 85%, persistence, all three preset migrations, legacy `screenshotFormat` fallback, quality clamping both ends, availability fallback for stored and migrated formats
- `ImageFileWriter`: `.heif` gives HEIC, quality honoured for lossy destinations
- `ImageFileReader`: every readable format is writable — the test that stops WebP landing in the reader before there's an encoder
- `QuickAccessDragFileStore`: HEIC options write `.heic`, pruning covers every output format

`swift test` passes for SharedKit (214), AnnotationKit (93), CaptureKit (85), RecordingKit (9), and the Debug build passes. `CapsoTests` is unchanged from main — two tests there need a focused key window and fail locally on either branch.

Also checked by hand against a real capture through the shipping encoder: right extension, UTI and MIME per format, sizes tracking quality, migrations landing where they should.

New strings localized for ja, ko and zh-Hans. `Screenshot Format` was already in the catalog as a stale key with all three translations, so it's reused.

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass (`swift test --package-path Packages/SharedKit`)
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per CONTRIBUTING.md
