### PR TITLE
feat: add Pin from Clipboard

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -8658,6 +8658,94 @@
           }
         }
       }
+    },
+    "Pin from Clipboard" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリップボードからピン留め"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클립보드에서 고정"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从剪贴板悬浮"
+          }
+        }
+      }
+    },
+    "Float copied images, text, colors, or files above other windows" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "コピーした画像、テキスト、色、ファイルをほかのウインドウの手前に表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "복사한 이미지, 텍스트, 색상 또는 파일을 다른 윈도우 위에 띄우기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将复制的图像、文本、颜色或文件悬浮在其他窗口上方"
+          }
+        }
+      }
+    },
+    "Clipboard content is too large to pin" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリップボードの内容が大きすぎてピン留めできません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클립보드 내용이 너무 커서 고정할 수 없습니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剪贴板内容太大，无法悬浮"
+          }
+        }
+      }
+    },
+    "No supported content found on clipboard" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クリップボードに対応する内容がありません"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "클립보드에서 지원되는 콘텐츠를 찾을 수 없습니다"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剪贴板中没有支持的内容"
+          }
+        }
+      }
     }
   },
   "version" : "1.1"

--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -161,6 +161,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         KeyboardShortcuts.onKeyDown(for: .captureAreaAndAnnotate) { [weak self] in
             self?.captureCoordinator?.captureAreaAndAnnotate()
         }
+        KeyboardShortcuts.onKeyDown(for: .pinFromClipboard) { [weak self] in
+            self?.captureCoordinator?.pinFromClipboard()
+        }
         KeyboardShortcuts.onKeyDown(for: .editClipboardImage) { [weak self] in
             self?.captureCoordinator?.editClipboardImage()
         }

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -173,6 +173,37 @@ final class CaptureCoordinator {
         startAreaCapture()
     }
 
+    func pinFromClipboard(pasteboard: NSPasteboard = .general) {
+        let screen = NSScreen.screens.first {
+            NSMouseInRect(NSEvent.mouseLocation, $0.frame, false)
+        } ?? NSScreen.main
+
+        switch ClipboardPinContentReader.render(
+            from: pasteboard,
+            visibleFrame: screen?.visibleFrame
+        ) {
+        case let .image(image):
+            pinRenderedImage(
+                image,
+                anchor: screen?.frame,
+                sourceAppName: String(localized: "Clipboard"),
+                activatesApp: false
+            )
+        case .tooLarge:
+            showToast(
+                String(localized: "Clipboard content is too large to pin"),
+                icon: "exclamationmark.triangle",
+                iconColor: .systemYellow
+            )
+        case .unsupported:
+            showToast(
+                String(localized: "No supported content found on clipboard"),
+                icon: "doc.on.clipboard",
+                iconColor: .systemYellow
+            )
+        }
+    }
+
     func editClipboardImage() {
         guard let image = ClipboardImageReader.image() else {
             showToast(
@@ -1887,11 +1918,13 @@ final class CaptureCoordinator {
         anchor: CGRect?,
         sourceAppName: String? = nil,
         sourceWindowTitle: String? = nil,
-        date: Date = Date()
+        date: Date = Date(),
+        activatesApp: Bool = true
     ) {
         let controller = PinnedScreenshotController(
             image: image,
             anchorRect: anchor,
+            activatesApp: activatesApp,
             onCopy: { [weak self] in
                 self?.copyRenderedScreenshotToClipboard(image)
             },

--- a/App/Sources/Capture/PinnedScreenshotChromeWindow.swift
+++ b/App/Sources/Capture/PinnedScreenshotChromeWindow.swift
@@ -8,12 +8,12 @@ final class PinnedScreenshotChromeWindow: NSPanel {
     override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
 
-    init(frame: CGRect) {
+    init(frame: CGRect, activatesApp: Bool = true) {
         chromeView = PinnedScreenshotChromeView(frame: NSRect(origin: .zero, size: frame.size))
 
         super.init(
             contentRect: frame,
-            styleMask: [.borderless],
+            styleMask: activatesApp ? [.borderless] : [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )

--- a/App/Sources/Capture/PinnedScreenshotController.swift
+++ b/App/Sources/Capture/PinnedScreenshotController.swift
@@ -9,6 +9,7 @@ final class PinnedScreenshotController {
     private let onCopy: () -> Void
     private let onSave: () -> Void
     private let onDidClose: (UUID) -> Void
+    private let activatesApp: Bool
 
     private let contentWindow: PinnedScreenshotWindow
     private let chromeWindow: PinnedScreenshotChromeWindow
@@ -20,6 +21,7 @@ final class PinnedScreenshotController {
     init(
         image: CGImage,
         anchorRect: CGRect?,
+        activatesApp: Bool = true,
         onCopy: @escaping () -> Void,
         onSave: @escaping () -> Void,
         onDidClose: @escaping (UUID) -> Void
@@ -28,15 +30,20 @@ final class PinnedScreenshotController {
         self.onCopy = onCopy
         self.onSave = onSave
         self.onDidClose = onDidClose
+        self.activatesApp = activatesApp
 
         contentWindow = PinnedScreenshotWindow(
             image: image,
             anchorRect: anchorRect,
+            activatesApp: activatesApp,
             onCopy: onCopy,
             onSave: onSave,
             onDidClose: { _ in }
         )
-        chromeWindow = PinnedScreenshotChromeWindow(frame: contentWindow.frame)
+        chromeWindow = PinnedScreenshotChromeWindow(
+            frame: contentWindow.frame,
+            activatesApp: activatesApp
+        )
 
         contentWindow.onDidClose = { [weak self] _ in
             self?.closeAll(fromContentWindow: true)
@@ -58,7 +65,11 @@ final class PinnedScreenshotController {
     func show() {
         contentWindow.show()
         contentWindow.addChildWindow(chromeWindow, ordered: .above)
-        chromeWindow.orderFront(nil)
+        if activatesApp {
+            chromeWindow.orderFront(nil)
+        } else {
+            chromeWindow.orderFrontRegardless()
+        }
     }
 
     func updateZoomHUD(scalePercent: Int) {

--- a/App/Sources/Capture/PinnedScreenshotWindow.swift
+++ b/App/Sources/Capture/PinnedScreenshotWindow.swift
@@ -8,6 +8,7 @@ final class PinnedScreenshotWindow: NSPanel {
     private let image: CGImage
     private let onCopy: () -> Void
     private let onSave: () -> Void
+    let activatesAppWhenShown: Bool
     var onDidClose: (UUID) -> Void
     private var screenshotView: PinnedScreenshotContentView!
 
@@ -26,6 +27,7 @@ final class PinnedScreenshotWindow: NSPanel {
     init(
         image: CGImage,
         anchorRect: CGRect?,
+        activatesApp: Bool = true,
         onCopy: @escaping () -> Void,
         onSave: @escaping () -> Void,
         onDidClose: @escaping (UUID) -> Void
@@ -33,6 +35,7 @@ final class PinnedScreenshotWindow: NSPanel {
         self.image = image
         self.onCopy = onCopy
         self.onSave = onSave
+        activatesAppWhenShown = activatesApp
         self.onDidClose = onDidClose
 
         let imageWidth = CGFloat(image.width)
@@ -52,7 +55,7 @@ final class PinnedScreenshotWindow: NSPanel {
 
         super.init(
             contentRect: NSRect(x: x, y: y, width: width, height: height),
-            styleMask: [.borderless],
+            styleMask: activatesApp ? [.borderless] : [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
@@ -79,8 +82,12 @@ final class PinnedScreenshotWindow: NSPanel {
     }
 
     func show() {
-        makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        if activatesAppWhenShown {
+            makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+        } else {
+            orderFrontRegardless()
+        }
     }
 
     override func cancelOperation(_ sender: Any?) {

--- a/App/Sources/MenuBar/MenuBarController.swift
+++ b/App/Sources/MenuBar/MenuBarController.swift
@@ -89,6 +89,11 @@ final class MenuBarController: NSObject {
         captureWindow.setShortcut(for: .captureWindow)
         menu.addItem(captureWindow)
 
+        let pinFromClipboard = menuItem(String(localized: "Pin from Clipboard"), action: #selector(pinFromClipboard))
+        pinFromClipboard.setShortcut(for: .pinFromClipboard)
+        pinFromClipboard.toolTip = String(localized: "Float copied images, text, colors, or files above other windows")
+        menu.addItem(pinFromClipboard)
+
         let editClipboardImage = menuItem(String(localized: "Edit Clipboard Image"), action: #selector(editClipboardImage))
         editClipboardImage.setShortcut(for: .editClipboardImage)
         editClipboardImage.toolTip = String(localized: "Open the image currently copied to the clipboard in Annotate")
@@ -250,6 +255,10 @@ final class MenuBarController: NSObject {
         captureCoordinator.captureWindow()
     }
 
+    @objc private func pinFromClipboard() {
+        captureCoordinator.pinFromClipboard()
+    }
+
     @objc private func editClipboardImage() {
         captureCoordinator.editClipboardImage()
     }
@@ -315,6 +324,7 @@ extension MenuBarController: NSMenuDelegate {
             case #selector(captureArea): item.setShortcut(for: .captureArea)
             case #selector(captureFullscreen): item.setShortcut(for: .captureFullscreen)
             case #selector(captureWindow): item.setShortcut(for: .captureWindow)
+            case #selector(pinFromClipboard): item.setShortcut(for: .pinFromClipboard)
             case #selector(editClipboardImage): item.setShortcut(for: .editClipboardImage)
             case #selector(captureText): item.setShortcut(for: .captureText)
             case #selector(captureAndTranslate): item.setShortcut(for: .captureAndTranslate)

--- a/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
@@ -15,6 +15,7 @@ extension KeyboardShortcuts.Name {
     static let captureAreaToClipboard = Self("captureAreaToClipboard", default: .init(.seven, modifiers: [.option, .shift]))
     static let captureAreaAndShare = Self("captureAreaAndShare", default: .init(.zero, modifiers: [.option, .shift]))
     static let captureAreaAndAnnotate = Self("captureAreaAndAnnotate", default: .init(.eight, modifiers: [.option, .shift]))
+    static let pinFromClipboard = Self("pinFromClipboard")
     static let editClipboardImage = Self("editClipboardImage")
     static let screenshotHistory = Self("screenshotHistory", default: .init(.nine, modifiers: [.option, .shift]))
     static let captureAndTranslate = Self("captureAndTranslate", default: .init(.t, modifiers: [.option, .shift]))
@@ -88,6 +89,12 @@ struct ShortcutSettingsView: View {
                     shortcutRow("Capture Area to Clipboard", name: .captureAreaToClipboard, showDivider: true)
                     shortcutRow("Capture and Share to Cloud", name: .captureAreaAndShare, showDivider: true)
                     shortcutRow("Capture Area & Annotate", name: .captureAreaAndAnnotate, showDivider: true)
+                    shortcutRow(
+                        "Pin from Clipboard",
+                        name: .pinFromClipboard,
+                        showDivider: true,
+                        help: "Float copied images, text, colors, or files above other windows"
+                    )
                     shortcutRow(
                         "Edit Clipboard Image",
                         name: .editClipboardImage,

--- a/App/Tests/PinnedScreenshotWindowPresentationTests.swift
+++ b/App/Tests/PinnedScreenshotWindowPresentationTests.swift
@@ -1,0 +1,73 @@
+import AppKit
+import SharedKit
+import XCTest
+
+@testable import Capso
+
+@MainActor
+final class PinnedScreenshotWindowPresentationTests: XCTestCase {
+    func testClipboardPinUsesNonactivatingPanel() throws {
+        let window = PinnedScreenshotWindow(
+            image: try makeImage(),
+            anchorRect: nil,
+            activatesApp: false,
+            onCopy: {},
+            onSave: {},
+            onDidClose: { _ in }
+        )
+        defer { window.close() }
+
+        XCTAssertTrue(window.styleMask.contains(.nonactivatingPanel))
+        XCTAssertFalse(window.activatesAppWhenShown)
+    }
+
+    func testExistingPinDefaultsToActivatingWindow() throws {
+        let window = PinnedScreenshotWindow(
+            image: try makeImage(),
+            anchorRect: nil,
+            onCopy: {},
+            onSave: {},
+            onDidClose: { _ in }
+        )
+        defer { window.close() }
+
+        XCTAssertFalse(window.styleMask.contains(.nonactivatingPanel))
+        XCTAssertTrue(window.activatesAppWhenShown)
+    }
+
+    func testCoordinatorRoutesClipboardContentToANonactivatingPin() throws {
+        let suiteName = "PinnedScreenshotWindowPresentationTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        let coordinator = CaptureCoordinator(settings: AppSettings(defaults: defaults))
+        let pasteboard = NSPasteboard(
+            name: NSPasteboard.Name("PinnedScreenshotWindowPresentationTests.\(UUID().uuidString)")
+        )
+        pasteboard.clearContents()
+        pasteboard.setString("Pinned clipboard text", forType: .string)
+        let existingWindows = Set(NSApp.windows.map(ObjectIdentifier.init))
+
+        coordinator.pinFromClipboard(pasteboard: pasteboard)
+
+        let window = try XCTUnwrap(NSApp.windows.first {
+            $0 is PinnedScreenshotWindow && !existingWindows.contains(ObjectIdentifier($0))
+        } as? PinnedScreenshotWindow)
+        defer { window.close() }
+        XCTAssertTrue(window.isVisible)
+        XCTAssertTrue(window.styleMask.contains(.nonactivatingPanel))
+        XCTAssertFalse(window.activatesAppWhenShown)
+    }
+
+    private func makeImage() throws -> CGImage {
+        let context = try XCTUnwrap(CGContext(
+            data: nil,
+            width: 12,
+            height: 8,
+            bitsPerComponent: 8,
+            bytesPerRow: 48,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        return try XCTUnwrap(context.makeImage())
+    }
+}

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ClipboardPinContentReader.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ClipboardPinContentReader.swift
@@ -193,9 +193,14 @@ public enum ClipboardPinContentReader {
             return .image(image)
         }
 
-        if let attributed = attributedText(from: pasteboard),
-           let image = renderCard(attributed, visibleFrame: visibleFrame) {
-            return .image(image)
+        if let attributed = attributedText(from: pasteboard) {
+            let content = attributed.string.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !content.isEmpty {
+                guard attributed.length <= maxTextLength else { return .tooLarge }
+                if let image = renderCard(attributed, visibleFrame: visibleFrame) {
+                    return .image(image)
+                }
+            }
         }
 
         switch readImage(from: pasteboard) {
@@ -204,9 +209,11 @@ public enum ClipboardPinContentReader {
         case .unsupported: break
         }
 
-        if let text = htmlText(from: pasteboard),
-           let image = renderCard(plainAttributedString(text), visibleFrame: visibleFrame) {
-            return .image(image)
+        if let text = htmlText(from: pasteboard) {
+            guard text.utf16.count <= maxTextLength else { return .tooLarge }
+            if let image = renderCard(plainAttributedString(text), visibleFrame: visibleFrame) {
+                return .image(image)
+            }
         }
 
         guard let text = pasteboard.string(forType: .string)?
@@ -327,7 +334,8 @@ public enum ClipboardPinContentReader {
             with: NSSize(width: maxContentWidth, height: .greatestFiniteMagnitude),
             options: [.usesLineFragmentOrigin, .usesFontLeading]
         )
-        let width = max(320, ceil(measured.width + padding.left + padding.right))
+        let maxWidth = ceil(maxContentWidth + padding.left + padding.right)
+        let width = min(maxWidth, max(320, ceil(measured.width + padding.left + padding.right)))
         let height = min(8_000, max(120, ceil(measured.height + padding.top + padding.bottom)))
         guard let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
               let context = CGContext(

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ClipboardPinContentReader.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ClipboardPinContentReader.swift
@@ -342,6 +342,8 @@ public enum ClipboardPinContentReader {
             return nil
         }
 
+        context.translateBy(x: 0, y: height)
+        context.scaleBy(x: 1, y: -1)
         NSGraphicsContext.saveGraphicsState()
         NSGraphicsContext.current = NSGraphicsContext(cgContext: context, flipped: true)
         defer { NSGraphicsContext.restoreGraphicsState() }
@@ -420,6 +422,8 @@ public enum ClipboardPinContentReader {
         context.setFillColor(srgb.cgColor)
         context.fill(CGRect(x: 0, y: 0, width: width, height: height))
 
+        context.translateBy(x: 0, y: CGFloat(height))
+        context.scaleBy(x: 1, y: -1)
         NSGraphicsContext.saveGraphicsState()
         NSGraphicsContext.current = NSGraphicsContext(cgContext: context, flipped: true)
         defer { NSGraphicsContext.restoreGraphicsState() }

--- a/Packages/SharedKit/Sources/SharedKit/Utilities/ClipboardPinContentReader.swift
+++ b/Packages/SharedKit/Sources/SharedKit/Utilities/ClipboardPinContentReader.swift
@@ -1,0 +1,437 @@
+import AppKit
+import CoreGraphics
+import ImageIO
+
+public enum ClipboardPinContentResult {
+    case image(CGImage)
+    case tooLarge
+    case unsupported
+}
+
+@MainActor
+public enum ClipboardPinContentReader {
+    private static let padding = NSEdgeInsets(top: 24, left: 26, bottom: 24, right: 26)
+    private static let maxTextLength = 100_000
+    private static let maxRichDataSize = 4 * 1_024 * 1_024
+    private static let maxEncodedImageSize = 128 * 1_024 * 1_024
+    private static let maxImagePixelCount = 40_000_000
+    private static let maxImageDimension = 32_768
+
+    private enum ImageReadResult {
+        case image(CGImage)
+        case tooLarge
+        case unsupported
+    }
+
+    static func isSafeImageDimensions(width: Int, height: Int) -> Bool {
+        guard width > 0, height > 0,
+              width <= maxImageDimension, height <= maxImageDimension else {
+            return false
+        }
+        return width <= maxImagePixelCount / height
+    }
+
+    static func attributedText(from pasteboard: NSPasteboard) -> NSAttributedString? {
+        for (pasteboardType, documentType) in [
+            (NSPasteboard.PasteboardType.rtfd, NSAttributedString.DocumentType.rtfd),
+            (.rtf, .rtf),
+        ] {
+            guard let data = pasteboard.data(forType: pasteboardType) else { continue }
+            if let attributed = try? NSAttributedString(
+                data: data,
+                options: [.documentType: documentType],
+                documentAttributes: nil
+            ) {
+                return attributed
+            }
+        }
+        return nil
+    }
+
+    static func htmlText(from pasteboard: NSPasteboard) -> String? {
+        guard let html = pasteboard.string(forType: .html) else { return nil }
+        var text = replacingMatches(
+            in: html,
+            pattern: #"<(script|style)\b[^>]*>.*?</\1\s*>"#,
+            with: ""
+        )
+        text = replacingMatches(
+            in: text,
+            pattern: #"<\s*(br\s*/?|/\s*(p|div|li|h[1-6]|tr))\s*>"#,
+            with: "\n"
+        )
+        text = replacingMatches(in: text, pattern: #"<[^>]+>"#, with: "")
+        text = decodeHTMLEntities(in: text)
+
+        let lines = text.components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let result = lines.joined(separator: "\n")
+        return result.isEmpty ? nil : result
+    }
+
+    static func fileListText(from pasteboard: NSPasteboard) -> String? {
+        let urls = fileURLs(from: pasteboard)
+        guard !urls.isEmpty else { return nil }
+
+        let displayed = urls.prefix(100).map { url in
+            "\(url.lastPathComponent)\n\(url.path)"
+        }
+        var lines = displayed.joined(separator: "\n\n")
+        if urls.count > displayed.count {
+            lines += "\n\n+\(urls.count - displayed.count) more"
+        }
+        return lines
+    }
+
+    private static func fileURLs(from pasteboard: NSPasteboard) -> [URL] {
+        let options: [NSPasteboard.ReadingOptionKey: Any] = [
+            .urlReadingFileURLsOnly: true,
+        ]
+        return pasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: options
+        ) as? [URL] ?? []
+    }
+
+    private static func replacingMatches(
+        in string: String,
+        pattern: String,
+        with replacement: String
+    ) -> String {
+        guard let expression = try? NSRegularExpression(
+            pattern: pattern,
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        ) else {
+            return string
+        }
+        let range = NSRange(string.startIndex..., in: string)
+        return expression.stringByReplacingMatches(
+            in: string,
+            range: range,
+            withTemplate: replacement
+        )
+    }
+
+    private static func decodeHTMLEntities(in string: String) -> String {
+        let namedEntities = [
+            "amp": "&", "lt": "<", "gt": ">", "quot": "\"",
+            "apos": "'", "#39": "'", "nbsp": " ",
+        ]
+        var result = ""
+        var index = string.startIndex
+        while index < string.endIndex {
+            guard string[index] == "&" else {
+                result.append(string[index])
+                index = string.index(after: index)
+                continue
+            }
+
+            let entityStart = string.index(after: index)
+            var cursor = entityStart
+            var semicolon: String.Index?
+            for _ in 0..<12 where cursor < string.endIndex {
+                if string[cursor] == ";" {
+                    semicolon = cursor
+                    break
+                }
+                if string[cursor] == "&" { break }
+                cursor = string.index(after: cursor)
+            }
+            guard let semicolon else {
+                result.append(string[index])
+                index = string.index(after: index)
+                continue
+            }
+
+            let entity = String(string[entityStart..<semicolon])
+            let decoded: String?
+            if let named = namedEntities[entity.lowercased()] {
+                decoded = named
+            } else if entity.lowercased().hasPrefix("#x"),
+                      let value = UInt32(entity.dropFirst(2), radix: 16),
+                      let scalar = UnicodeScalar(value) {
+                decoded = String(scalar)
+            } else if entity.hasPrefix("#"),
+                      let value = UInt32(entity.dropFirst()),
+                      let scalar = UnicodeScalar(value) {
+                decoded = String(scalar)
+            } else {
+                decoded = nil
+            }
+
+            if let decoded {
+                result.append(decoded)
+                index = string.index(after: semicolon)
+            } else {
+                result.append(string[index])
+                index = string.index(after: index)
+            }
+        }
+        return result
+    }
+
+    public static func render(
+        from pasteboard: NSPasteboard = .general,
+        visibleFrame: CGRect? = nil
+    ) -> ClipboardPinContentResult {
+        if isOversized(pasteboard) {
+            return .tooLarge
+        }
+
+        let urls = fileURLs(from: pasteboard)
+        if urls.count == 1, ImageFileReader.isSupported(urls[0]) {
+            switch readImage(at: urls[0]) {
+            case let .image(image): return .image(image)
+            case .tooLarge: return .tooLarge
+            case .unsupported: break
+            }
+        }
+        if !urls.isEmpty,
+           let text = fileListText(from: pasteboard),
+           let image = renderCard(plainAttributedString(text), visibleFrame: visibleFrame) {
+            return .image(image)
+        }
+
+        if let attributed = attributedText(from: pasteboard),
+           let image = renderCard(attributed, visibleFrame: visibleFrame) {
+            return .image(image)
+        }
+
+        switch readImage(from: pasteboard) {
+        case let .image(image): return .image(image)
+        case .tooLarge: return .tooLarge
+        case .unsupported: break
+        }
+
+        if let text = htmlText(from: pasteboard),
+           let image = renderCard(plainAttributedString(text), visibleFrame: visibleFrame) {
+            return .image(image)
+        }
+
+        guard let text = pasteboard.string(forType: .string)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !text.isEmpty else {
+            return .unsupported
+        }
+
+        let pathURL = URL(fileURLWithPath: text)
+        if text.hasPrefix("/"), ImageFileReader.isSupported(pathURL) {
+            switch readImage(at: pathURL) {
+            case let .image(image): return .image(image)
+            case .tooLarge: return .tooLarge
+            case .unsupported: break
+            }
+        }
+
+        if let color = clipboardColor(from: text),
+           let image = renderColorCard(color: color, label: text) {
+            return .image(image)
+        }
+
+        guard let image = renderCard(plainAttributedString(text), visibleFrame: visibleFrame) else {
+            return .unsupported
+        }
+        return .image(image)
+    }
+
+    private static func readImage(at url: URL) -> ImageReadResult {
+        guard let values = try? url.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey]),
+              values.isRegularFile == true,
+              let fileSize = values.fileSize else {
+            return .unsupported
+        }
+        guard fileSize <= maxEncodedImageSize else { return .tooLarge }
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+            return .unsupported
+        }
+        return readImage(from: source)
+    }
+
+    private static func readImage(from pasteboard: NSPasteboard) -> ImageReadResult {
+        let types: [NSPasteboard.PasteboardType] = [
+            .png,
+            NSPasteboard.PasteboardType("public.jpeg"),
+            NSPasteboard.PasteboardType("public.heic"),
+            NSPasteboard.PasteboardType("com.compuserve.gif"),
+            .tiff,
+        ]
+        var foundOversizedData = false
+        for type in types {
+            guard let data = pasteboard.data(forType: type) else { continue }
+            guard data.count <= maxEncodedImageSize else {
+                foundOversizedData = true
+                continue
+            }
+            guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { continue }
+            switch readImage(from: source) {
+            case let .image(image): return .image(image)
+            case .tooLarge: foundOversizedData = true
+            case .unsupported: continue
+            }
+        }
+        return foundOversizedData ? .tooLarge : .unsupported
+    }
+
+    private static func readImage(from source: CGImageSource) -> ImageReadResult {
+        guard CGImageSourceGetCount(source) > 0,
+              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+              let width = (properties[kCGImagePropertyPixelWidth] as? NSNumber)?.intValue,
+              let height = (properties[kCGImagePropertyPixelHeight] as? NSNumber)?.intValue else {
+            return .unsupported
+        }
+        guard isSafeImageDimensions(width: width, height: height) else { return .tooLarge }
+
+        let options = [
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceShouldAllowFloat: false,
+        ] as CFDictionary
+        guard let image = CGImageSourceCreateImageAtIndex(source, 0, options),
+              isSafeImageDimensions(width: image.width, height: image.height) else {
+            return .unsupported
+        }
+        return .image(image)
+    }
+
+    private static func isOversized(_ pasteboard: NSPasteboard) -> Bool {
+        for type in [NSPasteboard.PasteboardType.rtfd, .rtf, .html] {
+            if let data = pasteboard.data(forType: type), data.count > maxRichDataSize {
+                return true
+            }
+        }
+        return pasteboard.string(forType: .string)?.utf16.count ?? 0 > maxTextLength
+    }
+
+    private static func plainAttributedString(_ text: String) -> NSAttributedString {
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.lineBreakMode = .byWordWrapping
+        return NSAttributedString(
+            string: text,
+            attributes: [
+                .font: NSFont.monospacedSystemFont(ofSize: 18, weight: .regular),
+                .foregroundColor: NSColor.labelColor,
+                .paragraphStyle: paragraph,
+            ]
+        )
+    }
+
+    private static func renderCard(
+        _ attributed: NSAttributedString,
+        visibleFrame: CGRect?
+    ) -> CGImage? {
+        let screenFrame = visibleFrame
+            ?? NSScreen.main?.visibleFrame
+            ?? CGRect(x: 0, y: 0, width: 1440, height: 900)
+        let maxContentWidth = max(320, min(760, screenFrame.width * 0.72))
+        let measured = attributed.boundingRect(
+            with: NSSize(width: maxContentWidth, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading]
+        )
+        let width = max(320, ceil(measured.width + padding.left + padding.right))
+        let height = min(8_000, max(120, ceil(measured.height + padding.top + padding.bottom)))
+        guard let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
+              let context = CGContext(
+                data: nil,
+                width: Int(width),
+                height: Int(height),
+                bitsPerComponent: 8,
+                bytesPerRow: Int(width) * 4,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+              ) else {
+            return nil
+        }
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(cgContext: context, flipped: true)
+        defer { NSGraphicsContext.restoreGraphicsState() }
+
+        NSColor.textBackgroundColor.usingColorSpace(.sRGB)?.setFill()
+        NSBezierPath(
+            roundedRect: NSRect(x: 0, y: 0, width: width, height: height),
+            xRadius: 14,
+            yRadius: 14
+        ).fill()
+        attributed.draw(
+            with: NSRect(
+                x: padding.left,
+                y: padding.top,
+                width: width - padding.left - padding.right,
+                height: height - padding.top - padding.bottom
+            ),
+            options: [.usesLineFragmentOrigin, .usesFontLeading]
+        )
+        return context.makeImage()
+    }
+
+    private static func clipboardColor(from text: String) -> NSColor? {
+        if let hexadecimal = hexadecimalColor(from: text) {
+            return hexadecimal
+        }
+
+        let lowercased = text.lowercased()
+        let components: Substring
+        if lowercased.hasPrefix("rgb("), lowercased.hasSuffix(")") {
+            components = lowercased.dropFirst(4).dropLast()
+        } else {
+            components = Substring(lowercased)
+        }
+        let values = components.split(separator: ",")
+            .compactMap { Double($0.trimmingCharacters(in: .whitespaces)) }
+        guard values.count == 3, values.allSatisfy({ (0...255).contains($0) }) else { return nil }
+        let divisor = values.allSatisfy({ $0 <= 1 }) ? 1.0 : 255.0
+        return NSColor(
+            srgbRed: values[0] / divisor,
+            green: values[1] / divisor,
+            blue: values[2] / divisor,
+            alpha: 1
+        )
+    }
+
+    private static func hexadecimalColor(from text: String) -> NSColor? {
+        guard text.hasPrefix("#") else { return nil }
+        let hex = String(text.dropFirst())
+        guard hex.count == 6, let value = UInt64(hex, radix: 16) else { return nil }
+        return NSColor(
+            srgbRed: CGFloat((value >> 16) & 0xFF) / 255,
+            green: CGFloat((value >> 8) & 0xFF) / 255,
+            blue: CGFloat(value & 0xFF) / 255,
+            alpha: 1
+        )
+    }
+
+    private static func renderColorCard(color: NSColor, label: String) -> CGImage? {
+        let width = 360
+        let height = 180
+        guard let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
+              let context = CGContext(
+                data: nil,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+              ),
+              let srgb = color.usingColorSpace(.sRGB) else {
+            return nil
+        }
+
+        context.setFillColor(srgb.cgColor)
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(cgContext: context, flipped: true)
+        defer { NSGraphicsContext.restoreGraphicsState() }
+
+        let foreground: NSColor = srgb.brightnessComponent > 0.58 ? .black : .white
+        NSString(string: label.uppercased()).draw(
+            at: NSPoint(x: 24, y: height - 52),
+            withAttributes: [
+                .font: NSFont.monospacedSystemFont(ofSize: 22, weight: .semibold),
+                .foregroundColor: foreground,
+            ]
+        )
+        return context.makeImage()
+    }
+}

--- a/Packages/SharedKit/Tests/SharedKitTests/ClipboardPinContentReaderTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ClipboardPinContentReaderTests.swift
@@ -159,6 +159,32 @@ struct ClipboardPinContentReaderTests {
         #expect(parsed.string == "RTFD content")
     }
 
+    @Test("ignores empty rich text when the clipboard also contains an image")
+    @MainActor
+    func emptyRichTextFallsBackToImage() throws {
+        let source = try makeImage(width: 11, height: 7)
+        let pngData = try #require(ImageUtilities.pngData(from: source))
+        let blank = NSAttributedString(string: " \n ")
+        let rtfData = try blank.data(
+            from: NSRange(location: 0, length: blank.length),
+            documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf]
+        )
+        let item = NSPasteboardItem()
+        item.setData(rtfData, forType: .rtf)
+        item.setData(pngData, forType: .png)
+        let pasteboard = makePasteboard()
+        pasteboard.writeObjects([item])
+
+        let result = ClipboardPinContentReader.render(from: pasteboard)
+
+        guard case let .image(image) = result else {
+            Issue.record("Expected the clipboard image, got \(result)")
+            return
+        }
+        #expect(image.width == 11)
+        #expect(image.height == 7)
+    }
+
     @Test("converts HTML locally without retaining remote resources or scripts")
     @MainActor
     func convertsHTMLSafely() throws {
@@ -271,6 +297,45 @@ struct ClipboardPinContentReaderTests {
 
         guard case .tooLarge = result else {
             Issue.record("Expected oversized clipboard content, got \(result)")
+            return
+        }
+    }
+
+    @Test("rejects rich text that expands beyond the text limit")
+    @MainActor
+    func rejectsExpandedRichText() throws {
+        let source = NSAttributedString(string: String(repeating: "A", count: 100_001))
+        let data = try source.data(
+            from: NSRange(location: 0, length: source.length),
+            documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf]
+        )
+        let item = NSPasteboardItem()
+        item.setData(data, forType: .rtf)
+        item.setString("short fallback", forType: .string)
+        let pasteboard = makePasteboard()
+        pasteboard.writeObjects([item])
+
+        let result = ClipboardPinContentReader.render(from: pasteboard)
+
+        guard case .tooLarge = result else {
+            Issue.record("Expected expanded rich text to be rejected, got \(result)")
+            return
+        }
+    }
+
+    @Test("rejects HTML that expands beyond the text limit")
+    @MainActor
+    func rejectsExpandedHTML() {
+        let item = NSPasteboardItem()
+        item.setString("<p>\(String(repeating: "A", count: 100_001))</p>", forType: .html)
+        item.setString("short fallback", forType: .string)
+        let pasteboard = makePasteboard()
+        pasteboard.writeObjects([item])
+
+        let result = ClipboardPinContentReader.render(from: pasteboard)
+
+        guard case .tooLarge = result else {
+            Issue.record("Expected expanded HTML to be rejected, got \(result)")
             return
         }
     }

--- a/Packages/SharedKit/Tests/SharedKitTests/ClipboardPinContentReaderTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ClipboardPinContentReaderTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Testing
+import Vision
 @testable import SharedKit
 
 @Suite("ClipboardPinContentReader")
@@ -45,6 +46,22 @@ struct ClipboardPinContentReaderTests {
         #expect(image.colorSpace?.name == CGColorSpace.sRGB)
         #expect(image.bitsPerComponent == 8)
         #expect(try rgbaPixel(in: image, x: 10, y: 10) == [0, 255, 128, 255])
+    }
+
+    @Test("renders color card labels upright")
+    @MainActor
+    func rendersColorLabelsUpright() throws {
+        let pasteboard = makePasteboard()
+        pasteboard.setString("#00FF80", forType: .string)
+
+        let result = ClipboardPinContentReader.render(from: pasteboard)
+
+        guard case let .image(image) = result else {
+            Issue.record("Expected a color card, got \(result)")
+            return
+        }
+        let recognized = try recognizedText(in: image)
+        #expect(recognized.contains("00FF80"))
     }
 
     @Test("renders integer RGB clipboard colors as color cards")
@@ -277,6 +294,31 @@ struct ClipboardPinContentReaderTests {
         #expect(image.height >= 100)
         #expect(image.colorSpace?.name == CGColorSpace.sRGB)
         #expect(image.bitsPerComponent == 8)
+    }
+
+    @Test("renders clipboard text upright")
+    @MainActor
+    func rendersTextUpright() throws {
+        let pasteboard = makePasteboard()
+        pasteboard.setString("CAPSO UPRIGHT 123", forType: .string)
+
+        let result = ClipboardPinContentReader.render(from: pasteboard)
+
+        guard case let .image(image) = result else {
+            Issue.record("Expected rendered clipboard text, got \(result)")
+            return
+        }
+        let recognized = try recognizedText(in: image)
+        #expect(recognized.contains("CAPSO UPRIGHT 123"))
+    }
+
+    private func recognizedText(in image: CGImage) throws -> String {
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        try VNImageRequestHandler(cgImage: image).perform([request])
+        return (request.results ?? [])
+            .compactMap { $0.topCandidates(1).first?.string.uppercased() }
+            .joined(separator: " ")
     }
 
     private func makePasteboard() -> NSPasteboard {

--- a/Packages/SharedKit/Tests/SharedKitTests/ClipboardPinContentReaderTests.swift
+++ b/Packages/SharedKit/Tests/SharedKitTests/ClipboardPinContentReaderTests.swift
@@ -1,0 +1,310 @@
+import AppKit
+import Testing
+@testable import SharedKit
+
+@Suite("ClipboardPinContentReader")
+struct ClipboardPinContentReaderTests {
+    @Test("keeps clipboard images at their original pixel dimensions")
+    @MainActor
+    func keepsClipboardImages() throws {
+        let pasteboard = makePasteboard()
+        let source = try makeImage(width: 11, height: 7)
+        pasteboard.writeObjects([ImageUtilities.nsImage(from: source)])
+
+        let result = ClipboardPinContentReader.render(from: pasteboard)
+
+        guard case let .image(image) = result else {
+            Issue.record("Expected the clipboard image, got \(result)")
+            return
+        }
+        #expect(image.width == 11)
+        #expect(image.height == 7)
+    }
+
+    @Test("rejects image dimensions that exceed the clipboard pin memory budget")
+    @MainActor
+    func validatesImageDimensions() {
+        #expect(ClipboardPinContentReader.isSafeImageDimensions(width: 6_016, height: 3_384))
+        #expect(!ClipboardPinContentReader.isSafeImageDimensions(width: 50_000, height: 50_000))
+        #expect(!ClipboardPinContentReader.isSafeImageDimensions(width: .max, height: 2))
+        #expect(!ClipboardPinContentReader.isSafeImageDimensions(width: 0, height: 100))
+    }
+
+    @Test("renders hexadecimal clipboard colors as color cards")
+    @MainActor
+    func rendersHexColorCard() throws {
+        let pasteboard = makePasteboard()
+        pasteboard.setString("#00FF80", forType: .string)
+
+        let result = ClipboardPinContentReader.render(from: pasteboard)
+
+        guard case let .image(image) = result else {
+            Issue.record("Expected a color card, got \(result)")
+            return
+        }
+        #expect(image.colorSpace?.name == CGColorSpace.sRGB)
+        #expect(image.bitsPerComponent == 8)
+        #expect(try rgbaPixel(in: image, x: 10, y: 10) == [0, 255, 128, 255])
+    }
+
+    @Test("renders integer RGB clipboard colors as color cards")
+    @MainActor
+    func rendersIntegerRGBColorCard() throws {
+        let pasteboard = makePasteboard()
+        pasteboard.setString("rgb(255, 0, 128)", forType: .string)
+
+        let result = ClipboardPinContentReader.render(from: pasteboard)
+
+        guard case let .image(image) = result else {
+            Issue.record("Expected a color card, got \(result)")
+            return
+        }
+        #expect(try rgbaPixel(in: image, x: 10, y: 10) == [255, 0, 128, 255])
+    }
+
+    @Test("renders normalized RGB clipboard colors as color cards")
+    @MainActor
+    func rendersNormalizedRGBColorCard() throws {
+        let pasteboard = makePasteboard()
+        pasteboard.setString("1, 0.5, 0", forType: .string)
+
+        let result = ClipboardPinContentReader.render(from: pasteboard)
+
+        guard case let .image(image) = result else {
+            Issue.record("Expected a color card, got \(result)")
+            return
+        }
+        #expect(try rgbaPixel(in: image, x: 10, y: 10) == [255, 128, 0, 255])
+    }
+
+    @Test("preserves RTF font and color attributes")
+    @MainActor
+    func preservesRTFAttributes() throws {
+        let pasteboard = makePasteboard()
+        let source = NSAttributedString(
+            string: "Styled text",
+            attributes: [
+                .font: NSFont.systemFont(ofSize: 26, weight: .bold),
+                .foregroundColor: NSColor.systemRed,
+            ]
+        )
+        let data = try source.data(
+            from: NSRange(location: 0, length: source.length),
+            documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf]
+        )
+        pasteboard.setData(data, forType: .rtf)
+
+        let parsed = try #require(ClipboardPinContentReader.attributedText(from: pasteboard))
+        let font = try #require(parsed.attribute(.font, at: 0, effectiveRange: nil) as? NSFont)
+        let color = try #require(parsed.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor)
+
+        #expect(font.pointSize == 26)
+        #expect(font.fontDescriptor.symbolicTraits.contains(.bold))
+        #expect(color.usingColorSpace(.sRGB) == NSColor.systemRed.usingColorSpace(.sRGB))
+    }
+
+    @Test("renders RTF clipboard content as a pin image")
+    @MainActor
+    func rendersRTF() throws {
+        let pasteboard = makePasteboard()
+        let source = NSAttributedString(
+            string: Array(repeating: "Styled text", count: 10).joined(separator: "\n"),
+            attributes: [.font: NSFont.systemFont(ofSize: 42, weight: .bold)]
+        )
+        let data = try source.data(
+            from: NSRange(location: 0, length: source.length),
+            documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf]
+        )
+        pasteboard.setData(data, forType: .rtf)
+
+        let result = ClipboardPinContentReader.render(from: pasteboard)
+
+        guard case let .image(image) = result else {
+            Issue.record("Expected rendered RTF content, got \(result)")
+            return
+        }
+        #expect(image.height > 400)
+    }
+
+    @Test("reads RTFD clipboard content")
+    @MainActor
+    func readsRTFD() throws {
+        let pasteboard = makePasteboard()
+        let source = NSAttributedString(string: "RTFD content")
+        let data = try source.data(
+            from: NSRange(location: 0, length: source.length),
+            documentAttributes: [.documentType: NSAttributedString.DocumentType.rtfd]
+        )
+        pasteboard.setData(data, forType: .rtfd)
+
+        let parsed = try #require(ClipboardPinContentReader.attributedText(from: pasteboard))
+
+        #expect(parsed.string == "RTFD content")
+    }
+
+    @Test("converts HTML locally without retaining remote resources or scripts")
+    @MainActor
+    func convertsHTMLSafely() throws {
+        let pasteboard = makePasteboard()
+        pasteboard.setString(
+            #"<p>Hello <strong>world</strong></p><img src="https://example.invalid/pixel.png"><p>Second &amp; third</p><script>bad()</script>"#,
+            forType: .html
+        )
+
+        let text = try #require(ClipboardPinContentReader.htmlText(from: pasteboard))
+
+        #expect(text == "Hello world\nSecond & third")
+        #expect(!text.contains("https://"))
+        #expect(!text.contains("bad()"))
+    }
+
+    @Test("decodes adversarial HTML entities within a bounded time")
+    @MainActor
+    func decodesHTMLEntitiesInLinearTime() throws {
+        let pasteboard = makePasteboard()
+        let html = "<p>\(String(repeating: "&", count: 50_000));</p>"
+        pasteboard.setString(html, forType: .html)
+        let clock = ContinuousClock()
+
+        let duration = try clock.measure {
+            _ = try #require(ClipboardPinContentReader.htmlText(from: pasteboard))
+        }
+
+        #expect(duration < .seconds(1))
+    }
+
+    @Test("describes every copied file instead of choosing the first one")
+    @MainActor
+    func describesFileLists() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CapsoClipboardPinTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let first = directory.appendingPathComponent("notes.txt")
+        let second = directory.appendingPathComponent("archive.zip")
+        try Data("notes".utf8).write(to: first)
+        try Data("archive".utf8).write(to: second)
+        let pasteboard = makePasteboard()
+        pasteboard.writeObjects([first as NSURL, second as NSURL])
+
+        let text = try #require(ClipboardPinContentReader.fileListText(from: pasteboard))
+
+        #expect(text.contains("notes.txt"))
+        #expect(text.contains("archive.zip"))
+        #expect(text.contains(first.path))
+        #expect(text.contains(second.path))
+
+        guard case .image = ClipboardPinContentReader.render(from: pasteboard) else {
+            Issue.record("Expected the copied file list to render as a pin image")
+            return
+        }
+    }
+
+    @Test("loads an image from a copied plain file path")
+    @MainActor
+    func loadsImagePathString() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CapsoClipboardPin-\(UUID().uuidString).png")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let source = try makeImage(width: 13, height: 9)
+        let data = try #require(NSBitmapImageRep(cgImage: source).representation(using: .png, properties: [:]))
+        try data.write(to: url)
+        let pasteboard = makePasteboard()
+        pasteboard.setString(url.path, forType: .string)
+
+        let result = ClipboardPinContentReader.render(from: pasteboard)
+
+        guard case let .image(image) = result else {
+            Issue.record("Expected the copied image path to load, got \(result)")
+            return
+        }
+        #expect(image.width == 13)
+        #expect(image.height == 9)
+    }
+
+    @Test("does not open arbitrary file paths as images")
+    @MainActor
+    func rejectsUnsupportedImagePathExtension() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CapsoClipboardPin-\(UUID().uuidString).txt")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let source = try makeImage(width: 13, height: 9)
+        let data = try #require(NSBitmapImageRep(cgImage: source).representation(using: .png, properties: [:]))
+        try data.write(to: url)
+        let pasteboard = makePasteboard()
+        pasteboard.setString(url.path, forType: .string)
+
+        let result = ClipboardPinContentReader.render(from: pasteboard)
+
+        guard case let .image(image) = result else {
+            Issue.record("Expected the path to render as text, got \(result)")
+            return
+        }
+        #expect(image.width >= 320)
+        #expect(image.height >= 100)
+    }
+
+    @Test("rejects oversized text clipboard content")
+    @MainActor
+    func rejectsOversizedText() {
+        let pasteboard = makePasteboard()
+        pasteboard.setString(String(repeating: "x", count: 100_001), forType: .string)
+
+        let result = ClipboardPinContentReader.render(from: pasteboard)
+
+        guard case .tooLarge = result else {
+            Issue.record("Expected oversized clipboard content, got \(result)")
+            return
+        }
+    }
+
+    @Test("renders plain text clipboard content as a pin image")
+    @MainActor
+    func rendersPlainText() throws {
+        let pasteboard = makePasteboard()
+        pasteboard.setString("First line\nSecond line", forType: .string)
+
+        let result = ClipboardPinContentReader.render(
+            from: pasteboard,
+            visibleFrame: CGRect(x: 0, y: 0, width: 1440, height: 900)
+        )
+
+        guard case let .image(image) = result else {
+            Issue.record("Expected a rendered pin image, got \(result)")
+            return
+        }
+        #expect(image.width >= 300)
+        #expect(image.height >= 100)
+        #expect(image.colorSpace?.name == CGColorSpace.sRGB)
+        #expect(image.bitsPerComponent == 8)
+    }
+
+    private func makePasteboard() -> NSPasteboard {
+        let name = NSPasteboard.Name("CapsoClipboardPinContentReaderTests.\(UUID().uuidString)")
+        let pasteboard = NSPasteboard(name: name)
+        pasteboard.clearContents()
+        return pasteboard
+    }
+
+    private func makeImage(width: Int, height: Int) throws -> CGImage {
+        let context = try #require(CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(CGColor(red: 0.2, green: 0.4, blue: 0.8, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return try #require(context.makeImage())
+    }
+
+    private func rgbaPixel(in image: CGImage, x: Int, y: Int) throws -> [UInt8] {
+        #expect(image.bitsPerPixel == 32)
+        let data = try #require(image.dataProvider?.data as Data?)
+        let offset = y * image.bytesPerRow + x * 4
+        return Array(data[offset..<(offset + 4)])
+    }
+}


### PR DESCRIPTION
## Summary

- add a customizable Pin from Clipboard shortcut and menu action
- support images, image paths, plain and rich text, safe HTML, colors, and copied file lists
- reuse the existing always-on-top pin UI without stealing focus
- bound untrusted clipboard image/text inputs and keep rendered text upright

## Testing

- `swift test --package-path Packages/SharedKit`
- focused `PinnedScreenshotWindowPresentationTests`
- unsigned Debug build
- local full App test run reaches one existing `AnnotationEditorWindowCenteringTests.testWindowNeverOutgrowsTheDisplayWidth` failure after rebasing onto the latest `main`; feature-focused tests pass

Addresses #253.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Parses untrusted clipboard data (HTML, images, file paths) and changes pin window activation behavior. Size limits and non-activating presentation reduce impact, but this is still user-facing capture/UI plumbing.
> 
> **Overview**
> Users can pin the current clipboard as a floating overlay via a new **Pin from Clipboard** menu item and optional shortcut. Images stay as images; text, RTF, stripped HTML, hex/RGB colors, and copied file lists are rendered as cards.
> 
> Clipboard pins reuse the existing pin windows but **do not steal focus** (`nonactivatingPanel` + `orderFrontRegardless`). Capture pins still activate the app by default.
> 
> `ClipboardPinContentReader` bounds untrusted pasteboard size/pixels, strips scripts from HTML, and toasts when content is too large or unsupported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba47827af43294ede115ce1362b67c59646beefb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->