### PR TITLE
l10n: localize annotation discard alert

### DIFF
--- a/App/Resources/Localizable.xcstrings
+++ b/App/Resources/Localizable.xcstrings
@@ -2524,6 +2524,50 @@
         }
       }
     },
+    "Discard" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "破棄"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버리기"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "放弃"
+          }
+        }
+      }
+    },
+    "Discard your edits?" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "編集内容を破棄しますか？"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "편집 내용을 버리시겠습니까?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "要放弃修改吗？"
+          }
+        }
+      }
+    },
     "Display thumbnail with quick actions" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -5287,6 +5331,28 @@
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "昨日" } },
         "ko" : { "stringUnit" : { "state" : "translated", "value" : "어제" } },
         "zh-Hans" : { "stringUnit" : { "state" : "translated", "value" : "昨天" } }
+      }
+    },
+    "Your annotations haven't been saved and will be lost." : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "注釈は保存されていないため、失われます。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주석이 저장되지 않아 모두 사라집니다."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的标注尚未保存，放弃后将会丢失。"
+          }
+        }
       }
     },
     "Your screenshots and recordings will appear here" : {


### PR DESCRIPTION
## What changed

- Add Simplified Chinese translations for the native annotation discard alert.
- Add Japanese and Korean translations for the same title, message, and destructive action.
- Keep English as the source-language fallback for unsupported app languages.

## Related issue

None.

## Screenshots / recordings

No layout changes. The existing native macOS NSAlert automatically uses the app language.

## Checklist

- [x] Project regeneration not required; source layout is unchanged
- [x] String catalog passes JSON validation
- [x] No package code was touched
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] I agree that my contribution is licensed under BSL 1.1 per `CONTRIBUTING.md`