### PR TITLE
feat: grow a 1:1 selection from the click as the center

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -1502,6 +1502,116 @@
         }
       }
     },
+    "Center 1:1 from click" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリック位置を中心に1:1"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클릭 위치를 중심으로 1:1"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以点击为中心的 1:1"
+          }
+        }
+      }
+    },
+    "Click to record a different extra key" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリックして別の追加キーを録音"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클릭하여 다른 추가 키를 지정"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击以录制其他附加键"
+          }
+        }
+      }
+    },
+    "Extra key for centered 1:1" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中央1:1用の追加キー"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "중심 1:1용 추가 키"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "居中 1:1 的附加键"
+          }
+        }
+      }
+    },
+    "Hold Shift for 1:1, then this extra key to grow from the click as the center. Shift cannot be changed." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shiftで1:1に固定し、この追加キーで最初のクリックを中心に拡大します。Shiftは変更できません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shift로 1:1을 유지한 뒤, 이 추가 키로 첫 클릭을 중심으로 키웁니다. Shift는 바꿀 수 없습니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "按住 Shift 锁定 1:1，再按此附加键从点击处居中扩展。Shift 无法更改。"
+          }
+        }
+      }
+    },
+    "Selection" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選択"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "선택"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选区"
+          }
+        }
+      }
+    },
     "Cancel" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasNSView.swift
@@ -2,6 +2,7 @@
 import AppKit
 import CoreGraphics
 import AnnotationKit
+import SharedKit
 
 /// Which visible handle is being dragged for resize or path adjustment.
 private enum ResizeHandle {
@@ -151,6 +152,10 @@ final class AnnotationCanvasNSView: NSView {
     /// 1:1 and line tools snap to 45°. Seeded on mouse down so a Shift press
     /// that precedes the drag is honored.
     private var squareLock = false
+    /// Whether the configurable extra key (default C) is held.
+    private var centerLockKeyHeld = false
+    /// Extra key that, with Shift, grows a constrained creation from the click.
+    var squareCenterLockShortcut = SquareCenterLockShortcut.default
     private var isDragging = false
     private var dragObjectID: ObjectID?
     private var activeResizeHandle: ResizeHandle?
@@ -430,10 +435,10 @@ final class AnnotationCanvasNSView: NSView {
                 }
             }
 
-            if let start = dragStart, let current = previewDragEnd,
+            if let drag = previewDrag,
                isDragging, activeResizeHandle == nil,
                currentTool != .select, currentTool != .freehand, currentTool != .text, currentTool != .highlighter {
-                drawPreview(ctx: ctx, from: start, to: current)
+                drawPreview(ctx: ctx, from: drag.start, to: drag.end)
             }
         }
 
@@ -749,21 +754,33 @@ final class AnnotationCanvasNSView: NSView {
         return nil
     }
 
-    /// The drag endpoint after the active tool's Shift constraint. Both the live
-    /// preview and the committed object go through this, so a square preview can
-    /// never commit as a free rectangle.
-    private func constrainedCreationEnd(from start: CGPoint, to end: CGPoint) -> CGPoint {
-        guard squareLock else { return end }
-        return AnnotationDragConstraint.constrainedEnd(from: start, to: end, tool: currentTool)
+    /// The start and end of a creation drag after Shift / center-lock
+    /// constraints. Both the live preview and the committed object go through
+    /// this, so a centered square preview can never commit as a corner square.
+    private func constrainedCreationDrag(
+        from start: CGPoint,
+        to end: CGPoint
+    ) -> (start: CGPoint, end: CGPoint) {
+        guard squareLock else { return (start: start, end: end) }
+        return AnnotationDragConstraint.constrainedDrag(
+            from: start,
+            to: end,
+            tool: currentTool,
+            centerLock: centerLockKeyHeld
+        )
     }
 
     /// The endpoint the in-progress preview is drawn to: the live pointer
     /// position with the active tool's Shift constraint applied. Internal so
     /// interaction tests can assert on what the user sees mid-drag.
-    var previewDragEnd: CGPoint? {
+    var previewDrag: (start: CGPoint, end: CGPoint)? {
         guard let start = dragStart, let current = dragCurrent else { return nil }
-        return constrainedCreationEnd(from: start, to: current)
+        return constrainedCreationDrag(from: start, to: current)
     }
+
+    var previewDragStart: CGPoint? { previewDrag?.start }
+
+    var previewDragEnd: CGPoint? { previewDrag?.end }
 
     private func drawPreview(ctx: CGContext, from start: CGPoint, to end: CGPoint) {
         ctx.saveGState()
@@ -830,6 +847,8 @@ final class AnnotationCanvasNSView: NSView {
         dragStart = point
         dragCurrent = point
         squareLock = event.modifierFlags.contains(.shift)
+        centerLockKeyHeld = event.modifierFlags.intersection([.command, .option, .control]).isEmpty
+            && squareCenterLockShortcut.isHardwareKeyPressed
         isDragging = true
         activeResizeHandle = nil
         resizeOriginalTextFontSize = nil
@@ -1108,14 +1127,16 @@ final class AnnotationCanvasNSView: NSView {
             return
         }
 
-        guard let doc = document, let start = dragStart else {
+        guard let doc = document, let origin = dragStart else {
             isDragging = false; return
         }
         squareLock = event.modifierFlags.contains(.shift)
-        let end = constrainedCreationEnd(
-            from: start,
+        let drag = constrainedCreationDrag(
+            from: origin,
             to: toImagePoint(convert(event.locationInWindow, from: nil))
         )
+        let start = drag.start
+        let end = drag.end
 
         if activeResizeHandle != nil {
             dragObjectID = nil
@@ -1230,6 +1251,9 @@ final class AnnotationCanvasNSView: NSView {
     }
 
     override func keyDown(with event: NSEvent) {
+        if handleCenterLockKeyEvent(event) {
+            return
+        }
         if performAnnotationClipboardShortcut(with: event) {
             return
         }
@@ -1240,6 +1264,35 @@ final class AnnotationCanvasNSView: NSView {
         } else {
             super.keyDown(with: event)
         }
+    }
+
+    override func keyUp(with event: NSEvent) {
+        if handleCenterLockKeyEvent(event) {
+            return
+        }
+        super.keyUp(with: event)
+    }
+
+    /// Shared entry for key-down/up so center lock toggles live. Returns `true`
+    /// when the extra key was handled and should not propagate.
+    @discardableResult
+    func handleCenterLockKeyEvent(_ event: NSEvent) -> Bool {
+        guard event.keyCode == squareCenterLockShortcut.keyCode, !event.isARepeat else {
+            return false
+        }
+
+        if event.type == .keyUp {
+            centerLockKeyHeld = false
+        } else if event.modifierFlags.intersection([.command, .option, .control]).isEmpty {
+            centerLockKeyHeld = true
+        } else {
+            return false
+        }
+
+        if isDragging, AnnotationDragConstraint.kind(for: currentTool) != .none {
+            needsDisplay = true
+        }
+        return true
     }
 
     /// Handles annotation-object clipboard shortcuts (⌘C / ⌘V / ⌘D).

--- a/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
+++ b/App/Sources/AnnotationEditor/AnnotationCanvasView.swift
@@ -2,6 +2,7 @@
 import SwiftUI
 import AppKit
 import AnnotationKit
+import SharedKit
 
 struct AnnotationCanvasView: NSViewRepresentable {
     let document: AnnotationDocument
@@ -75,6 +76,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
         // of swallowing it in a no-op wrapper.
         view.onMagnify = onMagnify
         view.onScroll = onScroll
+        view.squareCenterLockShortcut = AppSettings().squareCenterLockShortcut
         return view
     }
 
@@ -106,6 +108,7 @@ struct AnnotationCanvasView: NSViewRepresentable {
         nsView.onTextEditingEnded = { onTextEditingEnded?() }
         nsView.onMagnify = onMagnify
         nsView.onScroll = onScroll
+        nsView.squareCenterLockShortcut = AppSettings().squareCenterLockShortcut
         if context.coordinator.lastCommitEditingTrigger != commitEditingTrigger {
             context.coordinator.lastCommitEditingTrigger = commitEditingTrigger
             nsView.commitTextEditingIfNeeded()

--- a/App/Sources/AnnotationEditor/AnnotationToolShortcutMonitor.swift
+++ b/App/Sources/AnnotationEditor/AnnotationToolShortcutMonitor.swift
@@ -1,6 +1,7 @@
 import AppKit
 import SwiftUI
 import AnnotationKit
+import SharedKit
 
 private struct AnnotationToolShortcutMonitor: NSViewRepresentable {
     @Binding var currentTool: AnnotationTool
@@ -51,7 +52,12 @@ private struct AnnotationToolShortcutMonitor: NSViewRepresentable {
                   !isTextInputActive(in: event.window),
                   allowsToolShortcutModifiers(event.modifierFlags),
                   let key = event.charactersIgnoringModifiers,
-                  let tool = AnnotationToolShortcut.tool(for: key) else {
+                  let tool = AnnotationToolShortcut.tool(
+                    for: key,
+                    keyCode: event.keyCode,
+                    shiftHeld: event.modifierFlags.contains(.shift),
+                    centerLockShortcut: AppSettings().squareCenterLockShortcut
+                  ) else {
                 return event
             }
 

--- a/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
+++ b/App/Sources/Capture/CaptureAllInOneToolbarWindow.swift
@@ -128,6 +128,7 @@ final class CaptureAllInOneToolbarWindow {
             activePreset: activePreset
         )
         overlayView.passesThroughSelectionBody = frozenImage != nil
+        overlayView.squareCenterLockShortcut = AppSettings().squareCenterLockShortcut
         overlayView.onSelectionPreviewChanged = { [weak self] selectionRect in
             self?.updateSelection(selectionRect, phase: .live)
         }
@@ -468,7 +469,7 @@ final class CaptureAllInOneToolbarWindow {
             guard event.keyCode == 53 else { return }
             Task { @MainActor in self?.onCancel?() }
         }
-        localEscMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+        localEscMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .keyUp]) { [weak self] event in
             self?.handleKeyboardEvent(event)
         }
         // The toolbar panel can be key while the selection is being dragged, so
@@ -496,6 +497,10 @@ final class CaptureAllInOneToolbarWindow {
     }
 
     private func handleKeyboardEvent(_ event: NSEvent) -> NSEvent? {
+        if selectionOverlayView?.handleCenterLockKeyEvent(event) == true {
+            return nil
+        }
+        guard event.type == .keyDown else { return event }
         if event.keyCode == 53 {
             onCancel?()
             return nil
@@ -1213,6 +1218,10 @@ final class AllInOneSelectionOverlayView: NSView {
     private var trackingArea: NSTrackingArea?
     /// Whether Shift is currently held, locking the drag to a 1:1 square.
     private var squareLock = false
+    /// Whether the configurable extra key (default C) is held.
+    private var centerLockKeyHeld = false
+    /// Extra key that, with Shift, grows a create-drag from the click center.
+    var squareCenterLockShortcut = SquareCenterLockShortcut.default
     /// Last pointer location during a drag, so a live Shift toggle can recompute.
     private var lastDragPoint: CGPoint = .zero
 
@@ -1360,6 +1369,7 @@ final class AllInOneSelectionOverlayView: NSView {
         // previous drag's endpoint.
         lastDragPoint = point
         squareLock = event.modifierFlags.contains(.shift)
+        centerLockKeyHeld = isCenterLockKeyPressed(alongside: event)
 
         if let fixedSize = activePreset.fixedPixelSize {
             if hitTarget(at: point) != nil {
@@ -1417,6 +1427,51 @@ final class AllInOneSelectionOverlayView: NSView {
         updateSelectionForDrag(to: lastDragPoint)
     }
 
+    /// Shared entry for key-down/up from the view and the window's local
+    /// monitor. Returns `true` when the extra key was handled and should not
+    /// propagate (so ⌘⇧C can still copy).
+    @discardableResult
+    func handleCenterLockKeyEvent(_ event: NSEvent) -> Bool {
+        guard event.keyCode == squareCenterLockShortcut.keyCode, !event.isARepeat else {
+            return false
+        }
+
+        if event.type == .keyUp {
+            centerLockKeyHeld = false
+            if case .create = dragOperation {
+                updateSelectionForDrag(to: lastDragPoint)
+            }
+            return event.modifierFlags.contains(.shift) || isCreateDrag
+        }
+
+        if !event.modifierFlags.intersection([.command, .option, .control]).isEmpty {
+            return false
+        }
+
+        let shouldConsume = event.modifierFlags.contains(.shift) || isCreateDrag
+        guard shouldConsume else { return false }
+
+        centerLockKeyHeld = true
+        if case .create = dragOperation {
+            updateSelectionForDrag(to: lastDragPoint)
+        }
+        return true
+    }
+
+    private var isCreateDrag: Bool {
+        if case .create = dragOperation { return true }
+        return false
+    }
+
+    private func isCenterLockKeyPressed(alongside event: NSEvent) -> Bool {
+        event.modifierFlags.intersection([.command, .option, .control]).isEmpty
+            && squareCenterLockShortcut.isHardwareKeyPressed
+    }
+
+    private var isCenterLocked: Bool {
+        squareLock && centerLockKeyHeld
+    }
+
     /// Applies the active drag operation for a pointer location, honoring the
     /// resolved aspect ratio (Shift locks to 1:1, otherwise the preset ratio).
     private func updateSelectionForDrag(to point: CGPoint) {
@@ -1460,7 +1515,8 @@ final class AllInOneSelectionOverlayView: NSView {
                     to: point,
                     in: bounds,
                     minSize: minSelectionSize,
-                    aspectRatio: ratio
+                    aspectRatio: ratio,
+                    centered: isCenterLocked
                 )
             } else {
                 selectionRect = CaptureSelectionGeometry.rect(
@@ -1493,12 +1549,22 @@ final class AllInOneSelectionOverlayView: NSView {
     }
 
     override func keyDown(with event: NSEvent) {
+        if handleCenterLockKeyEvent(event) {
+            return
+        }
         guard event.keyCode == 53 else {
             super.keyDown(with: event)
             return
         }
 
         onCancel?()
+    }
+
+    override func keyUp(with event: NSEvent) {
+        if handleCenterLockKeyEvent(event) {
+            return
+        }
+        super.keyUp(with: event)
     }
 
     override func draw(_ dirtyRect: NSRect) {

--- a/App/Sources/Capture/CaptureOverlayView.swift
+++ b/App/Sources/Capture/CaptureOverlayView.swift
@@ -48,6 +48,9 @@ final class CaptureOverlayView: NSView {
     private var dragEnd: NSPoint = .zero
     /// Whether Shift is currently held, locking the area drag to a 1:1 square.
     private var squareLock = false
+    /// Whether the configurable extra key (default C) is held. Center lock is
+    /// `squareLock && centerLockKeyHeld`.
+    private var centerLockKeyHeld = false
     /// Last raw (unconstrained) pointer location during an area drag, so a live
     /// Shift toggle can recompute the constrained corner.
     private var lastRawEnd: NSPoint = .zero
@@ -179,6 +182,7 @@ final class CaptureOverlayView: NSView {
         currentMouseLocation = nil
         selectedWindowIDs = []
         isShiftHeld = false
+        centerLockKeyHeld = false
         needsDisplay = true
     }
 
@@ -639,11 +643,25 @@ final class CaptureOverlayView: NSView {
     /// The live selection built from the drag anchors. Internal so interaction
     /// tests can assert mid-drag state.
     var selectionRect: CGRect {
+        if isCenterLocked {
+            return CaptureSelectionGeometry.rect(
+                from: dragStart,
+                to: lastRawEnd,
+                in: bounds,
+                minSize: .zero,
+                aspectRatio: 1,
+                centered: true
+            )
+        }
         let x = min(dragStart.x, dragEnd.x)
         let y = min(dragStart.y, dragEnd.y)
         let w = abs(dragEnd.x - dragStart.x)
         let h = abs(dragEnd.y - dragStart.y)
         return CGRect(x: x, y: y, width: w, height: h)
+    }
+
+    private var isCenterLocked: Bool {
+        squareLock && centerLockKeyHeld
     }
 
     private func drawDimensionLabel(for rect: CGRect, in context: CGContext) {
@@ -809,6 +827,7 @@ final class CaptureOverlayView: NSView {
             // endpoint.
             lastRawEnd = loc
             squareLock = event.modifierFlags.contains(.shift)
+            centerLockKeyHeld = isCenterLockKeyPressed(alongside: event)
 
             // Fixed-size: no drag — capture immediately centered on cursor
             if let fixedSize = activePreset.fixedPixelSize {
@@ -915,7 +934,7 @@ final class CaptureOverlayView: NSView {
         squareLock = event.modifierFlags.contains(.shift)
         dragEnd = constrainedDragEnd(rawEnd: rawEnd)
         // Reticle tracks the constrained corner so it stays on the selection edge
-        currentMouseLocation = dragEnd
+        currentMouseLocation = reticlePoint
 
         // Ensure cursor stays hidden during drag (it can reappear on screen edges)
         if !cursorHidden {
@@ -990,6 +1009,9 @@ final class CaptureOverlayView: NSView {
     }
 
     override func keyDown(with event: NSEvent) {
+        if handleCenterLockKeyEvent(event) {
+            return
+        }
         if event.keyCode == 53 { // ESC
             if !handleEscapeKey() {
                 cancelOverlay()
@@ -1004,6 +1026,13 @@ final class CaptureOverlayView: NSView {
         }
     }
 
+    override func keyUp(with event: NSEvent) {
+        if handleCenterLockKeyEvent(event) {
+            return
+        }
+        super.keyUp(with: event)
+    }
+
     override func flagsChanged(with event: NSEvent) {
         handleFlagsChanged(event)
         super.flagsChanged(with: event)
@@ -1016,9 +1045,49 @@ final class CaptureOverlayView: NSView {
         let shiftNow = event.modifierFlags.contains(.shift)
         guard shiftNow != squareLock else { return }
         squareLock = shiftNow
+        recomputeConstrainedSelection()
+    }
+
+    /// Shared entry for key-down/up from the view and the window's local
+    /// monitor so center lock toggles live even when this view is not first
+    /// responder. Returns `true` when the extra key was handled and should
+    /// not propagate (for example to ⌘C).
+    @discardableResult
+    func handleCenterLockKeyEvent(_ event: NSEvent) -> Bool {
+        let shortcut = settings.squareCenterLockShortcut
+        guard event.keyCode == shortcut.keyCode, !event.isARepeat else { return false }
+
+        if event.type == .keyUp {
+            centerLockKeyHeld = false
+        } else if event.modifierFlags.intersection([.command, .option, .control]).isEmpty {
+            centerLockKeyHeld = true
+        } else {
+            return false
+        }
+
+        recomputeConstrainedSelection()
+        return true
+    }
+
+    private func isCenterLockKeyPressed(alongside event: NSEvent) -> Bool {
+        event.modifierFlags.intersection([.command, .option, .control]).isEmpty
+            && settings.squareCenterLockShortcut.isHardwareKeyPressed
+    }
+
+    private func recomputeConstrainedSelection() {
+        guard case .area = mode, isDragging else { return }
         dragEnd = constrainedDragEnd(rawEnd: lastRawEnd)
-        currentMouseLocation = dragEnd
+        currentMouseLocation = reticlePoint
         needsDisplay = true
+    }
+
+    private var reticlePoint: NSPoint {
+        guard isCenterLocked else { return dragEnd }
+        let rect = selectionRect
+        return NSPoint(
+            x: lastRawEnd.x >= dragStart.x ? rect.maxX : rect.minX,
+            y: lastRawEnd.y >= dragStart.y ? rect.maxY : rect.minY
+        )
     }
 
     /// Shared entry for both the view's `flagsChanged` and the window's local

--- a/App/Sources/Capture/CaptureOverlayWindow.swift
+++ b/App/Sources/Capture/CaptureOverlayWindow.swift
@@ -137,7 +137,7 @@ final class CaptureOverlayWindow: NSPanel {
             }
         }
         // Local monitor: catches ESC/Space when our window is key.
-        localEscMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+        localEscMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .keyUp]) { [weak self] event in
             self?.handleLocalKeyEvent(event) ?? event
         }
         // Ensure Shift-driven behavior still runs when the view is not first
@@ -177,6 +177,10 @@ final class CaptureOverlayWindow: NSPanel {
     /// untouched so one key press is handled exactly once.
     func handleLocalKeyEvent(_ event: NSEvent) -> NSEvent? {
         guard event.windowNumber == windowNumber else { return event }
+        if overlayView.handleCenterLockKeyEvent(event) {
+            return nil
+        }
+        guard event.type == .keyDown else { return event }
         switch event.keyCode {
         case 53:
             if overlayView.handleEscapeKey() {

--- a/App/Sources/Preferences/PreferencesView.swift
+++ b/App/Sources/Preferences/PreferencesView.swift
@@ -141,7 +141,7 @@ struct PreferencesView: View {
                 case .ocr:
                     TextAndTranslationSettingsView(viewModel: viewModel)
                 case .shortcuts:
-                    ShortcutSettingsView()
+                    ShortcutSettingsView(viewModel: viewModel)
                 }
             }
             .padding(.horizontal, 28)

--- a/App/Sources/Preferences/PreferencesViewModel.swift
+++ b/App/Sources/Preferences/PreferencesViewModel.swift
@@ -316,6 +316,19 @@ final class PreferencesViewModel {
             }
         }
     }
+
+    var squareCenterLockShortcut: SquareCenterLockShortcut {
+        get {
+            access(keyPath: \.squareCenterLockShortcut)
+            return settings.squareCenterLockShortcut
+        }
+        set {
+            withMutation(keyPath: \.squareCenterLockShortcut) {
+                settings.squareCenterLockShortcut = newValue
+            }
+        }
+    }
+
     var customCapturePresets: [CapturePreset] {
         get {
             access(keyPath: \.customCapturePresets)

--- a/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
@@ -1,6 +1,8 @@
 // App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
 import SwiftUI
+import AppKit
 import KeyboardShortcuts
+import SharedKit
 
 extension KeyboardShortcuts.Name {
     static let captureAllInOne = Self("captureAllInOne")
@@ -28,6 +30,7 @@ extension KeyboardShortcuts.Name {
 }
 
 struct ShortcutSettingsView: View {
+    @Bindable var viewModel: PreferencesViewModel
     private struct ContextualShortcut: Identifiable {
         let id: String
         let scope: LocalizedStringKey
@@ -102,12 +105,30 @@ struct ShortcutSettingsView: View {
 
             SettingGroup(title: "Contextual Shortcuts") {
                 SettingCard {
-                    ForEach(Array(contextualShortcuts.enumerated()), id: \.element.id) { index, item in
-                        contextualShortcutRow(item, showDivider: index > 0)
+                    centerLockRow
+                    ForEach(Array(contextualShortcuts.enumerated()), id: \.element.id) { _, item in
+                        contextualShortcutRow(item, showDivider: true)
                     }
                 }
             }
         }
+    }
+
+    private var centerLockRow: some View {
+        SettingRow(
+            label: "Center 1:1 from click",
+            sublabel: "Selection",
+            showDivider: false
+        ) {
+            HStack(spacing: 6) {
+                ShortcutKeycap(text: "⇧")
+                Text("+")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                SquareCenterLockKeyRecorder(shortcut: $viewModel.squareCenterLockShortcut)
+            }
+        }
+        .help("Hold Shift for 1:1, then this extra key to grow from the click as the center. Shift cannot be changed.")
     }
 
     @ViewBuilder
@@ -135,6 +156,99 @@ struct ShortcutSettingsView: View {
                 ForEach(Array(item.shortcuts.enumerated()), id: \.offset) { _, shortcut in
                     ShortcutKeycap(text: shortcut)
                 }
+            }
+        }
+    }
+}
+
+private struct SquareCenterLockKeyRecorder: View {
+    @Binding var shortcut: SquareCenterLockShortcut
+    @State private var isRecording = false
+
+    var body: some View {
+        Button {
+            isRecording.toggle()
+        } label: {
+            Text(isRecording ? "…" : shortcut.displayCharacter)
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .foregroundStyle(isRecording ? Color.accentColor : Color.secondary)
+                .padding(.horizontal, 8)
+                .frame(height: 24)
+                .background(
+                    Color.primary.opacity(isRecording ? 0.12 : 0.08),
+                    in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(
+                            isRecording ? Color.accentColor : Color.primary.opacity(0.10),
+                            lineWidth: isRecording ? 1.5 : 0.5
+                        )
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Extra key for centered 1:1")
+        .accessibilityValue(shortcut.displayCharacter)
+        .help("Click to record a different extra key")
+        .background {
+            if isRecording {
+                CenterLockKeyCapture { event in
+                    if event.keyCode == 53 {
+                        isRecording = false
+                        return
+                    }
+                    if let recorded = SquareCenterLockShortcut(event: event) {
+                        shortcut = recorded
+                        isRecording = false
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Local key-down monitor used only while the extra-key recorder is listening.
+private struct CenterLockKeyCapture: NSViewRepresentable {
+    var onKeyDown: (NSEvent) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onKeyDown: onKeyDown)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        context.coordinator.install()
+        return NSView(frame: .zero)
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.onKeyDown = onKeyDown
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.uninstall()
+    }
+
+    @MainActor
+    final class Coordinator {
+        var onKeyDown: (NSEvent) -> Void
+        private var monitor: Any?
+
+        init(onKeyDown: @escaping (NSEvent) -> Void) {
+            self.onKeyDown = onKeyDown
+        }
+
+        func install() {
+            guard monitor == nil else { return }
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                self?.onKeyDown(event)
+                return nil
+            }
+        }
+
+        func uninstall() {
+            if let monitor {
+                NSEvent.removeMonitor(monitor)
+                self.monitor = nil
             }
         }
     }

--- a/App/Tests/AnnotationCanvasInteractionTests.swift
+++ b/App/Tests/AnnotationCanvasInteractionTests.swift
@@ -92,6 +92,87 @@ final class AnnotationCanvasInteractionTests: XCTestCase {
         XCTAssertEqual(rect.width, rect.height, accuracy: 0.001)
     }
 
+    func testShiftPlusCCommitsARectangleCenteredOnClick() throws {
+        let (view, document) = makeCanvas(tool: .rectangle)
+
+        view.mouseDown(with: mouseEvent(.leftMouseDown, at: NSPoint(x: 100, y: 400), modifierFlags: .shift))
+        view.mouseDragged(with: mouseEvent(.leftMouseDragged, at: NSPoint(x: 300, y: 320), modifierFlags: .shift))
+        view.handleCenterLockKeyEvent(keyEvent(keyCode: 8, characters: "c", modifierFlags: .shift))
+        view.mouseUp(with: mouseEvent(.leftMouseUp, at: NSPoint(x: 300, y: 320), modifierFlags: .shift))
+
+        let rect = try XCTUnwrap(document.objects.first as? RectangleObject).rect
+        XCTAssertEqual(rect.origin.x, -100, accuracy: 0.001)
+        XCTAssertEqual(rect.origin.y, 0, accuracy: 0.001)
+        XCTAssertEqual(rect.width, 400, accuracy: 0.001)
+        XCTAssertEqual(rect.height, 400, accuracy: 0.001)
+        XCTAssertEqual(rect.midX, 100, accuracy: 0.001)
+        XCTAssertEqual(rect.midY, 200, accuracy: 0.001)
+    }
+
+    func testShiftPlusCCommitsACircularEllipseCenteredOnClick() throws {
+        let (view, document) = makeCanvas(tool: .ellipse)
+
+        view.mouseDown(with: mouseEvent(.leftMouseDown, at: NSPoint(x: 120, y: 420), modifierFlags: .shift))
+        view.mouseDragged(with: mouseEvent(.leftMouseDragged, at: NSPoint(x: 260, y: 380), modifierFlags: .shift))
+        view.handleCenterLockKeyEvent(keyEvent(keyCode: 8, characters: "c", modifierFlags: .shift))
+        view.mouseUp(with: mouseEvent(.leftMouseUp, at: NSPoint(x: 260, y: 380), modifierFlags: .shift))
+
+        let rect = try XCTUnwrap(document.objects.first as? EllipseObject).rect
+        XCTAssertEqual(rect.width, rect.height, accuracy: 0.001)
+        XCTAssertEqual(rect.midX, 120, accuracy: 0.001)
+        XCTAssertEqual(rect.midY, 180, accuracy: 0.001)
+    }
+
+    func testShiftPlusCCommitsALineCenteredOnClick() throws {
+        let (view, document) = makeCanvas(tool: .line)
+
+        view.mouseDown(with: mouseEvent(.leftMouseDown, at: NSPoint(x: 100, y: 300), modifierFlags: .shift))
+        view.mouseDragged(with: mouseEvent(.leftMouseDragged, at: NSPoint(x: 280, y: 288), modifierFlags: .shift))
+        view.handleCenterLockKeyEvent(keyEvent(keyCode: 8, characters: "c", modifierFlags: .shift))
+        view.mouseUp(with: mouseEvent(.leftMouseUp, at: NSPoint(x: 280, y: 288), modifierFlags: .shift))
+
+        let line = try XCTUnwrap(document.objects.first as? LineObject)
+        let click = CGPoint(x: 100, y: 300)
+        XCTAssertEqual((line.start.x + line.end.x) / 2, click.x, accuracy: 0.001)
+        XCTAssertEqual((line.start.y + line.end.y) / 2, click.y, accuracy: 0.001)
+        XCTAssertEqual(line.end.y, line.start.y, accuracy: 0.001)
+    }
+
+    func testTogglingCMidDragRecentersThePreviewLive() throws {
+        let (view, _) = makeCanvas(tool: .rectangle)
+
+        view.mouseDown(with: mouseEvent(.leftMouseDown, at: NSPoint(x: 100, y: 400)))
+        view.mouseDragged(with: mouseEvent(.leftMouseDragged, at: NSPoint(x: 300, y: 320)))
+        view.flagsChanged(with: flagsChangedEvent(modifierFlags: .shift))
+
+        let cornerStart = try XCTUnwrap(view.previewDragStart)
+        XCTAssertEqual(cornerStart.x, 100, accuracy: 0.001)
+        XCTAssertEqual(cornerStart.y, 200, accuracy: 0.001)
+
+        view.handleCenterLockKeyEvent(keyEvent(keyCode: 8, characters: "c", modifierFlags: .shift))
+        let centeredStart = try XCTUnwrap(view.previewDragStart)
+        let centeredEnd = try XCTUnwrap(view.previewDragEnd)
+        XCTAssertEqual((centeredStart.x + centeredEnd.x) / 2, 100, accuracy: 0.001)
+        XCTAssertEqual((centeredStart.y + centeredEnd.y) / 2, 200, accuracy: 0.001)
+
+        view.handleCenterLockKeyEvent(keyEvent(type: .keyUp, keyCode: 8, characters: "c", modifierFlags: .shift))
+        let restored = try XCTUnwrap(view.previewDragStart)
+        XCTAssertEqual(restored.x, cornerStart.x, accuracy: 0.001)
+        XCTAssertEqual(restored.y, cornerStart.y, accuracy: 0.001)
+    }
+
+    func testShiftPlusCDoesNotConstrainFreehand() throws {
+        let (view, _) = makeCanvas(tool: .freehand)
+
+        view.mouseDown(with: mouseEvent(.leftMouseDown, at: NSPoint(x: 100, y: 400)))
+        view.mouseDragged(with: mouseEvent(.leftMouseDragged, at: NSPoint(x: 300, y: 320)))
+        let free = try XCTUnwrap(view.previewDragEnd)
+
+        view.flagsChanged(with: flagsChangedEvent(modifierFlags: .shift))
+        view.handleCenterLockKeyEvent(keyEvent(keyCode: 8, characters: "c", modifierFlags: .shift))
+        XCTAssertEqual(try XCTUnwrap(view.previewDragEnd), free)
+    }
+
     // MARK: - Helpers
 
     private func makeCanvas(tool: AnnotationTool) -> (AnnotationCanvasNSView, AnnotationDocument) {
@@ -152,6 +233,26 @@ final class AnnotationCanvasInteractionTests: XCTestCase {
             charactersIgnoringModifiers: "",
             isARepeat: false,
             keyCode: 56
+        )!
+    }
+
+    private func keyEvent(
+        type: NSEvent.EventType = .keyDown,
+        keyCode: UInt16,
+        characters: String,
+        modifierFlags: NSEvent.ModifierFlags
+    ) -> NSEvent {
+        NSEvent.keyEvent(
+            with: type,
+            location: .zero,
+            modifierFlags: modifierFlags,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: keyCode
         )!
     }
 }

--- a/App/Tests/CaptureOverlayInteractionTests.swift
+++ b/App/Tests/CaptureOverlayInteractionTests.swift
@@ -251,6 +251,149 @@ final class CaptureOverlayInteractionTests: XCTestCase {
         XCTAssertEqual(view.selectionRect, CGRect(x: 180, y: 140, width: 120, height: 120))
     }
 
+    func testShiftPlusCDuringDragCentersSelectionOnClick() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+
+        let view = makeAreaOverlayView(settings: settings)
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 180, y: 140)))
+        view.mouseDragged(with: try makeMouseEvent(.leftMouseDragged, at: NSPoint(x: 300, y: 200)))
+        view.handleFlagsChanged(try makeFlagsChangedEvent(modifierFlags: .shift))
+        XCTAssertEqual(view.selectionRect, CGRect(x: 180, y: 140, width: 120, height: 120))
+
+        view.handleCenterLockKeyEvent(try makeKeyEvent(keyCode: 8, characters: "c", modifierFlags: .shift))
+        XCTAssertEqual(view.selectionRect, CGRect(x: 60, y: 20, width: 240, height: 240))
+    }
+
+    func testReleasingCRestoresCornerAnchoredSquare() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+
+        let view = makeAreaOverlayView(settings: settings)
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 180, y: 140)))
+        view.mouseDragged(with: try makeMouseEvent(.leftMouseDragged, at: NSPoint(x: 300, y: 200), modifierFlags: .shift))
+        view.handleFlagsChanged(try makeFlagsChangedEvent(modifierFlags: .shift))
+        view.handleCenterLockKeyEvent(try makeKeyEvent(keyCode: 8, characters: "c", modifierFlags: .shift))
+        XCTAssertEqual(view.selectionRect, CGRect(x: 60, y: 20, width: 240, height: 240))
+
+        view.handleCenterLockKeyEvent(try makeKeyEvent(
+            type: .keyUp,
+            keyCode: 8,
+            characters: "c",
+            modifierFlags: .shift
+        ))
+        XCTAssertEqual(view.selectionRect, CGRect(x: 180, y: 140, width: 120, height: 120))
+    }
+
+    func testReleasingShiftRestoresFreeDragWhileCIsHeld() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+
+        let view = makeAreaOverlayView(settings: settings)
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 180, y: 140)))
+        view.mouseDragged(with: try makeMouseEvent(.leftMouseDragged, at: NSPoint(x: 300, y: 200)))
+        view.handleFlagsChanged(try makeFlagsChangedEvent(modifierFlags: .shift))
+        view.handleCenterLockKeyEvent(try makeKeyEvent(keyCode: 8, characters: "c", modifierFlags: .shift))
+        view.handleFlagsChanged(try makeFlagsChangedEvent(modifierFlags: []))
+
+        XCTAssertEqual(view.selectionRect, CGRect(x: 180, y: 140, width: 120, height: 60))
+    }
+
+    func testCWithoutShiftDoesNotCenter() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+
+        let view = makeAreaOverlayView(settings: settings)
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 180, y: 140)))
+        view.mouseDragged(with: try makeMouseEvent(.leftMouseDragged, at: NSPoint(x: 300, y: 200)))
+        view.handleCenterLockKeyEvent(try makeKeyEvent(keyCode: 8, characters: "c", modifierFlags: []))
+
+        XCTAssertEqual(view.selectionRect, CGRect(x: 180, y: 140, width: 120, height: 60))
+    }
+
+    func testCommandShiftCDoesNotCenter() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+
+        let view = makeAreaOverlayView(settings: settings)
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 180, y: 140)))
+        view.mouseDragged(with: try makeMouseEvent(.leftMouseDragged, at: NSPoint(x: 300, y: 200)))
+        view.handleFlagsChanged(try makeFlagsChangedEvent(modifierFlags: .shift))
+        view.handleCenterLockKeyEvent(try makeKeyEvent(
+            keyCode: 8,
+            characters: "c",
+            modifierFlags: [.command, .shift]
+        ))
+
+        XCTAssertEqual(view.selectionRect, CGRect(x: 180, y: 140, width: 120, height: 120))
+    }
+
+    func testCustomCenterLockKeyIsHonored() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+        settings.squareCenterLockShortcut = SquareCenterLockShortcut(keyCode: 7, displayCharacter: "X")
+
+        let view = makeAreaOverlayView(settings: settings)
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 180, y: 140)))
+        view.mouseDragged(with: try makeMouseEvent(.leftMouseDragged, at: NSPoint(x: 300, y: 200)))
+        view.handleFlagsChanged(try makeFlagsChangedEvent(modifierFlags: .shift))
+        view.handleCenterLockKeyEvent(try makeKeyEvent(keyCode: 8, characters: "c", modifierFlags: .shift))
+        XCTAssertEqual(view.selectionRect, CGRect(x: 180, y: 140, width: 120, height: 120))
+
+        view.handleCenterLockKeyEvent(try makeKeyEvent(keyCode: 7, characters: "x", modifierFlags: .shift))
+        XCTAssertEqual(view.selectionRect, CGRect(x: 60, y: 20, width: 240, height: 240))
+    }
+
+    func testCenterLockKeyIsIgnoredInWindowSelectionMode() throws {
+        let (settings, defaultsSuiteName) = makeSettings()
+        defer { UserDefaults.standard.removePersistentDomain(forName: defaultsSuiteName) }
+
+        let view = makeAreaOverlayView(settings: settings)
+        view.setMode(.windowSelection([]))
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 180, y: 140)))
+        view.handleFlagsChanged(try makeFlagsChangedEvent(modifierFlags: .shift))
+        view.handleCenterLockKeyEvent(try makeKeyEvent(keyCode: 8, characters: "c", modifierFlags: .shift))
+
+        XCTAssertEqual(view.selectionRect, .zero)
+    }
+
+    func testAllInOneShiftPlusCCreateCentersOnClick() throws {
+        let (view, previews) = makeAllInOneOverlayView(activePreset: .freeform)
+
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 50, y: 50)))
+        view.mouseDragged(with: try makeMouseEvent(.leftMouseDragged, at: NSPoint(x: 90, y: 70)))
+        view.handleFlagsChanged(try makeFlagsChangedEvent(modifierFlags: .shift))
+        XCTAssertEqual(try XCTUnwrap(previews.last), CGRect(x: 50, y: 50, width: 40, height: 40))
+
+        view.handleCenterLockKeyEvent(try makeKeyEvent(keyCode: 8, characters: "c", modifierFlags: .shift))
+        XCTAssertEqual(try XCTUnwrap(previews.last), CGRect(x: 10, y: 10, width: 80, height: 80))
+    }
+
+    func testAllInOneResizeIgnoresCenterLockKey() throws {
+        let (view, previews) = makeAllInOneOverlayView(activePreset: .freeform)
+
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 500, y: 360)))
+        view.mouseDragged(with: try makeMouseEvent(.leftMouseDragged, at: NSPoint(x: 560, y: 420), modifierFlags: .shift))
+        view.handleFlagsChanged(try makeFlagsChangedEvent(modifierFlags: .shift))
+        let squared = try XCTUnwrap(previews.last)
+
+        view.handleCenterLockKeyEvent(try makeKeyEvent(keyCode: 8, characters: "c", modifierFlags: .shift))
+        XCTAssertEqual(previews.last, squared)
+    }
+
+    func testAllInOneMoveIgnoresCenterLockKey() throws {
+        let (view, previews) = makeAllInOneOverlayView(activePreset: .freeform)
+
+        view.mouseDown(with: try makeMouseEvent(.leftMouseDown, at: NSPoint(x: 350, y: 260)))
+        view.mouseDragged(with: try makeMouseEvent(.leftMouseDragged, at: NSPoint(x: 370, y: 280)))
+        let moved = try XCTUnwrap(previews.last)
+        XCTAssertEqual(moved.size, CGSize(width: 300, height: 200))
+
+        view.handleFlagsChanged(try makeFlagsChangedEvent(modifierFlags: .shift))
+        view.handleCenterLockKeyEvent(try makeKeyEvent(keyCode: 8, characters: "c", modifierFlags: .shift))
+        XCTAssertEqual(previews.last, moved)
+    }
+
     func testAllInOneShiftBeforeFirstDragCreatesSquareAtPressPoint() throws {
         let (view, previews) = makeAllInOneOverlayView(activePreset: .freeform)
 
@@ -454,6 +597,26 @@ final class CaptureOverlayInteractionTests: XCTestCase {
             context: nil,
             characters: "",
             charactersIgnoringModifiers: "",
+            isARepeat: false,
+            keyCode: keyCode
+        ))
+    }
+
+    private func makeKeyEvent(
+        type: NSEvent.EventType = .keyDown,
+        keyCode: UInt16,
+        characters: String,
+        modifierFlags: NSEvent.ModifierFlags
+    ) throws -> NSEvent {
+        try XCTUnwrap(NSEvent.keyEvent(
+            with: type,
+            location: .zero,
+            modifierFlags: modifierFlags,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
             isARepeat: false,
             keyCode: keyCode
         ))

--- a/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationDragConstraint.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationDragConstraint.swift
@@ -27,20 +27,56 @@ public enum AnnotationDragConstraint {
     }
 
     /// The drag endpoint to use for `tool` when Shift is held. Returns `end`
-    /// unchanged for tools Shift does not constrain.
+    /// unchanged for tools Shift does not constrain. Equivalent to
+    /// `constrainedDrag(..., centerLock: false).end`.
     public static func constrainedEnd(
         from start: CGPoint,
         to end: CGPoint,
         tool: AnnotationTool
     ) -> CGPoint {
+        constrainedDrag(from: start, to: end, tool: tool, centerLock: false).end
+    }
+
+    /// The start and end of a creation drag after Shift constraints.
+    ///
+    /// When `centerLock` is `true` and the tool honors Shift, `start` is the
+    /// midpoint and `end` is mirrored through it so the live preview and the
+    /// committed object share one pair of points.
+    public static func constrainedDrag(
+        from start: CGPoint,
+        to end: CGPoint,
+        tool: AnnotationTool,
+        centerLock: Bool = false
+    ) -> (start: CGPoint, end: CGPoint) {
+        let constrained: CGPoint
         switch kind(for: tool) {
         case .square:
-            return squaredEnd(from: start, to: end)
+            constrained = squaredEnd(from: start, to: end)
         case .angle:
-            return angleSnappedEnd(from: start, to: end)
+            constrained = angleSnappedEnd(from: start, to: end)
         case .none:
-            return end
+            return (start: start, end: end)
         }
+
+        guard centerLock else {
+            return (start: start, end: constrained)
+        }
+
+        return mirroredDrag(around: start, to: constrained)
+    }
+
+    /// Reflects `end` through `center` so `center` is the segment midpoint.
+    private static func mirroredDrag(
+        around center: CGPoint,
+        to end: CGPoint
+    ) -> (start: CGPoint, end: CGPoint) {
+        (
+            start: CGPoint(
+                x: center.x - (end.x - center.x),
+                y: center.y - (end.y - center.y)
+            ),
+            end: end
+        )
     }
 
     /// Moves `end` so the box anchored at `start` is square, keeping the drag's

--- a/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationToolShortcut.swift
+++ b/Packages/AnnotationKit/Sources/AnnotationKit/AnnotationToolShortcut.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SharedKit
 
 public enum AnnotationToolShortcut {
     private static let shortcuts: [String: AnnotationTool] = [
@@ -34,6 +35,20 @@ public enum AnnotationToolShortcut {
     public static func tool(for key: String) -> AnnotationTool? {
         guard key.count == 1 else { return nil }
         return shortcuts[key.lowercased()]
+    }
+
+    /// Resolves a key press to a tool, except when Shift plus the center-lock
+    /// extra key is held — that chord recenters a constrained drag instead.
+    public static func tool(
+        for key: String,
+        keyCode: UInt16,
+        shiftHeld: Bool,
+        centerLockShortcut: SquareCenterLockShortcut
+    ) -> AnnotationTool? {
+        if centerLockShortcut.blocksToolShortcut(keyCode: keyCode, shiftHeld: shiftHeld) {
+            return nil
+        }
+        return tool(for: key)
     }
 
     public static func displayKey(for tool: AnnotationTool) -> String? {

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationDragConstraintTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationDragConstraintTests.swift
@@ -132,4 +132,69 @@ struct AnnotationDragConstraintTests {
     func angleSnapWithoutMovement() {
         #expect(AnnotationDragConstraint.angleSnappedEnd(from: start, to: start) == start)
     }
+
+    // MARK: - Center lock
+
+    @Test("Center lock on a box tool mirrors opposite corners through the click")
+    func centerLockSquaresAroundClick() {
+        for tool in [AnnotationTool.rectangle, .ellipse, .pixelate] {
+            let drag = AnnotationDragConstraint.constrainedDrag(
+                from: start,
+                to: CGPoint(x: 260, y: 140),
+                tool: tool,
+                centerLock: true
+            )
+
+            #expect(drag.start == CGPoint(x: -60, y: -60))
+            #expect(drag.end == CGPoint(x: 260, y: 260))
+            #expect((drag.start.x + drag.end.x) / 2 == start.x)
+            #expect((drag.start.y + drag.end.y) / 2 == start.y)
+            #expect(abs(drag.end.x - drag.start.x) == abs(drag.end.y - drag.start.y))
+        }
+    }
+
+    @Test("Center lock on a line keeps the click as the midpoint")
+    func centerLockSnapsAngleAroundClick() {
+        let pointer = CGPoint(x: 300, y: 112)
+        let drag = AnnotationDragConstraint.constrainedDrag(
+            from: start,
+            to: pointer,
+            tool: .line,
+            centerLock: true
+        )
+        let halfLength = hypot(pointer.x - start.x, pointer.y - start.y)
+
+        #expect(abs((drag.start.x + drag.end.x) / 2 - start.x) < 0.0001)
+        #expect(abs((drag.start.y + drag.end.y) / 2 - start.y) < 0.0001)
+        #expect(abs(drag.end.y - drag.start.y) < 0.0001)
+        #expect(abs(hypot(drag.end.x - drag.start.x, drag.end.y - drag.start.y) - halfLength * 2) < 0.0001)
+    }
+
+    @Test("Center lock does not constrain freehand, text, counter or select")
+    func centerLockIsNoOpForUnconstrainedTools() {
+        let end = CGPoint(x: 260, y: 140)
+        for tool in [AnnotationTool.select, .text, .freehand, .highlighter, .counter] {
+            let drag = AnnotationDragConstraint.constrainedDrag(
+                from: start,
+                to: end,
+                tool: tool,
+                centerLock: true
+            )
+            #expect(drag.start == start)
+            #expect(drag.end == end)
+        }
+    }
+
+    @Test("Center lock off matches the existing corner-anchored square")
+    func centerLockOffKeepsCornerAnchor() {
+        let drag = AnnotationDragConstraint.constrainedDrag(
+            from: start,
+            to: CGPoint(x: 340, y: 190),
+            tool: .rectangle,
+            centerLock: false
+        )
+
+        #expect(drag.start == start)
+        #expect(drag.end == CGPoint(x: 340, y: 340))
+    }
 }

--- a/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationToolShortcutTests.swift
+++ b/Packages/AnnotationKit/Tests/AnnotationKitTests/AnnotationToolShortcutTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import SharedKit
 @testable import AnnotationKit
 
 @Suite("AnnotationToolShortcut")
@@ -51,5 +52,29 @@ struct AnnotationToolShortcutTests {
         #expect(AnnotationToolShortcut.tool(for: "A") == .arrow)
         #expect(AnnotationToolShortcut.tool(for: " ") == nil)
         #expect(AnnotationToolShortcut.tool(for: "save") == nil)
+    }
+
+    @Test("Shift plus the center-lock key does not select a tool")
+    func shiftPlusCenterLockKeyDoesNotSelectTool() {
+        #expect(
+            AnnotationToolShortcut.tool(
+                for: "c",
+                keyCode: 8,
+                shiftHeld: true,
+                centerLockShortcut: .default
+            ) == nil
+        )
+    }
+
+    @Test("C without Shift still selects the counter")
+    func cWithoutShiftSelectsCounter() {
+        #expect(
+            AnnotationToolShortcut.tool(
+                for: "c",
+                keyCode: 8,
+                shiftHeld: false,
+                centerLockShortcut: .default
+            ) == .counter
+        )
     }
 }

--- a/Packages/CaptureKit/Sources/CaptureKit/CaptureSelectionGeometry.swift
+++ b/Packages/CaptureKit/Sources/CaptureKit/CaptureSelectionGeometry.swift
@@ -63,12 +63,18 @@ public enum CaptureSelectionGeometry {
         return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
     }
 
+    /// Creates an aspect-ratio-locked selection from `startPoint` to `currentPoint`.
+    ///
+    /// When `centered` is `false` (the default), `startPoint` stays a corner.
+    /// When `centered` is `true`, `startPoint` is the midpoint and the pointer
+    /// distance is the half-extent.
     public static func rect(
         from startPoint: CGPoint,
         to currentPoint: CGPoint,
         in bounds: CGRect,
         minSize: CGSize,
-        aspectRatio: CGFloat
+        aspectRatio: CGFloat,
+        centered: Bool = false
     ) -> CGRect {
         guard aspectRatio > 0 else {
             return rect(
@@ -81,6 +87,20 @@ public enum CaptureSelectionGeometry {
 
         let start = clamp(startPoint, to: bounds)
         let current = clamp(currentPoint, to: bounds)
+        let targetWidth = abs(current.x - start.x)
+        let targetHeight = abs(current.y - start.y)
+
+        if centered {
+            return centeredAspectRatioRect(
+                centeredAt: start,
+                targetWidth: targetWidth,
+                targetHeight: targetHeight,
+                aspectRatio: aspectRatio,
+                in: bounds,
+                minSize: minSize
+            )
+        }
+
         let horizontalDirection = direction(
             from: start.x,
             to: current.x,
@@ -98,8 +118,8 @@ public enum CaptureSelectionGeometry {
             anchoredAt: start,
             horizontalDirection: horizontalDirection,
             verticalDirection: verticalDirection,
-            targetWidth: abs(current.x - start.x),
-            targetHeight: abs(current.y - start.y),
+            targetWidth: targetWidth,
+            targetHeight: targetHeight,
             aspectRatio: aspectRatio,
             in: bounds,
             minSize: minSize
@@ -455,6 +475,42 @@ public enum CaptureSelectionGeometry {
             return 1
         }
         return -1
+    }
+
+    /// Grows an aspect-ratio box from `center` so the pointer distance is the
+    /// half-extent. Clamps the half-extent so the box stays inside `bounds`
+    /// without sliding the center. A zero-length drag stays empty at `center`
+    /// rather than jumping to `minSize`.
+    private static func centeredAspectRatioRect(
+        centeredAt center: CGPoint,
+        targetWidth: CGFloat,
+        targetHeight: CGFloat,
+        aspectRatio: CGFloat,
+        in bounds: CGRect,
+        minSize: CGSize
+    ) -> CGRect {
+        let desiredHalfHeight = max(targetHeight, targetWidth / aspectRatio)
+        guard desiredHalfHeight > 0 else {
+            return CGRect(x: center.x, y: center.y, width: 0, height: 0)
+        }
+
+        let maximumHalfWidth = min(center.x - bounds.minX, bounds.maxX - center.x)
+        let maximumHalfHeight = min(center.y - bounds.minY, bounds.maxY - center.y)
+        let maximumRatioHalfHeight = min(maximumHalfHeight, maximumHalfWidth / aspectRatio)
+        let minimum = aspectRatioMinimumSize(aspectRatio: aspectRatio, minSize: minSize)
+        let halfHeight = constrainedDimension(
+            desiredHalfHeight,
+            minimum: minimum.height / 2,
+            maximum: maximumRatioHalfHeight
+        )
+        let halfWidth = halfHeight * aspectRatio
+
+        return CGRect(
+            x: center.x - halfWidth,
+            y: center.y - halfHeight,
+            width: halfWidth * 2,
+            height: halfHeight * 2
+        )
     }
 
     private static func aspectRatioRect(

--- a/Packages/CaptureKit/Tests/CaptureKitTests/CaptureSelectionGeometryTests.swift
+++ b/Packages/CaptureKit/Tests/CaptureKitTests/CaptureSelectionGeometryTests.swift
@@ -235,6 +235,67 @@ struct CaptureSelectionGeometryTests {
         #expect(created == CGRect(x: 100, y: 100, width: 130, height: 130))
     }
 
+    @Test("Centered create keeps the click as the square's midpoint")
+    func centeredCreateKeepsClickAsMidpoint() {
+        let created = CaptureSelectionGeometry.rect(
+            from: CGPoint(x: 180, y: 140),
+            to: CGPoint(x: 300, y: 200),
+            in: bounds,
+            minSize: minSize,
+            aspectRatio: 1,
+            centered: true
+        )
+
+        #expect(created == CGRect(x: 60, y: 20, width: 240, height: 240))
+        #expect(created.midX == 180)
+        #expect(created.midY == 140)
+    }
+
+    @Test("Centered create near an edge shrinks without sliding the center")
+    func centeredCreateNearEdgeShrinksWithoutSliding() {
+        let created = CaptureSelectionGeometry.rect(
+            from: CGPoint(x: 10, y: 10),
+            to: CGPoint(x: 50, y: 50),
+            in: bounds,
+            minSize: minSize,
+            aspectRatio: 1,
+            centered: true
+        )
+
+        #expect(created == CGRect(x: 0, y: 0, width: 20, height: 20))
+        #expect(created.midX == 10)
+        #expect(created.midY == 10)
+        #expect(bounds.contains(created))
+    }
+
+    @Test("Centered create with no movement stays empty at the click")
+    func centeredCreateWithoutMovementStaysAtClick() {
+        let created = CaptureSelectionGeometry.rect(
+            from: CGPoint(x: 100, y: 100),
+            to: CGPoint(x: 100, y: 100),
+            in: bounds,
+            minSize: minSize,
+            aspectRatio: 1,
+            centered: true
+        )
+
+        #expect(created == CGRect(x: 100, y: 100, width: 0, height: 0))
+    }
+
+    @Test("Centered false still anchors the aspect-ratio create at the drag start")
+    func centeredFalseKeepsDragStartAnchored() {
+        let created = CaptureSelectionGeometry.rect(
+            from: CGPoint(x: 100, y: 100),
+            to: CGPoint(x: 230, y: 170),
+            in: bounds,
+            minSize: minSize,
+            aspectRatio: 1,
+            centered: false
+        )
+
+        #expect(created == CGRect(x: 100, y: 100, width: 130, height: 130))
+    }
+
     @Test("Fixed size presets stay inside bounds")
     func fixedSizePresetStaysInsideBounds() {
         let fixed = CaptureSelectionGeometry.fixedSize(

--- a/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/AppSettings.swift
@@ -862,6 +862,21 @@ public final class AppSettings: @unchecked Sendable {
         return builtins + customCapturePresets
     }
 
+    /// Extra key that, with Shift, grows a 1:1 selection from the click center.
+    /// Shift itself is not stored and cannot be changed.
+    public var squareCenterLockShortcut: SquareCenterLockShortcut {
+        get {
+            SquareCenterLockShortcut(
+                storedKeyCode: defaults.object(forKey: "squareCenterLockKeyCode") as? Int,
+                storedDisplayCharacter: defaults.string(forKey: "squareCenterLockDisplayCharacter")
+            )
+        }
+        set {
+            defaults.set(Int(newValue.keyCode), forKey: "squareCenterLockKeyCode")
+            defaults.set(newValue.displayCharacter, forKey: "squareCenterLockDisplayCharacter")
+        }
+    }
+
     // MARK: History
     public var historyEnabled: Bool {
         get { defaults.object(forKey: "historyEnabled") as? Bool ?? true }

--- a/Packages/SharedKit/Sources/SharedKit/Settings/SquareCenterLockShortcut.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Settings/SquareCenterLockShortcut.swift
@@ -1,0 +1,180 @@
+import AppKit
+import Carbon.HIToolbox
+import CoreGraphics
+import CoreServices
+import Foundation
+
+/// The extra key that, while Shift is held, grows a 1:1 selection from the
+/// original click as the center. Shift itself is not configurable.
+public struct SquareCenterLockShortcut: Equatable, Sendable {
+    public let keyCode: UInt16
+    public let displayCharacter: String
+
+    public static let `default` = SquareCenterLockShortcut(
+        keyCode: UInt16(kVK_ANSI_C),
+        displayCharacter: "C"
+    )
+
+    public init(keyCode: UInt16, displayCharacter: String) {
+        self.keyCode = keyCode
+        self.displayCharacter = displayCharacter
+    }
+
+    /// Restores a shortcut from `UserDefaults`, falling back to ``default``
+    /// when the stored key is missing, empty, or reserved.
+    public init(storedKeyCode: Int?, storedDisplayCharacter: String?) {
+        guard let storedKeyCode,
+              let storedDisplayCharacter,
+              !storedDisplayCharacter.isEmpty else {
+            self = .default
+            return
+        }
+
+        let keyCode = UInt16(storedKeyCode)
+        guard !Self.reservedKeyCodes.contains(keyCode) else {
+            self = .default
+            return
+        }
+
+        self.keyCode = keyCode
+        self.displayCharacter = storedDisplayCharacter
+    }
+
+    /// Records the extra key from a key-down event. Returns `nil` for reserved
+    /// keys, repeats, and chords that include Command, Option, or Control.
+    /// Shift may be held so the recorder can capture the key during ⇧+key.
+    public init?(event: NSEvent) {
+        guard !event.isARepeat else { return nil }
+        guard event.modifierFlags.intersection([.command, .option, .control]).isEmpty else {
+            return nil
+        }
+        guard !Self.reservedKeyCodes.contains(event.keyCode) else { return nil }
+        guard let display = Self.displayName(for: event) else { return nil }
+
+        self.keyCode = event.keyCode
+        self.displayCharacter = display
+    }
+
+    /// `true` when `event` is this extra key held with Shift and no other
+    /// modifiers — the chord that activates center lock.
+    public func matches(_ event: NSEvent) -> Bool {
+        guard !event.isARepeat else { return false }
+        guard event.keyCode == keyCode else { return false }
+        return event.modifierFlags.intersection([.command, .shift, .option, .control]) == .shift
+    }
+
+    /// `true` when this extra key is currently down, independent of modifiers.
+    /// Used to seed center lock on mouse-down if key-down was missed.
+    public var isHardwareKeyPressed: Bool {
+        CGEventSource.keyState(.hidSystemState, key: keyCode)
+    }
+
+    /// Shift plus this extra key is reserved for center lock, so it must not
+    /// also switch annotation tools.
+    public func blocksToolShortcut(keyCode: UInt16, shiftHeld: Bool) -> Bool {
+        shiftHeld && keyCode == self.keyCode
+    }
+
+    private static let reservedKeyCodes: Set<UInt16> = [
+        UInt16(kVK_Escape),
+        UInt16(kVK_Space),
+        UInt16(kVK_Return),
+        UInt16(kVK_ANSI_KeypadEnter),
+        UInt16(kVK_Tab),
+        UInt16(kVK_Delete),
+        UInt16(kVK_ForwardDelete),
+        UInt16(kVK_LeftArrow),
+        UInt16(kVK_RightArrow),
+        UInt16(kVK_DownArrow),
+        UInt16(kVK_UpArrow),
+        UInt16(kVK_Shift),
+        UInt16(kVK_RightShift),
+        UInt16(kVK_Control),
+        UInt16(kVK_RightControl),
+        UInt16(kVK_Option),
+        UInt16(kVK_RightOption),
+        UInt16(kVK_Command),
+        UInt16(kVK_RightCommand),
+        UInt16(kVK_Function),
+        UInt16(kVK_CapsLock),
+    ]
+
+    /// Labels for keys that do not produce a printable character.
+    private static let specialDisplayNames: [UInt16: String] = [
+        UInt16(kVK_F1): "F1", UInt16(kVK_F2): "F2", UInt16(kVK_F3): "F3",
+        UInt16(kVK_F4): "F4", UInt16(kVK_F5): "F5", UInt16(kVK_F6): "F6",
+        UInt16(kVK_F7): "F7", UInt16(kVK_F8): "F8", UInt16(kVK_F9): "F9",
+        UInt16(kVK_F10): "F10", UInt16(kVK_F11): "F11", UInt16(kVK_F12): "F12",
+        UInt16(kVK_F13): "F13", UInt16(kVK_F14): "F14", UInt16(kVK_F15): "F15",
+        UInt16(kVK_F16): "F16", UInt16(kVK_F17): "F17", UInt16(kVK_F18): "F18",
+        UInt16(kVK_F19): "F19", UInt16(kVK_F20): "F20",
+        UInt16(kVK_Home): "↖", UInt16(kVK_End): "↘",
+        UInt16(kVK_PageUp): "⇞", UInt16(kVK_PageDown): "⇟",
+    ]
+
+    private static func displayName(for event: NSEvent) -> String? {
+        if let special = specialDisplayNames[event.keyCode] {
+            return special
+        }
+
+        let raw = unshiftedCharacter(for: event.keyCode)
+            ?? event.charactersIgnoringModifiers
+            ?? ""
+        guard raw.count == 1, let character = raw.first else { return nil }
+        guard character.isLetter
+                || character.isNumber
+                || character.isPunctuation
+                || character.isSymbol else {
+            return nil
+        }
+        if character.isLetter {
+            return String(character).uppercased()
+        }
+        return String(character)
+    }
+
+    private static let layoutLock = NSLock()
+
+    /// Layout-aware glyph for `keyCode` with no modifiers, so Shift+; records as
+    /// ";" rather than ":".
+    private static func unshiftedCharacter(for keyCode: UInt16) -> String? {
+        layoutLock.lock()
+        defer { layoutLock.unlock() }
+
+        guard let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue() else {
+            return nil
+        }
+        guard let cfDataPtr = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
+            return nil
+        }
+        let data = Unmanaged<CFData>.fromOpaque(cfDataPtr).takeUnretainedValue() as Data
+        return data.withUnsafeBytes { raw -> String? in
+            guard let base = raw.bindMemory(to: UCKeyboardLayout.self).baseAddress else {
+                return nil
+            }
+            var deadKeyState: UInt32 = 0
+            var chars = [UniChar](repeating: 0, count: 4)
+            var actualLength = 0
+            let status = chars.withUnsafeMutableBufferPointer { buffer -> OSStatus in
+                var length = 0
+                let result = UCKeyTranslate(
+                    base,
+                    keyCode,
+                    UInt16(kUCKeyActionDisplay),
+                    0,
+                    UInt32(LMGetKbdType()),
+                    OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                    &deadKeyState,
+                    buffer.count,
+                    &length,
+                    buffer.baseAddress
+                )
+                actualLength = length
+                return result
+            }
+            guard status == noErr, actualLength > 0 else { return nil }
+            let translated = String(utf16CodeUnits: chars, count: actualLength)
+            return translated.isEmpty ? nil : translated
+        }
+    }
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/AppSettingsTests.swift
@@ -825,4 +825,40 @@ struct AppSettingsTests {
         settings.openedImageSaveBehavior = .copy
         #expect(settings.openedImageSaveBehavior == .copy)
     }
+
+    @Test("Square center-lock shortcut defaults to Shift+C")
+    func squareCenterLockShortcutDefaultsToC() {
+        let settings = makeSettings("test.squareCenterLock.default")
+        #expect(settings.squareCenterLockShortcut == .default)
+        #expect(settings.squareCenterLockShortcut.displayCharacter == "C")
+    }
+
+    @Test("Square center-lock shortcut persists across AppSettings instances")
+    func squareCenterLockShortcutPersists() {
+        let suite = "test.squareCenterLock.persist"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let first = AppSettings(defaults: defaults)
+        first.squareCenterLockShortcut = SquareCenterLockShortcut(
+            keyCode: 7,
+            displayCharacter: "X"
+        )
+
+        let second = AppSettings(defaults: defaults)
+        #expect(second.squareCenterLockShortcut.keyCode == 7)
+        #expect(second.squareCenterLockShortcut.displayCharacter == "X")
+    }
+
+    @Test("An invalid stored square center-lock shortcut falls back to C")
+    func squareCenterLockShortcutFallsBackWhenInvalid() {
+        let suite = "test.squareCenterLock.invalid"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set(53, forKey: "squareCenterLockKeyCode")
+        defaults.set("C", forKey: "squareCenterLockDisplayCharacter")
+
+        let settings = AppSettings(defaults: defaults)
+        #expect(settings.squareCenterLockShortcut == .default)
+    }
 }

--- a/Packages/SharedKit/Tests/SharedKitTests/SquareCenterLockShortcutTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/SquareCenterLockShortcutTests.swift
@@ -1,0 +1,229 @@
+import AppKit
+import Carbon.HIToolbox
+import Testing
+@testable import SharedKit
+
+@Suite("SquareCenterLockShortcut")
+struct SquareCenterLockShortcutTests {
+    @Test("Default extra key is C")
+    func defaultIsC() {
+        #expect(SquareCenterLockShortcut.default.keyCode == UInt16(kVK_ANSI_C))
+        #expect(SquareCenterLockShortcut.default.displayCharacter == "C")
+    }
+
+    @Test("Shift plus the extra key matches")
+    func matchesShiftPlusExtraKey() throws {
+        let event = try makeKeyEvent(
+            keyCode: UInt16(kVK_ANSI_C),
+            characters: "c",
+            modifierFlags: .shift
+        )
+
+        #expect(SquareCenterLockShortcut.default.matches(event))
+    }
+
+    @Test("A key repeat does not match")
+    func ignoresKeyRepeat() throws {
+        let event = try makeKeyEvent(
+            keyCode: UInt16(kVK_ANSI_C),
+            characters: "c",
+            modifierFlags: .shift,
+            isARepeat: true
+        )
+
+        #expect(!SquareCenterLockShortcut.default.matches(event))
+    }
+
+    @Test("Command-Shift-C does not match")
+    func ignoresCommandShift() throws {
+        let event = try makeKeyEvent(
+            keyCode: UInt16(kVK_ANSI_C),
+            characters: "c",
+            modifierFlags: [.command, .shift]
+        )
+
+        #expect(!SquareCenterLockShortcut.default.matches(event))
+    }
+
+    @Test("C without Shift does not match")
+    func ignoresKeyWithoutShift() throws {
+        let event = try makeKeyEvent(
+            keyCode: UInt16(kVK_ANSI_C),
+            characters: "c",
+            modifierFlags: []
+        )
+
+        #expect(!SquareCenterLockShortcut.default.matches(event))
+    }
+
+    @Test("A different letter does not match the default shortcut")
+    func ignoresOtherLetters() throws {
+        let event = try makeKeyEvent(
+            keyCode: UInt16(kVK_ANSI_X),
+            characters: "x",
+            modifierFlags: .shift
+        )
+
+        #expect(!SquareCenterLockShortcut.default.matches(event))
+    }
+
+    @Test("Recording a letter produces an uppercase display character")
+    func recordsLetterKey() throws {
+        let event = try makeKeyEvent(
+            keyCode: UInt16(kVK_ANSI_X),
+            characters: "x",
+            modifierFlags: .shift
+        )
+        let shortcut = try #require(SquareCenterLockShortcut(event: event))
+
+        #expect(shortcut.keyCode == UInt16(kVK_ANSI_X))
+        #expect(shortcut.displayCharacter == "X")
+    }
+
+    @Test("Recording punctuation uses the unshifted glyph")
+    func recordsPunctuationKey() throws {
+        let event = try makeKeyEvent(
+            keyCode: UInt16(kVK_ANSI_Semicolon),
+            characters: ";",
+            modifierFlags: []
+        )
+        let shortcut = try #require(SquareCenterLockShortcut(event: event))
+
+        #expect(shortcut.keyCode == UInt16(kVK_ANSI_Semicolon))
+        #expect(shortcut.displayCharacter == ";")
+    }
+
+    @Test("Recording a symbol key uses the unshifted glyph")
+    func recordsMinusKey() throws {
+        let event = try makeKeyEvent(
+            keyCode: UInt16(kVK_ANSI_Minus),
+            characters: "-",
+            modifierFlags: []
+        )
+        let shortcut = try #require(SquareCenterLockShortcut(event: event))
+
+        #expect(shortcut.keyCode == UInt16(kVK_ANSI_Minus))
+        #expect(shortcut.displayCharacter == "-")
+    }
+
+    @Test("Recording while Shift is held still stores the unshifted punctuation glyph")
+    func recordsShiftedPunctuationAsUnshiftedGlyph() throws {
+        let event = try makeKeyEvent(
+            keyCode: UInt16(kVK_ANSI_Semicolon),
+            characters: ":",
+            modifierFlags: .shift
+        )
+        let shortcut = try #require(SquareCenterLockShortcut(event: event))
+
+        #expect(shortcut.keyCode == UInt16(kVK_ANSI_Semicolon))
+        #expect(shortcut.displayCharacter == ";")
+    }
+
+    @Test("Recording a function key uses its F-number label")
+    func recordsFunctionKey() throws {
+        let event = try makeKeyEvent(
+            keyCode: UInt16(kVK_F5),
+            characters: "",
+            modifierFlags: []
+        )
+        let shortcut = try #require(SquareCenterLockShortcut(event: event))
+
+        #expect(shortcut.keyCode == UInt16(kVK_F5))
+        #expect(shortcut.displayCharacter == "F5")
+    }
+
+    @Test("Shift plus a recorded punctuation key matches")
+    func matchesShiftPlusPunctuation() throws {
+        let shortcut = SquareCenterLockShortcut(
+            keyCode: UInt16(kVK_ANSI_Semicolon),
+            displayCharacter: ";"
+        )
+        let event = try makeKeyEvent(
+            keyCode: UInt16(kVK_ANSI_Semicolon),
+            characters: ":",
+            modifierFlags: .shift
+        )
+
+        #expect(shortcut.matches(event))
+    }
+
+    @Test("Reserved keys cannot be recorded", arguments: [
+        (UInt16(kVK_Escape), "\u{1B}"),
+        (UInt16(kVK_Space), " "),
+        (UInt16(kVK_Return), "\r"),
+        (UInt16(kVK_Tab), "\t"),
+        (UInt16(kVK_Delete), "\u{8}"),
+        (UInt16(kVK_LeftArrow), ""),
+        (UInt16(kVK_Shift), ""),
+        (UInt16(kVK_Command), ""),
+        (UInt16(kVK_Option), ""),
+        (UInt16(kVK_Control), ""),
+    ])
+    func rejectsReservedKeys(keyCode: UInt16, characters: String) throws {
+        let event = try makeKeyEvent(
+            keyCode: keyCode,
+            characters: characters,
+            modifierFlags: []
+        )
+
+        #expect(SquareCenterLockShortcut(event: event) == nil)
+    }
+
+    @Test("Command-modified keys cannot be recorded")
+    func rejectsCommandModifiedKeys() throws {
+        let event = try makeKeyEvent(
+            keyCode: UInt16(kVK_ANSI_C),
+            characters: "c",
+            modifierFlags: .command
+        )
+
+        #expect(SquareCenterLockShortcut(event: event) == nil)
+    }
+
+    @Test("An unrecognized stored shortcut falls back to C")
+    func invalidStoredValuesFallBackToDefault() {
+        #expect(
+            SquareCenterLockShortcut(storedKeyCode: Int(kVK_Escape), storedDisplayCharacter: "C")
+                == .default
+        )
+        #expect(
+            SquareCenterLockShortcut(storedKeyCode: Int(kVK_ANSI_X), storedDisplayCharacter: "")
+                == .default
+        )
+        #expect(
+            SquareCenterLockShortcut(storedKeyCode: nil, storedDisplayCharacter: nil)
+                == .default
+        )
+    }
+
+    @Test("A valid stored shortcut is restored")
+    func validStoredShortcutRestores() {
+        let restored = SquareCenterLockShortcut(
+            storedKeyCode: Int(kVK_ANSI_X),
+            storedDisplayCharacter: "X"
+        )
+
+        #expect(restored.keyCode == UInt16(kVK_ANSI_X))
+        #expect(restored.displayCharacter == "X")
+    }
+
+    private func makeKeyEvent(
+        keyCode: UInt16,
+        characters: String,
+        modifierFlags: NSEvent.ModifierFlags,
+        isARepeat: Bool = false
+    ) throws -> NSEvent {
+        try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifierFlags,
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: isARepeat,
+            keyCode: keyCode
+        ))
+    }
+}


### PR DESCRIPTION
## What changed

Shift still squares from the corner. Hold an extra key (C by default) with it and the original click becomes the center.

Works while creating an area capture, an All-in-One selection, or an annotation rectangle / ellipse / pixelate / line / arrow. Resize and move are left alone. Bare C in annotate still picks Counter.

Preferences > Shortcuts > Contextual has a locked ⇧ plus a recorder for the extra key. Shift isn't editable. You can bind a letter, number, punctuation key, or function key; Esc, Space, Return, arrows, and modifiers stay reserved.

## How it works

`CaptureSelectionGeometry.rect` got a `centered:` flag so the corner-anchored path stays the default. Annotation's `constrainedDrag` now returns both endpoints so the preview and the commit can't disagree about where the click was.

The extra key is a `SquareCenterLockShortcut` (keyCode + display glyph). Matching is by keyCode, so Shift+; is still the semicolon key, not `:`.

## Screenshots / recordings

<p align="center">
<img width="834" height="834" alt="Capso Recording 2026-08-13 at 10 17 02" src="https://github.com/user-attachments/assets/5d82fed0-da0d-40ec-8c55-c66a15e8199d" />
</p>

<p align="center">
<img width="696" height="524" alt="Capso Recording 2026-08-13 at 10 18 32" src="https://github.com/user-attachments/assets/f82a81b9-5473-47e6-90c0-edf2d18cf087" />
</p>

## Testing

Test-first. Geometry and drag constraints in CaptureKit / AnnotationKit, shortcut matching and persistence in SharedKit, then overlay/canvas interaction tests so C without Shift still selects Counter.

`swift test` passes for SharedKit, AnnotationKit, and CaptureKit. Debug build passes.

New strings localized for ja, ko, and zh-Hans.

## Checklist

- [x] `xcodegen generate` run if `project.yml` or source layout changed
- [x] `xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build` passes
- [x] Tests for any touched package pass (`swift test --package-path Packages/<Kit>`)
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency (`@MainActor`, `Sendable` where needed)
- [x] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)