### PR TITLE
fix: allow area captures while discard alert is open

### DIFF
--- a/App/Sources/AnnotationEditor/AnnotationEditorCloseGuard.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorCloseGuard.swift
@@ -1,13 +1,77 @@
 // App/Sources/AnnotationEditor/AnnotationEditorCloseGuard.swift
 import AppKit
 
+extension Notification.Name {
+    /// Posted after the desktop (including any system alert) has been frozen.
+    static let capsoCaptureDidFreezeDesktop = Notification.Name("capsoCaptureDidFreezeDesktop")
+    /// Posted after the interactive capture overlay has been dismissed.
+    static let capsoCaptureDidEnd = Notification.Name("capsoCaptureDidEnd")
+}
+
 @MainActor
 enum AnnotationEditorCloseGuard {
+    private static var suspendedAlertPresenter: AnnotationEditorSystemAlertPresenter?
+
     static func shouldClose(hasUnsavedChanges: Bool, confirmDiscard: () -> Bool) -> Bool {
         !hasUnsavedChanges || confirmDiscard()
     }
 
     static func presentDiscardAlert(above window: NSWindow?) -> Bool {
+        let presenter = AnnotationEditorSystemAlertPresenter(above: window)
+        switch presenter.runModal() {
+        case .confirmed:
+            return true
+        case .cancelled:
+            return false
+        case .suspendedForCapture:
+            suspendedAlertPresenter = presenter
+            presenter.parkUntilCaptureEnds()
+            return false
+        }
+    }
+
+    fileprivate static func presenterDidFinish(_ presenter: AnnotationEditorSystemAlertPresenter) {
+        if suspendedAlertPresenter === presenter {
+            suspendedAlertPresenter = nil
+        }
+    }
+
+#if DEBUG
+    static var isSuspendedAlertVisibleForTesting: Bool {
+        suspendedAlertPresenter?.isParkedAndVisible == true
+    }
+
+    static var isModelessAlertVisibleForTesting: Bool {
+        suspendedAlertPresenter?.isModelessAndVisible == true
+    }
+
+    static func dismissSuspendedAlertForTesting() {
+        suspendedAlertPresenter?.dismissWithoutResuming()
+        suspendedAlertPresenter = nil
+    }
+#endif
+}
+
+/// Owns the original AppKit `NSAlert` while area capture temporarily suspends
+/// its modal event loop. The same system window is restored after capture.
+@MainActor
+fileprivate final class AnnotationEditorSystemAlertPresenter: NSObject {
+    enum Outcome {
+        case confirmed
+        case cancelled
+        case suspendedForCapture
+    }
+
+    private let alert: NSAlert
+    private weak var editorWindow: NSWindow?
+    private let originalLevel: NSWindow.Level
+    private var captureFreezeObserver: NSObjectProtocol?
+    private var captureEndObserver: NSObjectProtocol?
+    private var editorCloseObserver: NSObjectProtocol?
+    private var isSuspendingForCapture = false
+    private var isParked = false
+
+    init(above window: NSWindow?) {
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = String(localized: "Discard your edits?")
@@ -16,13 +80,152 @@ enum AnnotationEditorCloseGuard {
         alert.addButton(withTitle: String(localized: "Cancel"))
 
         // The inline area-capture editor's panel sits at `.screenSaver` level;
-        // an unparented alert would render behind it, so lift the alert above
-        // whichever window is asking.
+        // an unparented alert would render behind it, so lift the system alert
+        // above whichever window is asking.
         if let window {
             alert.window.level = NSWindow.Level(rawValue: window.level.rawValue + 1)
         }
 
+        self.alert = alert
+        self.editorWindow = window
+        self.originalLevel = alert.window.level
+        super.init()
+    }
+
+    func runModal() -> Outcome {
+        isSuspendingForCapture = false
+        let observer = NotificationCenter.default.addObserver(
+            forName: .capsoCaptureDidFreezeDesktop,
+            object: nil,
+            queue: .main
+        ) { _ in
+            MainActor.assumeIsolated {
+                if NSApp.modalWindow === self.alert.window {
+                    self.isSuspendingForCapture = true
+                    NSApp.abortModal()
+                }
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
         let response = alert.runModal()
-        return response == .alertFirstButtonReturn
+        if isSuspendingForCapture {
+            return .suspendedForCapture
+        }
+        return response == .alertFirstButtonReturn ? .confirmed : .cancelled
+    }
+
+    func parkUntilCaptureEnds() {
+        guard !isParked else { return }
+        isParked = true
+
+        // Keep the real NSAlert alive. The frozen desktop already contains its
+        // pixels, so park it behind that layer and let the overlay receive all
+        // pointer events until selection finishes.
+        alert.window.ignoresMouseEvents = true
+        alert.window.level = .screenSaver - 2
+        alert.window.orderFrontRegardless()
+
+        captureEndObserver = NotificationCenter.default.addObserver(
+            forName: .capsoCaptureDidEnd,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.resumeAfterCapture()
+            }
+        }
+    }
+
+#if DEBUG
+    var isParkedAndVisible: Bool {
+        isParked && alert.window.isVisible && alert.window.ignoresMouseEvents
+    }
+
+    var isModelessAndVisible: Bool {
+        !isParked && alert.window.isVisible && NSApp.modalWindow !== alert.window
+    }
+
+    func dismissWithoutResuming() {
+        finish()
+    }
+#endif
+
+    private func resumeAfterCapture() {
+        if let captureEndObserver {
+            NotificationCenter.default.removeObserver(captureEndObserver)
+            self.captureEndObserver = nil
+        }
+
+        isParked = false
+        alert.window.ignoresMouseEvents = false
+        alert.window.level = originalLevel
+        installModelessButtonActions()
+        installCaptureFreezeObserver()
+        installEditorCloseObserver()
+        alert.window.makeKeyAndOrderFront(nil)
+    }
+
+    private func installModelessButtonActions() {
+        guard alert.buttons.count >= 2 else { return }
+
+        alert.buttons[0].target = self
+        alert.buttons[0].action = #selector(discardPressed)
+        alert.buttons[0].keyEquivalent = "\r"
+
+        alert.buttons[1].target = self
+        alert.buttons[1].action = #selector(cancelPressed)
+        alert.buttons[1].keyEquivalent = "\u{1b}"
+    }
+
+    private func installCaptureFreezeObserver() {
+        guard captureFreezeObserver == nil else { return }
+        captureFreezeObserver = NotificationCenter.default.addObserver(
+            forName: .capsoCaptureDidFreezeDesktop,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self, self.alert.window.isVisible else { return }
+                self.parkUntilCaptureEnds()
+            }
+        }
+    }
+
+    private func installEditorCloseObserver() {
+        guard editorCloseObserver == nil, let editorWindow else { return }
+        editorCloseObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: editorWindow,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.finish()
+            }
+        }
+    }
+
+    @objc private func discardPressed() {
+        let window = editorWindow
+        finish()
+        window?.close()
+    }
+
+    @objc private func cancelPressed() {
+        finish()
+    }
+
+    private func finish() {
+        for observer in [captureFreezeObserver, captureEndObserver, editorCloseObserver].compactMap({ $0 }) {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        captureFreezeObserver = nil
+        captureEndObserver = nil
+        editorCloseObserver = nil
+
+        isParked = false
+        alert.window.ignoresMouseEvents = false
+        alert.window.orderOut(nil)
+        AnnotationEditorCloseGuard.presenterDidFinish(self)
     }
 }

--- a/App/Sources/AnnotationEditor/AnnotationEditorCloseGuard.swift
+++ b/App/Sources/AnnotationEditor/AnnotationEditorCloseGuard.swift
@@ -1,13 +1,6 @@
 // App/Sources/AnnotationEditor/AnnotationEditorCloseGuard.swift
 import AppKit
 
-extension Notification.Name {
-    /// Posted after the desktop (including any system alert) has been frozen.
-    static let capsoCaptureDidFreezeDesktop = Notification.Name("capsoCaptureDidFreezeDesktop")
-    /// Posted after the interactive capture overlay has been dismissed.
-    static let capsoCaptureDidEnd = Notification.Name("capsoCaptureDidEnd")
-}
-
 @MainActor
 enum AnnotationEditorCloseGuard {
     private static var suspendedAlertPresenter: AnnotationEditorSystemAlertPresenter?
@@ -17,6 +10,10 @@ enum AnnotationEditorCloseGuard {
     }
 
     static func presentDiscardAlert(above window: NSWindow?) -> Bool {
+        if suspendedAlertPresenter?.bringForwardIfVisible() == true {
+            return false
+        }
+
         let presenter = AnnotationEditorSystemAlertPresenter(above: window)
         switch presenter.runModal() {
         case .confirmed:
@@ -135,6 +132,16 @@ fileprivate final class AnnotationEditorSystemAlertPresenter: NSObject {
                 self?.resumeAfterCapture()
             }
         }
+    }
+
+    /// Returns true when this is the existing discard alert for the editor.
+    /// A parked alert must remain behind the capture overlay; a modeless alert
+    /// can be brought forward instead of creating another `NSAlert`.
+    func bringForwardIfVisible() -> Bool {
+        guard alert.window.isVisible else { return false }
+        guard !isParked else { return true }
+        alert.window.makeKeyAndOrderFront(nil)
+        return true
     }
 
 #if DEBUG

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -867,7 +867,10 @@ final class CaptureCoordinator {
         mode: CaptureOverlayMode = .area,
         areaSelected: ((CGRect, NSScreen) -> Void)? = nil
     ) {
-        dismissOverlay()
+        // Starting a replacement overlay is not the end of capture. In
+        // particular, posting `capsoCaptureDidEnd` here would briefly resume a
+        // parked discard alert before the next freeze parks it again.
+        dismissOverlay(notifyingCaptureEnd: false)
 
         let frozenScreens = captureFrozenScreens()
         // Freeze first so an open system alert remains visible in the image
@@ -1167,11 +1170,13 @@ final class CaptureCoordinator {
         return ciCtx.createCGImage(ci, from: CGRect(origin: .zero, size: targetSize))
     }
 
-    private func dismissOverlay() {
+    private func dismissOverlay(notifyingCaptureEnd: Bool = true) {
         isSelectionFlowStarting = false
         dismissSelectionOverlays()
         dismissFreezeWindows()
-        NotificationCenter.default.post(name: .capsoCaptureDidEnd, object: nil)
+        if notifyingCaptureEnd {
+            NotificationCenter.default.post(name: .capsoCaptureDidEnd, object: nil)
+        }
     }
 
     private func dismissSelectionOverlays() {

--- a/App/Sources/Capture/CaptureCoordinator.swift
+++ b/App/Sources/Capture/CaptureCoordinator.swift
@@ -870,6 +870,11 @@ final class CaptureCoordinator {
         dismissOverlay()
 
         let frozenScreens = captureFrozenScreens()
+        // Freeze first so an open system alert remains visible in the image
+        // being selected. Only then end its modal event loop, which releases
+        // pointer events for the overlay without removing the alert from the
+        // already-frozen desktop.
+        NotificationCenter.default.post(name: .capsoCaptureDidFreezeDesktop, object: nil)
         guard !frozenScreens.isEmpty else {
             showOverlay(mode: mode, areaSelected: areaSelected)
             return
@@ -1166,6 +1171,7 @@ final class CaptureCoordinator {
         isSelectionFlowStarting = false
         dismissSelectionOverlays()
         dismissFreezeWindows()
+        NotificationCenter.default.post(name: .capsoCaptureDidEnd, object: nil)
     }
 
     private func dismissSelectionOverlays() {

--- a/App/Sources/Capture/CaptureNotifications.swift
+++ b/App/Sources/Capture/CaptureNotifications.swift
@@ -1,0 +1,9 @@
+// App/Sources/Capture/CaptureNotifications.swift
+import Foundation
+
+extension Notification.Name {
+    /// Posted after the desktop (including any system alert) has been frozen.
+    static let capsoCaptureDidFreezeDesktop = Notification.Name("capsoCaptureDidFreezeDesktop")
+    /// Posted after the interactive capture overlay has been dismissed.
+    static let capsoCaptureDidEnd = Notification.Name("capsoCaptureDidEnd")
+}

--- a/App/Tests/AnnotationEditorCloseGuardTests.swift
+++ b/App/Tests/AnnotationEditorCloseGuardTests.swift
@@ -52,6 +52,12 @@ final class AnnotationEditorCloseGuardTests: XCTestCase {
         XCTAssertNil(NSApp.modalWindow)
         XCTAssertTrue(AnnotationEditorCloseGuard.isModelessAlertVisibleForTesting)
 
+        // A second close request must reuse the restored modeless alert rather
+        // than presenting a second modal discard dialog on top of it.
+        XCTAssertFalse(AnnotationEditorCloseGuard.presentDiscardAlert(above: nil))
+        XCTAssertNil(NSApp.modalWindow)
+        XCTAssertTrue(AnnotationEditorCloseGuard.isModelessAlertVisibleForTesting)
+
         NotificationCenter.default.post(name: .capsoCaptureDidFreezeDesktop, object: nil)
         XCTAssertNil(NSApp.modalWindow)
         XCTAssertTrue(AnnotationEditorCloseGuard.isSuspendedAlertVisibleForTesting)

--- a/App/Tests/AnnotationEditorCloseGuardTests.swift
+++ b/App/Tests/AnnotationEditorCloseGuardTests.swift
@@ -36,4 +36,31 @@ final class AnnotationEditorCloseGuardTests: XCTestCase {
         )
         XCTAssertFalse(shouldClose)
     }
+
+    func testSystemAlertSupportsRepeatedAreaCapturesWithoutBecomingModalAgain() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            NotificationCenter.default.post(name: .capsoCaptureDidFreezeDesktop, object: nil)
+        }
+
+        let shouldClose = AnnotationEditorCloseGuard.presentDiscardAlert(above: nil)
+
+        XCTAssertFalse(shouldClose)
+        XCTAssertNil(NSApp.modalWindow)
+        XCTAssertTrue(AnnotationEditorCloseGuard.isSuspendedAlertVisibleForTesting)
+
+        NotificationCenter.default.post(name: .capsoCaptureDidEnd, object: nil)
+        XCTAssertNil(NSApp.modalWindow)
+        XCTAssertTrue(AnnotationEditorCloseGuard.isModelessAlertVisibleForTesting)
+
+        NotificationCenter.default.post(name: .capsoCaptureDidFreezeDesktop, object: nil)
+        XCTAssertNil(NSApp.modalWindow)
+        XCTAssertTrue(AnnotationEditorCloseGuard.isSuspendedAlertVisibleForTesting)
+
+        NotificationCenter.default.post(name: .capsoCaptureDidEnd, object: nil)
+        XCTAssertNil(NSApp.modalWindow)
+        XCTAssertTrue(AnnotationEditorCloseGuard.isModelessAlertVisibleForTesting)
+
+        AnnotationEditorCloseGuard.dismissSuspendedAlertForTesting()
+        XCTAssertNil(NSApp.modalWindow)
+    }
 }


### PR DESCRIPTION
## What changed

- Freeze the desktop before suspending the native discard alert modal loop, keeping the alert visible in the capture.
- Park the original system NSAlert behind the capture overlay so pointer input remains responsive.
- Restore the same native alert modelessly after capture and support repeated area captures without closing it.
- Add regression coverage for consecutive capture cycles.

## Related issue

None.

## Screenshots / recordings

The existing native macOS alert is retained; no custom alert UI is introduced.

## Checklist

- [x] `xcodegen generate` run for the isolated worktree
- [x] Debug test build passes via `xcodebuild test`
- [x] 10 annotation close/capture tests pass
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency conventions
- [x] I agree that my contribution is licensed under BSL 1.1 per `CONTRIBUTING.md`