### PR TITLE
feat: add direct recording shortcuts

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -3916,6 +3916,50 @@
         }
       }
     },
+    "Record Area" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "範囲を録画"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "영역 녹화"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "录制区域"
+          }
+        }
+      }
+    },
+    "Record Full Screen" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "画面全体を録画"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전체 화면 녹화"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "录制整个屏幕"
+          }
+        }
+      }
+    },
     "Record Screen" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -146,6 +146,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         KeyboardShortcuts.onKeyDown(for: .recordScreen) { [weak self] in
             self?.recordingCoordinator?.startRecordingFlow()
         }
+        KeyboardShortcuts.onKeyDown(for: .recordFullscreen) { [weak self] in
+            self?.recordingCoordinator?.startFullScreenRecordingFlow()
+        }
         KeyboardShortcuts.onKeyDown(for: .captureScrolling) { [weak self] in
             self?.captureCoordinator?.captureScrolling()
         }

--- a/App/Sources/MenuBar/MenuBarController.swift
+++ b/App/Sources/MenuBar/MenuBarController.swift
@@ -130,9 +130,13 @@ final class MenuBarController: NSObject {
 
         menu.addItem(.separator())
 
-        let recordScreen = menuItem(String(localized: "Record Screen"), action: #selector(recordScreen))
-        recordScreen.setShortcut(for: .recordScreen)
-        menu.addItem(recordScreen)
+        let recordArea = menuItem(String(localized: "Record Area"), action: #selector(recordArea))
+        recordArea.setShortcut(for: .recordScreen)
+        menu.addItem(recordArea)
+
+        let recordFullscreen = menuItem(String(localized: "Record Full Screen"), action: #selector(recordFullscreen))
+        recordFullscreen.setShortcut(for: .recordFullscreen)
+        menu.addItem(recordFullscreen)
 
         menu.addItem(cameraPiPMenuItem())
 
@@ -291,8 +295,12 @@ final class MenuBarController: NSObject {
         captureCoordinator.captureAreaWithSelfTimer()
     }
 
-    @objc private func recordScreen() {
+    @objc private func recordArea() {
         recordingCoordinator.startRecordingFlow()
+    }
+
+    @objc private func recordFullscreen() {
+        recordingCoordinator.startFullScreenRecordingFlow()
     }
 
     @objc private func openHistory() {
@@ -330,7 +338,8 @@ extension MenuBarController: NSMenuDelegate {
             case #selector(captureAndTranslate): item.setShortcut(for: .captureAndTranslate)
             case #selector(translateSelectedText): item.setShortcut(for: .translateSelectedText)
             case #selector(translateTypedText): item.setShortcut(for: .translateTypedText)
-            case #selector(recordScreen): item.setShortcut(for: .recordScreen)
+            case #selector(recordArea): item.setShortcut(for: .recordScreen)
+            case #selector(recordFullscreen): item.setShortcut(for: .recordFullscreen)
             case #selector(captureScrolling): item.setShortcut(for: .captureScrolling)
             case #selector(captureSelfTimer):
                 item.setShortcut(for: .selfTimerCapture)

--- a/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
+++ b/App/Sources/Preferences/Tabs/ShortcutSettingsView.swift
@@ -10,7 +10,10 @@ extension KeyboardShortcuts.Name {
     static let captureFullscreen = Self("captureFullscreen", default: .init(.two, modifiers: [.option, .shift]))
     static let captureWindow = Self("captureWindow", default: .init(.three, modifiers: [.option, .shift]))
     static let captureText = Self("captureText", default: .init(.four, modifiers: [.option, .shift]))
+    /// Keep the existing storage key so current users retain their recording shortcut.
     static let recordScreen = Self("recordScreen", default: .init(.five, modifiers: [.option, .shift]))
+    /// Opt-in to avoid adding another default global shortcut.
+    static let recordFullscreen = Self("recordFullscreen")
     static let captureScrolling = Self("captureScrolling", default: .init(.six, modifiers: [.option, .shift]))
     static let captureAreaToClipboard = Self("captureAreaToClipboard", default: .init(.seven, modifiers: [.option, .shift]))
     static let captureAreaAndShare = Self("captureAreaAndShare", default: .init(.zero, modifiers: [.option, .shift]))
@@ -105,7 +108,8 @@ struct ShortcutSettingsView: View {
                     shortcutRow("Translate Selected Text", name: .translateSelectedText, showDivider: true)
                     shortcutRow("Translate Typed Text", name: .translateTypedText, showDivider: true)
                     shortcutRow("Capture Previous Area", name: .captureLastArea, showDivider: true)
-                    shortcutRow("Start / Stop Recording", name: .recordScreen, showDivider: true)
+                    shortcutRow("Record Area", name: .recordScreen, showDivider: true)
+                    shortcutRow("Record Full Screen", name: .recordFullscreen, showDivider: true)
                     shortcutRow("Screenshot History", name: .screenshotHistory, showDivider: true)
                 }
             }

--- a/App/Sources/Recording/RecordingCoordinator.swift
+++ b/App/Sources/Recording/RecordingCoordinator.swift
@@ -96,6 +96,15 @@ final class RecordingCoordinator {
         }
     }
 
+    /// Start a full-screen recording flow for the display under the pointer.
+    /// The recording toolbar still appears before capture begins so the user
+    /// can confirm camera, microphone, system audio, format, and countdown.
+    func startFullScreenRecordingFlow() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+            self?.selectFullScreenForRecording()
+        }
+    }
+
     func startRecordingFlow(withSelectedArea rect: CGRect, screen: NSScreen) {
         dismissOverlay()
         dismissToolbarUI()

--- a/App/Tests/RecordingSelectionModeTests.swift
+++ b/App/Tests/RecordingSelectionModeTests.swift
@@ -210,6 +210,23 @@ final class RecordingSelectionModeTests: XCTestCase {
         XCTAssertTrue(NSApp.windows.contains { $0 is RecordingToolbarWindow && $0.isVisible })
     }
 
+    func testDirectFullScreenRecordingSkipsSelectionAndShowsToolbar() async throws {
+        let suiteName = "RecordingSelectionModeTests.\(UUID().uuidString)"
+        defer {
+            closeRecordingSelectionWindows()
+            UserDefaults.standard.removePersistentDomain(forName: suiteName)
+        }
+        let settings = AppSettings(defaults: try XCTUnwrap(UserDefaults(suiteName: suiteName)))
+        let coordinator = RecordingCoordinator(settings: settings)
+
+        coordinator.startFullScreenRecordingFlow()
+        try await Task.sleep(for: .milliseconds(250))
+
+        XCTAssertFalse(NSApp.windows.contains { $0 is RecordingSelectionModeWindow && $0.isVisible })
+        XCTAssertFalse(NSApp.windows.contains { $0 is CaptureOverlayWindow && $0.isVisible })
+        XCTAssertTrue(NSApp.windows.contains { $0 is RecordingToolbarWindow && $0.isVisible })
+    }
+
     private func makeKeyEvent(_ characters: String, keyCode: UInt16, windowNumber: Int) throws -> NSEvent {
         try XCTUnwrap(NSEvent.keyEvent(
             with: .keyDown,


### PR DESCRIPTION
## Summary

- split the recording menu and shortcut settings into Record Area and Record Full Screen
- reuse the existing full-screen target, recording toolbar, and countdown flow
- preserve the existing area-recording shortcut while leaving full-screen recording unbound by default
- add Japanese, Korean, and Simplified Chinese localizations
- add regression coverage for bypassing the selection overlay on direct full-screen recording

## Testing

- swift test --package-path Packages/SharedKit
- xcodebuild test -project Capso.xcodeproj -scheme Capso -only-testing:CapsoTests/RecordingSelectionModeTests -only-testing:CapsoTests/RecordingToolbarShortcutTests CODE_SIGNING_ALLOWED=NO
- xcodebuild -project Capso.xcodeproj -scheme Capso -configuration Debug build CODE_SIGNING_ALLOWED=NO
- manually verified the signed Debug app: shortcut settings, 3840 x 2160 full-screen targeting, 3-second countdown, recording controls, editor handoff, and 1280 x 720 area-toolbar sizing

Addresses #254

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and shortcut wiring around an existing recording flow; no auth, data, or capture-engine changes. Existing users keep their area-recording hotkey.
> 
> **Overview**
> Splits screen recording into **Record Area** and **Record Full Screen** in the menu bar and shortcut settings.
> 
> Full-screen recording skips the selection overlay and targets the display under the pointer, then still shows the recording toolbar for camera, mic, audio, format, and countdown. The existing area-recording shortcut (`recordScreen`) is unchanged; full-screen is opt-in with no default global hotkey.
> 
> Adds ja/ko/zh-Hans strings and a test that the direct full-screen path bypasses selection UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fe848efd9fd0a1a38fa57f190f7411a694c2472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->