### PR TITLE
feat: toggle screenshot history with global shortcut

### DIFF
--- a/App/Sources/AppDelegate.swift
+++ b/App/Sources/AppDelegate.swift
@@ -174,7 +174,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             self?.captureCoordinator?.replayLastCapture()
         }
         KeyboardShortcuts.onKeyDown(for: .screenshotHistory) { [weak self] in
-            self?.historyCoordinator?.showWindow()
+            self?.historyCoordinator?.toggleWindow()
         }
         KeyboardShortcuts.onKeyDown(for: .captureAndTranslate) { [weak self] in
             guard let self else { return }

--- a/App/Sources/History/HistoryCoordinator.swift
+++ b/App/Sources/History/HistoryCoordinator.swift
@@ -51,6 +51,22 @@ final class HistoryCoordinator {
         window.show()
     }
 
+    func toggleWindow() {
+        if let historyWindow {
+            historyWindow.toggle()
+            return
+        }
+        let window = HistoryWindow(coordinator: self)
+        self.historyWindow = window
+        window.show()
+    }
+
+#if DEBUG
+    var isWindowVisibleForTesting: Bool {
+        historyWindow?.isVisibleForTesting == true
+    }
+#endif
+
     // MARK: - Data Loading
 
     func loadEntries() {

--- a/App/Sources/History/HistoryCoordinator.swift
+++ b/App/Sources/History/HistoryCoordinator.swift
@@ -56,9 +56,7 @@ final class HistoryCoordinator {
             historyWindow.toggle()
             return
         }
-        let window = HistoryWindow(coordinator: self)
-        self.historyWindow = window
-        window.show()
+        showWindow()
     }
 
 #if DEBUG

--- a/App/Sources/History/HistoryWindow.swift
+++ b/App/Sources/History/HistoryWindow.swift
@@ -13,6 +13,9 @@ final class HistoryWindow {
 
     func show() {
         if let window {
+            if window.isMiniaturized {
+                window.deminiaturize(nil)
+            }
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             return
@@ -49,4 +52,23 @@ final class HistoryWindow {
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
     }
+
+    func toggle() {
+        guard let window else {
+            show()
+            return
+        }
+
+        if window.isVisible, !window.isMiniaturized {
+            window.orderOut(nil)
+        } else {
+            show()
+        }
+    }
+
+#if DEBUG
+    var isVisibleForTesting: Bool {
+        window?.isVisible == true && window?.isMiniaturized == false
+    }
+#endif
 }

--- a/App/Tests/QuickAccessWindowPresentationTests.swift
+++ b/App/Tests/QuickAccessWindowPresentationTests.swift
@@ -99,3 +99,28 @@ final class QuickAccessWindowPresentationTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(interval))
     }
 }
+
+@MainActor
+final class HistoryWindowShortcutToggleTests: XCTestCase {
+    func testToggleShowsHidesAndShowsTheSameHistoryWindow() throws {
+        let suiteName = "HistoryWindowShortcutToggleTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        let coordinator = HistoryCoordinator(settings: AppSettings(defaults: defaults))
+        defer {
+            if coordinator.isWindowVisibleForTesting {
+                coordinator.toggleWindow()
+            }
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        coordinator.toggleWindow()
+        XCTAssertTrue(coordinator.isWindowVisibleForTesting)
+
+        coordinator.toggleWindow()
+        XCTAssertFalse(coordinator.isWindowVisibleForTesting)
+
+        coordinator.toggleWindow()
+        XCTAssertTrue(coordinator.isWindowVisibleForTesting)
+    }
+}


### PR DESCRIPTION
## What changed

- Change the Screenshot History global shortcut from open-only to a show/hide toggle.
- Restore the history window when it is minimized instead of hiding it.
- Keep the menu-bar Screenshot History action open-only.
- Add regression coverage for show, hide, and show-again behavior.

## Related issue

None.

## Screenshots / recordings

No visual layout changes; this updates global shortcut behavior only.

## Checklist

- [x] `xcodegen generate` run for the isolated worktree
- [x] Debug test build passes via `xcodebuild test`
- [x] Screenshot history shortcut toggle test passes
- [x] No new `TODO` / `FIXME` / debug prints left behind
- [x] Code follows Swift 6.0 strict concurrency conventions
- [x] I agree that my contribution is licensed under BSL 1.1 per `CONTRIBUTING.md`