### PR TITLE
docs: add contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ A native, feature-rich alternative to CleanShot X. Built with Swift 6.0 and Swif
 
 ---
 
+<p align="center">
+  <strong>Made possible by our amazing contributors</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/lzhgus/Capso/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=lzhgus/Capso" alt="Capso contributors">
+  </a>
+</p>
+
+<p align="center">
+  <sub><a href="./CONTRIBUTING.md">Join them</a> and help make Capso better.</sub>
+</p>
+
+---
+
 ## Download
 
 Grab the latest signed, notarized DMG from [**GitHub Releases →**](https://github.com/lzhgus/Capso/releases/latest)


### PR DESCRIPTION
## What changed

Adds a contributor avatar grid to the README, just above the Download section, so everyone who's pitched in shows up on the front page.

It's a contrib.rocks image. Just an img tag pointing at the contributors graph, so there's nothing to install and no bot committing to the repo. It reads from the GitHub contributors API and updates itself as people land PRs.

Only touched README.md. Can do the zh-CN, ja and ko ones as a follow-up if you want it there too.

No hard feelings if it's not the look you're going for, close it and I won't be offended.

## Related issue

None.

## Screenshots / recordings

Here's how it renders:

<p align="center">
  <img src="https://contrib.rocks/image?repo=lzhgus/Capso" alt="Capso contributors">
</p>

## Checklist

- [x] I agree that my contribution is licensed under BSL 1.1 per [CONTRIBUTING.md](../CONTRIBUTING.md#license)

The build, test, `xcodegen` and concurrency items don't apply here. No Swift, `project.yml` or source layout changes, README only.
